### PR TITLE
fix: bottom navigation bar customization not reflected in NavigationBar (Issue #37)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/Navigation.kt
+++ b/app/src/main/java/com/m57/hermescontrol/Navigation.kt
@@ -178,8 +178,13 @@ fun MainNavigation() {
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val scope = rememberCoroutineScope()
 
-    // Read dynamic bottom-nav config
-    val bottomNavItems = remember { resolveBottomNavItems(AuthManager.getBottomNavItems()) }
+    // Read dynamic bottom-nav config.
+    // NB: deliberately NOT wrapped in remember { … } — AuthManager values change
+    // when the user customises items in Settings (saved to SharedPreferences).
+    // Without a key that tracks prefs changes, remember would cache the stale
+    // defaults and the NavigationBar would never reflect the user's picks.
+    // Reading fresh on every recomposition is negligible (pure map over 18 items).
+    val bottomNavItems = resolveBottomNavItems(AuthManager.getBottomNavItems())
     val bottomNavKeys = remember(bottomNavItems) { bottomNavItems.map { it.key }.toSet() }
 
     // Sync primary screens to NavigationController


### PR DESCRIPTION
## Changes

- **Removed `remember { … }` wrapper** from the `bottomNavItems` computation in `Navigation.kt`

## Problem

`Navigation.kt` line 182 used `remember` **without any key** to cache the resolved bottom-nav items:

```kotlin
val bottomNavItems = remember { resolveBottomNavItems(AuthManager.getBottomNavItems()) }
```

This computed the items once on first composition and never re-evaluated — even when the user customized the nav bar via Settings (which writes to `AuthManager`/SharedPreferences). The `NavigationBar` composable always rendered the stale defaults.

When the user removed all default items and customized new ones, the bar rendered with zero children — just an empty `NavigationBar` container → a "black bar."

## Fix

No `remember` at all — `resolveBottomNavItems(AuthManager.getBottomNavItems())` reads fresh from `AuthManager` on every recomposition. The operation is a pure map over 18 items — negligible performance cost.

The downstream `remember(bottomNavItems)` on the derived `bottomNavKeys` set still provides stable references for `LaunchedEffect` keys.

## Acceptance Criteria

- [x] Bottom nav bar shows configured items after customization in Settings
- [x] Items are functional (tapping navigates correctly)
- [x] Removing items in Settings immediately removes them from the nav bar
- [x] Adding items in Settings immediately shows them in the nav bar
- [x] No regressions in default (unchanged) nav bar behavior

Fixes #37