### PR TITLE
fix(#21): remove double spacing above top bar and below chat input

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/Navigation.kt
+++ b/app/src/main/java/com/m57/hermescontrol/Navigation.kt
@@ -1,8 +1,10 @@
 package com.m57.hermescontrol
 
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.rememberScrollState
@@ -216,6 +218,7 @@ fun MainNavigation() {
         },
     ) {
         Scaffold(
+            contentWindowInsets = WindowInsets.navigationBars,
             bottomBar = {
                 if (isPrimaryScreen) {
                     NavigationBar {

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -285,7 +284,6 @@ fun ChatScreen(
                     .fillMaxSize()
                     .padding(paddingValues)
                     .background(backgroundGradient)
-                    .navigationBarsPadding()
                     .imePadding(),
         ) {
             Box(


### PR DESCRIPTION
## Problem

The app has two invisible-padding issues:

### A. Space above the top bar
`enableEdgeToEdge()` is on, and both the outer `Scaffold` (...