### PR TITLE
[refactor] Remove unused WorkManager dependency (#77)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ local.properties
 .vscode/
 *.swp
 *.swo
+
+# Nix / Gradle user home
+\$PWD/
+$PWD/
+

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ hermes-mobile/
 | **Networking** | [Retrofit 2](https://square.github.io/retrofit/) + [OkHttp 4](https://square.github.io/okhttp/) | REST API calls |
 | **Persistence** | [Room](https://developer.android.com/training/data-storage/room) (SQLite) | Local message history |
 | **Encryption** | AndroidX Security Crypto | Secure key storage |
-| **Background** | [WorkManager](https://developer.android.com/topic/libraries/architecture/workmanager) | Notification polling |
+| **Background** | Foreground Service | Notification polling (`ChatNotificationService`) |
 | **Serialization** | [Gson](https://github.com/google/gson) | JSON parsing |
 | **Testing** | jUnit 5 + [MockK](https://mockk.io/) + [OkHttp MockWebServer](https://github.com/square/okhttp/tree/master/mockwebserver) | Unit testing |
 | **Linting** | [ktlint](https://ktlint.github.io/) | Kotlin code style |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -105,9 +105,6 @@ dependencies {
   implementation(libs.androidx.room.ktx)
   ksp(libs.androidx.room.compiler)
 
-  // Background notifications (WorkManager)
-  implementation(libs.androidx.work.runtime)
-
   // Local tests: jUnit, coroutines, Android runner
   testImplementation(libs.junit)
   testImplementation(libs.junit.jupiter.api)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ gson = "2.11.0"
 securityCrypto = "1.1.0-alpha06"
 mockk = "1.13.12"
 room = "2.7.1"
-workManager = "2.10.0"
 
 [libraries]
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
@@ -69,8 +68,6 @@ androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 
-# Background notifications (WorkManager)
-androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref = "workManager" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
Closes #77. Removes the unused work-runtime dependency from build.gradle.kts and libs.versions.toml, and updates README.md to document Foreground Service instead.