### PR TITLE
fix(#134): remove settings button from chat top bar

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/Navigation.kt
+++ b/app/src/main/java/com/m57/hermescontrol/Navigation.kt
@@ -330,12 +330,6 @@ fun MainNavigation() {
 
                         entry<ChatScreen> {
                             ChatScreenContent(
-                                onNavigateToSettings = {
-                                    // B7 (Jun 18 2026): route through
-                                    // NavigationController to prevent
-                                    // stacking duplicate entries.
-                                    NavigationController.navigateTo(SettingsScreen)
-                                },
                                 onOpenDrawer = { openDrawer() },
                             )
                         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -50,7 +50,6 @@ import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
@@ -100,7 +99,6 @@ import com.m57.hermescontrol.ui.common.HermesScaffold
 
 @Composable
 fun ChatScreen(
-    onNavigateToSettings: () -> Unit,
     modifier: Modifier = Modifier,
     onOpenDrawer: (() -> Unit)? = null,
     viewModel: ChatViewModel = viewModel(),
@@ -327,14 +325,6 @@ fun ChatScreen(
                         if (state.isSearchActive) Icons.Filled.Close else Icons.Filled.Search,
                     contentDescription =
                         if (state.isSearchActive) "Close search" else "Search",
-                )
-            }
-
-            // Settings
-            IconButton(onClick = onNavigateToSettings) {
-                Icon(
-                    imageVector = Icons.Filled.Settings,
-                    contentDescription = "Settings",
                 )
             }
         },


### PR DESCRIPTION
## Changes\n- Removed the Settings IconButton from the chat screen's top app bar\n- Removed the  parameter from ChatScreen (no longer needed)\n- Cleaned up unused  import\n- Settings remains accessible via the bottom navigation and drawer\n\nCloses #134