### PR TITLE
[refactor] Remove blanket coroutines keep rule from ProGuard (#80)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,6 +1,6 @@
 # ── Kotlin / Coroutines ─────────────────────────────────────────────────
--keepclassmembers class kotlinx.coroutines.** { *; }
 -dontwarn kotlinx.coroutines.**
+
 
 # ── Room ─────────────────────────────────────────────────────────────────
 -keep class * extends androidx.room.RoomDatabase { *; }


### PR DESCRIPTION
Closes #80. Removes the blanket coroutines keep rule from proguard-rules.pro. Release build compiles and minifies successfully with R8.