### PR TITLE
fix(#69): replace mipmap launcher icon with proper notification vector drawable

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/notification/ChatNotificationService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/notification/ChatNotificationService.kt
@@ -92,7 +92,7 @@ class ChatNotificationService : Service() {
         val notification =
             NotificationCompat
                 .Builder(this, CHANNEL_ID)
-                .setSmallIcon(R.mipmap.ic_launcher)
+                .setSmallIcon(R.drawable.ic_notification)
                 .setContentTitle("Hermes")
                 .setContentText(text)
                 .setStyle(NotificationCompat.BigTextStyle().bigText(text))
@@ -116,7 +116,7 @@ class ChatNotificationService : Service() {
     private fun buildForegroundNotification(text: String): Notification =
         NotificationCompat
             .Builder(this, CHANNEL_ID)
-            .setSmallIcon(R.mipmap.ic_launcher)
+            .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle("Hermes")
             .setContentText(text)
             .setPriority(NotificationCompat.PRIORITY_LOW)

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM11,6h2v6h-2V6zM11,14h2v2h-2v-2z"/>
+</vector>


### PR DESCRIPTION
Closes #69

**Problem:** `showReplyNotification` and `buildForegroundNotification` both pass `R.mipmap.ic_launcher` as the small icon. Launcher mipmaps are full-color adaptive icons — they don't render properly in the status bar notification area.

**Fix:** Added a simple single-color vector drawable (`ic_notification.xml`) and updated both notification builders to use `R.drawable.ic_notification`.

**Why safe:** 24×24dp mono vector is the standard pattern for notification small icons. No API changes, no permissions needed.