### PR TITLE
fix: remove space between bottom bar and chat input field (closes #48)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -322,12 +322,11 @@ fun ChatScreen(
                 )
             }
         },
-    ) { paddingValues ->
+    ) { _ ->
         Column(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .padding(paddingValues)
                     .background(backgroundGradient)
                     .imePadding(),
         ) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/common/HermesScaffold.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/common/HermesScaffold.kt
@@ -2,6 +2,7 @@ package com.m57.hermescontrol.ui.common
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -50,6 +51,7 @@ fun HermesScaffold(
 
     Scaffold(
         modifier = modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         snackbarHost = { snackbarHost() },
         topBar = {
             TopAppBar(


### PR DESCRIPTION
This PR fixes issue #48 by zeroing out the window insets of the nested Scaffold inside HermesScaffold, and removing the double-applied content padding inside ChatScreen. This removes the extra gap equal to the navigation bar height between the bottom navigation bar and the chat input field.