### PR TITLE
feat(#13): add pull-to-refresh to HermesScaffold

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/achievements/AchievementsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/achievements/AchievementsScreen.kt
@@ -47,6 +47,7 @@ fun AchievementsScreen(
     HermesScaffold(
         title = { Text("Agent Achievements") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadAchievements() },
     ) { paddingValues ->
         when {

--- a/app/src/main/java/com/m57/hermescontrol/ui/channels/ChannelsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/channels/ChannelsScreen.kt
@@ -61,10 +61,11 @@ fun ChannelsScreen(
     HermesScaffold(
         title = { Text("Messaging Channels") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadPlatforms() },
     ) { paddingValues ->
         when {
-            state.isLoading -> {
+            state.isLoading && state.platforms.isEmpty() -> {
                 LoadingState(modifier = Modifier.padding(paddingValues))
             }
             state.errorMessage != null -> {

--- a/app/src/main/java/com/m57/hermescontrol/ui/common/HermesScaffold.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/common/HermesScaffold.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -38,6 +39,7 @@ fun HermesScaffold(
     title: @Composable () -> Unit,
     onOpenDrawer: (() -> Unit)? = null,
     onRefresh: (() -> Unit)? = null,
+    isRefreshing: Boolean = false,
     onBack: (() -> Unit)? = null,
     showBack: Boolean = false,
     snackbarHost: @Composable () -> Unit = {},
@@ -95,13 +97,27 @@ fun HermesScaffold(
         },
         containerColor = MaterialTheme.colorScheme.background,
     ) { paddingValues ->
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-        ) {
-            content(paddingValues)
+        val refreshContent: @Composable () -> Unit = {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
+            ) {
+                content(paddingValues)
+            }
+        }
+
+        if (onRefresh != null) {
+            PullToRefreshBox(
+                isRefreshing = isRefreshing,
+                onRefresh = onRefresh,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                refreshContent()
+            }
+        } else {
+            refreshContent()
         }
     }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/config/ConfigScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/config/ConfigScreen.kt
@@ -59,10 +59,11 @@ fun ConfigScreen(
     HermesScaffold(
         title = { Text("Configuration") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadRawConfig() },
     ) { paddingValues ->
         when {
-            state.isLoading -> {
+            state.isLoading && state.yamlText == null -> {
                 LoadingState(modifier = Modifier.padding(paddingValues))
             }
             state.errorMessage != null -> {

--- a/app/src/main/java/com/m57/hermescontrol/ui/cron/CronJobsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/cron/CronJobsScreen.kt
@@ -61,10 +61,11 @@ fun CronJobsScreen(
     HermesScaffold(
         title = { Text("Cron Jobs") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadCronJobs() },
     ) {
         when {
-            state.isLoading -> LoadingState()
+            state.isLoading && state.jobs.isEmpty() -> LoadingState()
             state.errorMessage != null ->
                 ErrorState(
                     message = state.errorMessage ?: "Unknown error",

--- a/app/src/main/java/com/m57/hermescontrol/ui/gateway/GatewayScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/gateway/GatewayScreen.kt
@@ -64,10 +64,11 @@ fun GatewayScreen(
     HermesScaffold(
         title = { Text("Gateway Control") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadStatus() },
     ) { paddingValues ->
         when {
-            state.isLoading -> {
+            state.isLoading && state.status == null -> {
                 LoadingState(modifier = Modifier.padding(paddingValues))
             }
             state.errorMessage != null -> {

--- a/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
@@ -73,10 +73,11 @@ fun KanbanScreen(
     HermesScaffold(
         title = { Text("Kanban Board") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadBoards() },
     ) { paddingValues ->
         when {
-            state.isLoading -> {
+            state.isLoading && state.boards.isEmpty() -> {
                 LoadingState(modifier = Modifier.padding(paddingValues))
             }
             state.errorMessage != null -> {

--- a/app/src/main/java/com/m57/hermescontrol/ui/keys/KeysScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/keys/KeysScreen.kt
@@ -68,10 +68,11 @@ fun KeysScreen(
     HermesScaffold(
         title = { Text("Keys & Credentials") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadKeys() },
     ) { paddingValues ->
         when {
-            state.isLoading -> {
+            state.isLoading && state.envVars.isEmpty() -> {
                 LoadingState(modifier = Modifier.padding(paddingValues))
             }
             state.errorMessage != null -> {

--- a/app/src/main/java/com/m57/hermescontrol/ui/logs/LogsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/logs/LogsScreen.kt
@@ -61,10 +61,11 @@ fun LogsScreen(
     HermesScaffold(
         title = { Text("Logs") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadLogs() },
     ) {
         when {
-            state.isLoading -> LoadingState()
+            state.isLoading && state.logs.isEmpty() -> LoadingState()
             state.errorMessage != null ->
                 ErrorState(
                     message = state.errorMessage ?: "Unknown error",

--- a/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
@@ -61,10 +61,11 @@ fun McpServersScreen(
     HermesScaffold(
         title = { Text("MCP Servers") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadServers() },
     ) { paddingValues ->
         when {
-            state.isLoading -> {
+            state.isLoading && state.servers.isEmpty() -> {
                 LoadingState(modifier = Modifier.padding(paddingValues))
             }
             state.errorMessage != null -> {

--- a/app/src/main/java/com/m57/hermescontrol/ui/model/ModelScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/ModelScreen.kt
@@ -68,10 +68,11 @@ fun ModelScreen(
     HermesScaffold(
         title = { Text("Models") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadModelOptions() },
     ) { paddingValues ->
         when {
-            state.isLoading -> {
+            state.isLoading && state.providers.isEmpty() -> {
                 LoadingState(modifier = Modifier.padding(paddingValues))
             }
             state.errorMessage != null -> {

--- a/app/src/main/java/com/m57/hermescontrol/ui/pairing/PairingScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/pairing/PairingScreen.kt
@@ -60,10 +60,11 @@ fun PairingScreen(
     HermesScaffold(
         title = { Text("Device Pairing") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadPairing() },
     ) { paddingValues ->
         when {
-            state.isLoading -> {
+            state.isLoading && state.pairing == null -> {
                 LoadingState(modifier = Modifier.padding(paddingValues))
             }
             state.errorMessage != null -> {

--- a/app/src/main/java/com/m57/hermescontrol/ui/plugins/PluginsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/plugins/PluginsScreen.kt
@@ -59,10 +59,11 @@ fun PluginsScreen(
     HermesScaffold(
         title = { Text("Plugins") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadPlugins() },
     ) { paddingValues ->
         when {
-            state.isLoading -> {
+            state.isLoading && state.plugins.isEmpty() -> {
                 LoadingState(modifier = Modifier.padding(paddingValues))
             }
             state.errorMessage != null -> {

--- a/app/src/main/java/com/m57/hermescontrol/ui/profiles/ProfilesScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/profiles/ProfilesScreen.kt
@@ -72,10 +72,11 @@ fun ProfilesScreen(
     HermesScaffold(
         title = { Text("Profiles") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadProfiles() },
     ) { paddingValues ->
         when {
-            state.isLoading -> {
+            state.isLoading && state.profiles.isEmpty() -> {
                 LoadingState(modifier = Modifier.padding(paddingValues))
             }
             state.errorMessage != null -> {

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -74,10 +74,11 @@ fun SkillsScreen(
     HermesScaffold(
         title = { Text("Skills") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadSkills() },
     ) {
         when {
-            state.isLoading -> LoadingState()
+            state.isLoading && state.skills.isEmpty() -> LoadingState()
             state.errorMessage != null ->
                 ErrorState(
                     message = state.errorMessage ?: "Unknown error",

--- a/app/src/main/java/com/m57/hermescontrol/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/system/SystemScreen.kt
@@ -67,10 +67,11 @@ fun SystemScreen(
     HermesScaffold(
         title = { Text("System") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadSystemData() },
     ) {
         when {
-            state.isLoading -> LoadingState()
+            state.isLoading && state.stats == null && state.doctorReport == null -> LoadingState()
             state.errorMessage != null ->
                 ErrorState(
                     message = state.errorMessage ?: "Unknown error",

--- a/app/src/main/java/com/m57/hermescontrol/ui/toolsets/ToolsetsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/toolsets/ToolsetsScreen.kt
@@ -64,10 +64,11 @@ fun ToolsetsScreen(
     HermesScaffold(
         title = { Text("Toolsets") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadToolsets() },
     ) { paddingValues ->
         when {
-            state.isLoading -> {
+            state.isLoading && state.toolsets.isEmpty() -> {
                 LoadingState(modifier = Modifier.padding(paddingValues))
             }
             state.errorMessage != null -> {

--- a/app/src/main/java/com/m57/hermescontrol/ui/webhooks/WebhooksScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/webhooks/WebhooksScreen.kt
@@ -62,10 +62,11 @@ fun WebhooksScreen(
     HermesScaffold(
         title = { Text("Webhooks") },
         onOpenDrawer = onOpenDrawer,
+        isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadWebhooks() },
     ) { paddingValues ->
         when {
-            state.isLoading -> {
+            state.isLoading && state.baseUrl == null -> {
                 LoadingState(modifier = Modifier.padding(paddingValues))
             }
             state.errorMessage != null -> {


### PR DESCRIPTION
Every data screen in Hermes Mobile had an `onRefresh` callback, but it was only accessible via a tiny refresh icon in the TopAppBar. Swiping down to refresh is the universal mobile UX pattern — much more discoverable.

## Changes

### `HermesScaffold.kt`
- Added `isRefreshing: Boolean = false` parameter
- When `onRefresh != null`, wraps the content area in `PullToRefreshBox` (M3's swipe‑down‑to‑refresh container)
- When the user pulls down while content is visible, the Material pull‑to‑refresh indicator appears at the top, keeping the existing content visible underneath

### All 16 data screens
- Added `isRefreshing = state.isLoading` to their `HermesScaffold(...)` call
- Changed the loading-state condition from `state.isLoading ->` to `state.isLoading && data.isEmpty() ->` so the full‑screen `LoadingState` only shows on initial load (when there's nothing to show yet). On refresh, existing content stays visible and the `PullToRefreshBox` indicator shows instead

## UX improvement
Before: Tap the tiny refresh icon → full‑screen spinner for every reload, even when data already existed.

After: Swipe down → pull‑to‑refresh indicator appears over existing content. Full‑screen spinner only shows on initial load or when data has been cleared. The refresh icon button still works as a fallback.

Closes #13