### PR TITLE
ci(#19): add wrapper validation, remote build cache, and dependency submission

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -186,34 +186,7 @@ jobs:
           retention-days: 7
 
   # ─────────────────────────────────────────────────────────────────────
-  # Job 5: Dependency submission — generate a dependency graph for
-  # Dependabot alerts on GitHub.
-  # ─────────────────────────────────────────────────────────────────────
-  dependency-submission:
-    name: Dependency Submission
-    needs: [ktlint, android-lint, unit-tests]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v3
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '17'
-
-      - name: Generate and submit dependency graph
-        uses: gradle/actions/dependency-submission@v4
-
-  # ─────────────────────────────────────────────────────────────────────
-  # Job 6: PR status summary — posts a single check that aggregates the
+  # Job 5: PR status summary — posts a single check that aggregates the
   # others, so GitHub branch protection only needs one status check.
   # ─────────────────────────────────────────────────────────────────────
   ci-summary:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v3
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -36,6 +39,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTED_KEY }}
 
       - name: Grant Execute Permission for Gradlew
         run: chmod +x gradlew
@@ -72,6 +77,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v3
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -80,6 +88,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTED_KEY }}
 
       - name: Grant Execute Permission for Gradlew
         run: chmod +x gradlew
@@ -106,6 +116,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v3
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -114,6 +127,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTED_KEY }}
 
       - name: Grant Execute Permission for Gradlew
         run: chmod +x gradlew
@@ -141,6 +156,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v3
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -149,6 +167,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTED_KEY }}
 
       - name: Grant Execute Permission for Gradlew
         run: chmod +x gradlew
@@ -166,7 +186,34 @@ jobs:
           retention-days: 7
 
   # ─────────────────────────────────────────────────────────────────────
-  # Job 5: PR status summary — posts a single check that aggregates the
+  # Job 5: Dependency submission — generate a dependency graph for
+  # Dependabot alerts on GitHub.
+  # ─────────────────────────────────────────────────────────────────────
+  dependency-submission:
+    name: Dependency Submission
+    needs: [ktlint, android-lint, unit-tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v4
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Job 6: PR status summary — posts a single check that aggregates the
   # others, so GitHub branch protection only needs one status check.
   # ─────────────────────────────────────────────────────────────────────
   ci-summary:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v3
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -35,6 +38,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTED_KEY }}
 
       - name: Grant Execute Permission for Gradlew
         run: chmod +x gradlew
@@ -63,6 +68,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v3
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -71,6 +79,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTED_KEY }}
 
       - name: Grant Execute Permission for Gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
## Problem

The CI workflows are functional but miss critical best practices:

1. **No Gradle wrapper validation** — the `gradle-wrapper.jar` is a binary blob. Anyone who can push to the repo could replace it with a malicious copy. GitHub's `wrapper-validation-action` checks it against known checksums.
2. **Remote build cache not wired** — the `GRADLE_CACHE_ENCRYPTED_KEY` secret exists but was only set as an env var. The `gradle/actions/setup-gradle@v4` action never received it as `cache-encryption-key`, so the Gradle Build Cache was silently disabled. Every CI run compiled everything from scratch.
3. **No dependency graph** — Dependabot can't see the project's full dependency tree, so vulnerable transitive deps go undetected.

## Changes

### `android.yml` (CI) — 5 jobs updated, 1 added
- **All 4 Gradle jobs** (ktlint, android-lint, unit-tests, build): added `wrapper-validation-action@v3` after checkout, and `cache-encryption-key` input to `setup-gradle`
- **New job**: `dependency-submission` runs `gradle/actions/dependency-submission@v4` to submit the full dependency graph to GitHub for Dependabot
- `ci-summary` job unchanged (no Gradle usage)

### `release.yml` (Release) — 2 jobs updated
- `ci` and `build-release` jobs: same changes — wrapper validation + remote cache key

Closes #19