### PR TITLE
feat(#132): dynamic session title with ellipsis truncation

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -86,6 +86,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
@@ -212,11 +213,13 @@ fun ChatScreen(
         title = {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    text = "Hermes",
+                    text = state.chatTitle,
                     style =
-                        MaterialTheme.typography.titleLarge.copy(
+                        MaterialTheme.typography.titleMedium.copy(
                             fontWeight = FontWeight.Bold,
                         ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
                 // Connection status dot — red when offline, hidden when connected
                 if (!state.isConnected) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -27,6 +27,7 @@ data class ChatUiState(
     val messages: List<ChatMessage> = emptyList(),
     val currentSessionId: String? = null,
     val sessions: List<SessionUi> = emptyList(),
+    val chatTitle: String = "Hermes",
     val isConnected: Boolean = false,
     val isAgentTyping: Boolean = false,
     val isThinking: Boolean = false,
@@ -316,7 +317,10 @@ class ChatViewModel(
                             messageCount = (s["message_count"] as? Double)?.toInt() ?: 0,
                         )
                     }
-                _uiState.update { it.copy(sessions = sessions) }
+                _uiState.update { state ->
+                    val title = sessions.find { s -> s.id == state.currentSessionId }?.title ?: "Hermes"
+                    state.copy(sessions = sessions, chatTitle = title)
+                }
             }
 
             WsMethods.SESSION_RESUME -> {
@@ -331,9 +335,11 @@ class ChatViewModel(
                 // overwrite any message the user sent between switchSession() and
                 // the server ack, making the chat appear to go blank.
                 _uiState.update {
+                    val title = it.sessions.find { s -> s.id == sessionId }?.title ?: "Hermes"
                     it.copy(
                         isLoading = false,
                         currentSessionId = sessionId,
+                        chatTitle = title,
                     )
                 }
                 addSystemMessage("Session resumed")
@@ -574,10 +580,12 @@ class ChatViewModel(
     fun switchSession(sessionId: String) {
         if (sessionId == _uiState.value.currentSessionId) return
         _uiState.update {
+            val title = it.sessions.find { s -> s.id == sessionId }?.title ?: "Hermes"
             it.copy(
                 isLoading = true,
                 messages = emptyList(),
                 currentSessionId = sessionId,
+                chatTitle = title,
                 showSessionPicker = false,
                 isAgentTyping = false,
                 isThinking = false,


### PR DESCRIPTION
## Changes
- Added `chatTitle` field to `ChatUiState` (defaults to "Hermes")
- Title is populated from session data when sessions are listed, switched, or resumed
- Replaced hardcoded "Hermes" text in ChatScreen with `state.chatTitle`
- Uses `titleMedium` typography (slightly smaller than previous `titleLarge` to fit better)
- Added `maxLines = 1` and `TextOverflow.Ellipsis` for long titles

Closes #132