### PR TITLE
fix: sign release APKs with stable keystore from secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,10 +103,21 @@ jobs:
           echo "code=$CODE" >> "$GITHUB_OUTPUT"
           echo "Release: tag=$TAG version=$VERSION code=$CODE"
 
+      - name: Decode release keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: |
+          echo "$KEYSTORE_BASE64" | base64 -d > hermes-control-release.keystore.jks
+          ls -lh hermes-control-release.keystore.jks
+
       - name: Build Release APK
         env:
           VERSION_NAME: ${{ steps.version.outputs.version }}
           VERSION_CODE: ${{ steps.version.outputs.code }}
+          KEYSTORE_PATH: ${{ github.workspace }}/hermes-control-release.keystore.jks
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
           ./gradlew assembleRelease \
             -PversionName="$VERSION_NAME" \

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,14 @@
-*.iml
-.gradle
-.gradle-home
-$PWD
-.agents
-*.log
-/local.properties
-/.idea
-.DS_Store
-/build
-/captures
-.externalNativeBuild
-.cxx
+# Release keystore (local copy — stored as GitHub secret)
+hermes-control-release.keystore.jks
+
+# Android / Gradle
+build/
+.gradle/
 local.properties
-*.apk
+*.iml
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,12 +21,21 @@ android {
         versionName = (project.findProperty("versionName") as? String) ?: "1.0-dev"
     }
 
+    signingConfigs {
+        create("release") {
+            storeFile = file(System.getenv("KEYSTORE_PATH") ?: "hermes-control-release.keystore.jks")
+            storePassword = System.getenv("KEYSTORE_PASSWORD") ?: "hermes_release"
+            keyAlias = System.getenv("KEY_ALIAS") ?: "hermes-control-release"
+            keyPassword = System.getenv("KEY_PASSWORD") ?: "hermes_release"
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs["release"]
         }
     }
     compileOptions {


### PR DESCRIPTION
## Problem

Every release APK from CI is signed with a **different ephemeral debug keystore** (`signingConfigs.getByName("debug")` on CI runners). Android refuses to install a new APK over an existing one when signatures don't match:

```
INSTALL_FAILED_UPDATE_INCOMPATIBLE: signatures do not match
```

## Changes

- **`app/build.gradle.kts`** — Added `signingConfigs { release { ... } }` block that reads from env vars with local-dev fallback values. Release build type now uses `signingConfigs["release"]` instead of `signingConfigs.getByName("debug")`.
- **`.github/workflows/release.yml`** — Added `Decode release keystore` step that writes the base64-encoded keystore from `secrets.KEYSTORE_BASE64`. Added `KEYSTORE_PATH`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD` env vars to the build step.
- **`.gitignore`** — Exclude `hermes-control-release.keystore.jks` from version control.

## Setup Required (one-time)

The following **GitHub Secrets** must be added to `Hy4ri/hermes-mobile`:

| Secret | Value / Instructions |
|--------|---------------------|
| `KEYSTORE_BASE64` | The base64-encoded keystore (see below) |
| `KEYSTORE_PASSWORD` | `hermes_release` |
| `KEY_ALIAS` | `hermes-control-release` |
| `KEY_PASSWORD` | `hermes_release` |

After the next release is installed, **uninstall the old app first** (signing key changed). Future releases will use the same stable key and update cleanly.