### PR TITLE
Consume window insets in NavDisplay to eliminate keyboard gaps (Issue #59)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/Navigation.kt
+++ b/app/src/main/java/com/m57/hermescontrol/Navigation.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
@@ -445,6 +446,7 @@ fun MainNavigation() {
                 modifier =
                     Modifier
                         .padding(paddingValues)
+                        .consumeWindowInsets(paddingValues)
                         .fillMaxSize(),
             )
         }


### PR DESCRIPTION
Applies .consumeWindowInsets(paddingValues) to the NavDisplay container to ensure nested layouts (e.g. Chat compose input bar using imePadding()) sit flush against the soft keyboard without extra blank space.