### PR TITLE
fix: keep bottom navigation bar always visible (closes #49)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/Navigation.kt
+++ b/app/src/main/java/com/m57/hermescontrol/Navigation.kt
@@ -193,7 +193,7 @@ fun MainNavigation() {
         NavigationController.updatePrimaryScreens(bottomNavKeys)
     }
 
-    val isPrimaryScreen = currentScreen in bottomNavKeys
+    val showBottomBar = currentScreen != ConnectScreen
     val gesturesEnabled = currentScreen in DRAWER_GESTURE_SCREENS
     val openDrawer = { scope.launch { drawerState.open() } }
 
@@ -293,7 +293,7 @@ fun MainNavigation() {
         Scaffold(
             contentWindowInsets = WindowInsets.navigationBars,
             bottomBar = {
-                if (isPrimaryScreen) {
+                if (showBottomBar) {
                     NavigationBar {
                         bottomNavItems.forEach { item ->
                             NavigationBarItem(


### PR DESCRIPTION
This PR fixes issue #49 by making the bottom navigation bar visible on all screens except the ConnectScreen. When navigating to secondary screens or primary screens not currently active in bottomNavItems, the bar stays visible but shows no items as selected.