### PR TITLE
fix(#64): call wsClient.disconnect() directly in onCleared() instead of launching on cancelled scope

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -745,8 +745,6 @@ class ChatViewModel(
 
     override fun onCleared() {
         super.onCleared()
-        viewModelScope.launch(Dispatchers.IO) {
-            wsClient.disconnect()
-        }
+        wsClient.disconnect()
     }
 }


### PR DESCRIPTION
Closes #64

**What:** Removes the `viewModelScope.launch(Dispatchers.IO)` wrapper around `wsClient.disconnect()` in `ChatViewModel.onCleared()`. Since Android cancels `viewModelScope` **before** calling `onCleared()`, the launch is always a no-op — the WebSocket never actually disconnects.

```diff
 override fun onCleared() {
     super.onCleared()
-    viewModelScope.launch(Dispatchers.IO) {
-        wsClient.disconnect()
-    }
+    wsClient.disconnect()
 }
```

**Why safe:** `wsClient.disconnect()` is non-blocking — it just calls `webSocket?.close(...)`.