### PR TITLE
fix(#73): surface clear errors for malformed pairing strings instead of silent fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ local.properties
 \$PWD/
 $PWD/
 
+ktlint

--- a/app/src/main/java/com/m57/hermescontrol/ui/connect/ConnectViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/connect/ConnectViewModel.kt
@@ -165,12 +165,37 @@ class ConnectViewModel : ViewModel() {
                         connect()
                         return
                     }
+                    // Decoded valid JSON but missing required fields
+                    _uiState.update {
+                        it.copy(
+                            errorMessage = "Malformed pairing string — missing host, port, or token",
+                        )
+                    }
+                    return
                 }
+                // Decoded to valid string but not JSON shape — not a pairing string
+                _uiState.update {
+                    it.copy(
+                        errorMessage = "Malformed pairing string — expected URL or Base64-encoded JSON",
+                    )
+                }
+                return
+            } catch (e: IllegalArgumentException) {
+                // Not valid Base64 — check if input looks like a raw token
+                if (trimmed.length >= 32 && trimmed.matches(Regex("[A-Za-z0-9_\\-]+"))) {
+                    _uiState.update { it.copy(token = trimmed, errorMessage = null) }
+                } else {
+                    _uiState.update {
+                        it.copy(
+                            errorMessage = "Malformed pairing string — expected URL or Base64-encoded JSON",
+                        )
+                    }
+                }
+                return
             } catch (e: Exception) {
-                // Ignore base64 decode failures, fallback to setting raw token
+                _uiState.update { it.copy(errorMessage = "Failed to parse pairing string: ${e.message}") }
+                return
             }
-
-            _uiState.update { it.copy(token = trimmed, errorMessage = null) }
         } catch (e: Exception) {
             _uiState.update { it.copy(errorMessage = "Failed to parse pairing string: ${e.message}") }
         }


### PR DESCRIPTION
Closes #73

**What:** Rewrites the catch-all in `ConnectViewModel.onPairingString()` so the user gets clear feedback instead of silent acceptance.

**Changes:**
1. **Narrowed inner catch** — catches only `IllegalArgumentException` (Base64 decode failures) instead of all `Exception`. Falls back to raw token only when input looks token-shaped (\>=32 alphanumeric chars).
2. **Explicit errors for each failure mode:**
   - Invalid Base64 → "Malformed pairing string — expected URL or Base64-encoded JSON"
   - Valid Base64 but not JSON → same error
   - Valid JSON but missing host/port/token → "Malformed pairing string — missing host, port, or token"
   - Other parse exceptions → "Failed to parse pairing string: {message}"
3. **Every code path now returns** — no more silent fallthrough to storing raw arbitrary input as a token.