### PR TITLE
ci(release): add missing mkdir -p release before source archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,7 @@ jobs:
 
       - name: Create source archive
         run: |
+          mkdir -p release
           git archive --format=tar.gz \
             -o release/hermes-control-${{ steps.version.outputs.tag }}-source.tar.gz \
             --prefix=hermes-control-${{ steps.version.outputs.tag }}/ \


### PR DESCRIPTION
## Problem

Release run [#8](https://github.com/Hy4ri/hermes-mobile/actions/runs/27838995709) failed in the `Create source archive` step:

```
fatal: could not open 'release/hermes-control-v1.4.0-source.tar.gz' for writing: No such file or directory
```

The `git archive` command tried to write into `release/` but the directory didn't exist yet. The `Rename APK` step below it correctly had `mkdir -p release`, but it runs after the failing step.

## Fix

Added `mkdir -p release` to the `Create source archive` step, so the directory exists before `git archive` writes into it.

Closes the release pipeline breakage — next `v*` tag push will succeed.