### PR TITLE
ci: prevent concurrency cancellation on rapid main merges

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,9 +11,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Cancel in-progress runs on the same ref when a new commit lands.
+# Cancel in-progress runs when a new commit lands on the same PR branch.
+# On main (push events), each commit gets a unique group so rapid merges
+# don't cancel each other's CI runs.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

PRs #83, #84, #85, and #86 were merged rapidly (\~2 min apart). Each merge to `main` triggered a CI run, but because the concurrency group was `ci-${{ github.ref }}` (static `refs/heads/main` for all pushes) and `cancel-in-progress: true`, **each merge cancelled the previous run** before it could finish.

Result — all post-merge CI runs on main were cancelled:
| Run | Event | Conclusion |
|-----|-------|-----------|
| PR #83 merge commit | `push` to main | ❌ cancelled |
| PR #84 merge commit | `push` to main | ❌ cancelled |
| PR #85 merge commit | `push` to main | ❌ cancelled |
| PR #86 merge commit | `push` to main | ❌ cancelled |

The PR branch CI itself was actually **passing** for all 4 PRs — only the post-merge runs were killed.

## Fix

Changed the concurrency group to use `github.sha` (unique per commit) for `push` events to main, while keeping `github.ref` (group per branch) for PRs:

```yaml
concurrency:
  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
  cancel-in-progress: true
```

- **PRs**: group = `ci-Android CI/CD-refs/pull/N/merge` → new commits on the same PR still cancel in-progress runs ✅
- **Main pushes**: group = `ci-Android CI/CD-<commit sha>` → each commit gets a unique group, so rapid merges don't cancel each other ✅

Closes — no issue, but fixes the CI gap that made PRs 83-86 appear as "merged with failed CI."