### PR TITLE
fix(#74): mark unparseable cron expressions instead of silently returning raw

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/util/CronExpressionFormatter.kt
+++ b/app/src/main/java/com/m57/hermescontrol/util/CronExpressionFormatter.kt
@@ -1,5 +1,7 @@
 package com.m57.hermescontrol.util
 
+import com.m57.hermescontrol.BuildConfig
+
 object CronExpressionFormatter {
     fun cronToHumanReadable(schedule: String): String {
         val clean = schedule.trim().replace("\\s+".toRegex(), " ")
@@ -150,7 +152,10 @@ object CronExpressionFormatter {
             // Fallback
             return schedule
         } catch (e: Exception) {
-            return schedule
+            if (BuildConfig.DEBUG) {
+                android.util.Log.w("CronExpressionFormatter", "Failed to parse cron: $schedule", e)
+            }
+            return "Raw: $schedule"
         }
     }
 


### PR DESCRIPTION
Closes #74

**What:** Three changes to how `CronExpressionFormatter` handles parse failures:

1. **Debug logging** — logs the exception with `Log.w` in DEBUG builds so failures aren't invisible
2. **Distinguishable fallback** — returns `"Raw: $schedule"` instead of the bare `schedule`, so the UI shows the user something clearly different from a successful parse
3. **BuildConfig import** — added the required import

```diff
-        } catch (e: Exception) {
-            return schedule
+        } catch (e: Exception) {
+            if (BuildConfig.DEBUG) {
+                android.util.Log.w("CronExpressionFormatter", "Failed to parse cron: $schedule", e)
+            }
+            return "Raw: $schedule"
         }
```