### PR TITLE
fix(chat): don't reload cached msgs on SESSION_RESUME ack

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -325,14 +325,16 @@ class ChatViewModel(
                     (resultMap?.get("session_id") as? String)
                         ?: _uiState.value.currentSessionId
 
+                // B8 (Jun 20 2026, kanban t_session_resume): do NOT reload
+                // cached messages here — switchSession() already did so before
+                // the WS round-trip. Calling loadCachedMessages() here would
+                // overwrite any message the user sent between switchSession() and
+                // the server ack, making the chat appear to go blank.
                 _uiState.update {
                     it.copy(
                         isLoading = false,
                         currentSessionId = sessionId,
                     )
-                }
-                if (sessionId != null) {
-                    loadCachedMessages(sessionId)
                 }
                 addSystemMessage("Session resumed")
             }


### PR DESCRIPTION
Fixes a bug where switching to an old session and sending a message caused the chat history to disappear.

## Root Cause
The `SESSION_RESUME` RPC result handler was calling `loadCachedMessages()` after the server acknowledged the resume. Since `switchSession()` already loads cached messages *before* the WS round-trip, this second call overwrote the message list — clobbering any message the user had sent in the window between switching sessions and receiving the ack.

## Fix
Remove the redundant `loadCachedMessages()` call from the `SESSION_RESUME` handler. The state update (`isLoading = false`, `currentSessionId`) is still performed.