### PR TITLE
feat(#76): add testTag identifiers to composable elements for UI test targeting

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/Navigation.kt
+++ b/app/src/main/java/com/m57/hermescontrol/Navigation.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavKey
@@ -279,7 +280,10 @@ fun MainNavigation() {
                                             selectedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
                                             selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
                                         ),
-                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 2.dp),
+                                    modifier =
+                                        Modifier
+                                            .padding(horizontal = 12.dp, vertical = 2.dp)
+                                            .testTag("drawer_${entry.label.lowercase().replace(' ', '_')}"),
                                 )
                             }
                     }
@@ -302,6 +306,7 @@ fun MainNavigation() {
                                 onClick = { NavigationController.navigateTo(item.key) },
                                 icon = { Icon(item.icon, contentDescription = item.label) },
                                 label = { Text(item.label) },
+                                modifier = Modifier.testTag("nav_${item.label.lowercase().replace(' ', '_')}"),
                             )
                         }
                     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -81,6 +81,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -626,7 +627,8 @@ private fun ChatInputBar(
                         modifier =
                             Modifier
                                 .weight(1f)
-                                .heightIn(max = 140.dp),
+                                .heightIn(max = 140.dp)
+                                .testTag("chat_input"),
                         placeholder = {
                             Text(
                                 if (!isConnected) {
@@ -655,7 +657,10 @@ private fun ChatInputBar(
                         // Interrupt button
                         FilledTonalButton(
                             onClick = onInterrupt,
-                            modifier = Modifier.size(48.dp),
+                            modifier =
+                                Modifier
+                                    .size(48.dp)
+                                    .testTag("interrupt_button"),
                             shape = CircleShape,
                             contentPadding = PaddingValues(0.dp),
                         ) {
@@ -670,7 +675,10 @@ private fun ChatInputBar(
                         FilledTonalButton(
                             onClick = onSend,
                             enabled = canSend,
-                            modifier = Modifier.size(48.dp),
+                            modifier =
+                                Modifier
+                                    .size(48.dp)
+                                    .testTag("send_button"),
                             shape = CircleShape,
                             contentPadding = PaddingValues(0.dp),
                         ) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/common/HermesScaffold.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/common/HermesScaffold.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
 
 /**
  * Shared Scaffold wrapper that standardizes the TopAppBar.
@@ -69,6 +70,7 @@ fun HermesScaffold(
                                 Icon(
                                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                                     contentDescription = "Back",
+                                    modifier = Modifier.testTag("back_button"),
                                 )
                             }
                         }
@@ -78,6 +80,7 @@ fun HermesScaffold(
                                 Icon(
                                     imageVector = Icons.Filled.Menu,
                                     contentDescription = "Open navigation drawer",
+                                    modifier = Modifier.testTag("menu_button"),
                                 )
                             }
                         }
@@ -89,6 +92,7 @@ fun HermesScaffold(
                             Icon(
                                 imageVector = Icons.Filled.Refresh,
                                 contentDescription = "Refresh",
+                                modifier = Modifier.testTag("refresh_button"),
                             )
                         }
                     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/common/StateViews.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/common/StateViews.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.m57.hermescontrol.theme.LocalSpacing
@@ -34,13 +35,19 @@ import com.m57.hermescontrol.theme.LocalSpacing
 @Composable
 fun LoadingState(modifier: Modifier = Modifier) {
     Box(
-        modifier = modifier.fillMaxSize(),
+        modifier =
+            modifier
+                .fillMaxSize()
+                .testTag("loading_state"),
         contentAlignment = Alignment.Center,
     ) {
         CircularProgressIndicator(
             color = MaterialTheme.colorScheme.primary,
             strokeWidth = 3.dp,
-            modifier = Modifier.size(40.dp),
+            modifier =
+                Modifier
+                    .size(40.dp)
+                    .testTag("loading_spinner"),
         )
     }
 }
@@ -77,7 +84,10 @@ fun ErrorState(
         )
         if (onRetry != null) {
             Spacer(modifier = Modifier.height(spacing.md))
-            Button(onClick = onRetry) {
+            Button(
+                onClick = onRetry,
+                modifier = Modifier.testTag("error_retry_button"),
+            ) {
                 Icon(
                     imageVector = Icons.Filled.Refresh,
                     contentDescription = null,
@@ -133,7 +143,10 @@ fun EmptyState(
         }
         if (actionLabel != null && onAction != null) {
             Spacer(modifier = Modifier.height(spacing.md))
-            OutlinedButton(onClick = onAction) {
+            OutlinedButton(
+                onClick = onAction,
+                modifier = Modifier.testTag("empty_state_action"),
+            ) {
                 Text(actionLabel)
             }
         }


### PR DESCRIPTION
Closes #76

**Problem:** UI tests cannot target any element in the app — no `Modifier.testTag(...)` is set anywhere.

**Fix:** Added strategic `testTag` modifiers to key interactive and state elements across the core composables:

**Navigation** (`Navigation.kt`):
- `nav_{label}` on each `NavigationBarItem` (bottom nav)
- `drawer_{label}` on each `NavigationDrawerItem` (drawer)

**HermesScaffold** (`HermesScaffold.kt`):
- `back_button` — back arrow icon
- `menu_button` — hamburger menu icon
- `refresh_button` — refresh action icon

**StateViews** (`StateViews.kt`):
- `loading_state` / `loading_spinner` — loading container + spinner
- `error_retry_button` — retry action button
- `empty_state_action` — empty state CTA button

**ChatScreen** (`ChatScreen.kt`):
- `chat_input` — message input field
- `send_button` — send message button
- `interrupt_button` — stop/interrupt button

**Design principles:**
- Tags use `snake_case` for consistency
- Navigation items use dynamic labels (e.g. `nav_chat`, `nav_settings`)
- Only interactive / state-significant elements are tagged (no noise on decorative elements)