### PR TITLE
feat: attach source code archive to release assets (closes #54)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,14 @@ jobs:
             -PversionName="$VERSION_NAME" \
             -PversionCode="$VERSION_CODE"
 
+      - name: Create source archive
+        run: |
+          git archive --format=tar.gz \
+            -o release/hermes-control-${{ steps.version.outputs.tag }}-source.tar.gz \
+            --prefix=hermes-control-${{ steps.version.outputs.tag }}/ \
+            ${{ github.sha }}
+          ls -lh release/
+
       - name: Rename APK
         run: |
           mkdir -p release
@@ -146,7 +154,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: hermes-control-release
-          path: release/*.apk
+          path: |
+            release/*.apk
+            release/*-source.tar.gz
           retention-days: 90
 
       - name: Create GitHub Release
@@ -155,7 +165,9 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Hermes Control ${{ steps.version.outputs.tag }}
           generate_release_notes: true
-          files: release/*.apk
+          files: |
+            release/*.apk
+            release/*-source.tar.gz
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

Adds a `git archive` step to the release workflow that creates a source code tarball and uploads it alongside the APK as a release asset.

### What's new

- **`release.yml`** — New "Create source archive" step after the build. Uses `git archive` to generate a `.tar.gz` of the tag SHA with a clean prefix. The source archive is then:
  - Uploaded as a CI artifact (90-day retention)
  - Attached to the GitHub Release as a named asset (`hermes-control-<tag>-source.tar.gz`)

GitHub's auto-generated zip/tar.gz are always available at the standard archive URLs — this adds an explicit named asset to the release for visibility.

### Files modified

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Added `git archive` source tarball step, included it in artifact upload + release files |

Closes #54