### PR TITLE
Fix WebSocket connection stuck on subsequent launches (Issue #45)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -79,6 +79,15 @@ class ChatViewModel(
                 handleWsEvent(event)
             }
         }
+
+        if (wsClient.isConnected) {
+            _uiState.update { it.copy(isConnected = true, isLoading = false) }
+            addSystemMessage("Connected to Hermes")
+            loadSessions()
+            if (_uiState.value.currentSessionId == null) {
+                createNewSession()
+            }
+        }
     }
 
     private fun handleWsEvent(event: WsEvent) {


### PR DESCRIPTION
On subsequent launches, the cached application process already has an active WebSocket connection. The recreated ChatViewModel connect call is correctly skipped but manually triggers the session/header loading sequence to resolve the stuck 'Connecting...' state.