### PR TITLE
fix(#65): request POST_NOTIFICATIONS runtime permission on Android 13+

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol.ui.chat
 
+import android.os.Build
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol.ui.chat
 
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.LinearEasing
@@ -85,6 +86,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.m57.hermescontrol.notification.NotificationHelper
@@ -133,6 +135,26 @@ fun ChatScreen(
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose {
             lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    // Request POST_NOTIFICATIONS runtime permission on Android 13+ (API 33).
+    // The manifest declaration alone is insufficient — on API 33+ the system
+    // requires a runtime permission prompt before the app can post any
+    // notification, including the foreground service notification.
+    val requestNotificationPermission =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission(),
+        ) { /* granted — next lifecycle event will pick it up */ }
+    LaunchedEffect(Unit) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val permission = android.Manifest.permission.POST_NOTIFICATIONS
+            if (
+                ContextCompat.checkSelfPermission(context, permission) !=
+                android.content.pm.PackageManager.PERMISSION_GRANTED
+            ) {
+                requestNotificationPermission.launch(permission)
+            }
         }
     }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -1,6 +1,7 @@
 package com.m57.hermescontrol.ui.chat
 
 import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize


### PR DESCRIPTION
Closes #65

**Problem:** `POST_NOTIFICATIONS` is declared in `AndroidManifest.xml` but is never requested at runtime. On Android 13+ (API 33), this is a `dangerous`-level permission — the manifest declaration alone is ignored. The `ChatNotificationService` foreground service starts but can never post notification alerts because the permission is denied by default.

**Fix:** Added a `rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission())` in `ChatScreen` that fires a permission prompt on first composition when:
1. `Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU`
2. Permission not already granted

The next lifecycle transition (`ON_STOP` → `NotificationHelper.start`) picks up the granted permission automatically.

**Why minimal:** Single-file change, no new dependencies, no architectural changes. The prompt fires once; if denied, the user can enable notifications in system Settings.