### PR TITLE
feat: show app version in Settings screen (Issue #32)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.m57.hermescontrol.BuildConfig
 import com.m57.hermescontrol.theme.ThemePreference
 import com.m57.hermescontrol.ui.common.HermesScaffold
 
@@ -360,6 +361,16 @@ fun SettingsScreen(
                     Text("Save")
                 }
             }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // App version info
+            Text(
+                text = "v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+            )
 
             Spacer(modifier = Modifier.height(16.dp))
         }


### PR DESCRIPTION
## Summary

Adds the current app version to the bottom of the Settings screen.

### What changed

- Imported `BuildConfig`
- Added version text at the bottom of the scrollable Settings content: `v1.0-dev (1)` (or whatever the current build values are)
- Uses `labelSmall` typography in `onSurfaceVariant` colour — subtle, non-intrusive

### Mockup

```
┌─────────────────────────┐
│        Settings         │
├─────────────────────────┤
│  Connection             │
│  Behavior               │
│  Appearance             │
│  Navigation Bar         │
│  [Test] [Save]          │
│                         │
│   v1.0-dev (1)         │
└─────────────────────────┘
```

## Acceptance criteria

- [x] App version displayed in Settings
- [x] Shows version name and build code
- [x] Doesn't interfere with existing layout