### PR TITLE
fix(#140): fix skills content API endpoints — path params to query params

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/model/SaveSkillContentRequest.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/SaveSkillContentRequest.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol.data.model
 
 data class SaveSkillContentRequest(
+    val name: String,
     val content: String,
 )

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -54,14 +54,13 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface HermesApiService {
-    @GET("api/skills/{name}/content")
+    @GET("api/skills/content")
     suspend fun getSkillContent(
-        @Path("name") name: String,
+        @Query("name") name: String,
     ): Response<SkillContentResponse>
 
-    @PUT("api/skills/{name}/content")
+    @PUT("api/skills/content")
     suspend fun saveSkillContent(
-        @Path("name") name: String,
         @Body body: SaveSkillContentRequest,
     ): Response<Unit>
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsViewModel.kt
@@ -143,9 +143,11 @@ class SkillsViewModel : ViewModel() {
                 withContext(Dispatchers.IO) {
                     safeApiCall {
                         ApiClient.hermesApi.saveSkillContent(
-                            skillName,
                             com.m57.hermescontrol.data.model
-                                .SaveSkillContentRequest(content),
+                                .SaveSkillContentRequest(
+                                    name = skillName,
+                                    content = content,
+                                ),
                         )
                     }
                 }


### PR DESCRIPTION
## Summary
The Skills editor was returning 404 because the Android app was calling the wrong API endpoint format.

## Root Cause
The Hermes dashboard API serves skills content at:
- `GET /api/skills/content?name={name}` (query param)
- `PUT /api/skills/content` with `{name, content}` body

But the Android app was calling:
- `GET /api/skills/{name}/content` (path param) → 404
- `PUT /api/skills/{name}/content` (path param) → 404

## Changes
- Fixed `HermesApiService.kt`: Changed both endpoints from path params (`@Path`) to query params (`@Query`) / body-only
- Fixed `SaveSkillContentRequest.kt`: Added `name` field since the PUT body now carries the skill name
- Fixed `SkillsViewModel.kt`: Updated save call to pass `name` in the request body instead of as a path parameter

## Root cause reference
`/opt/hermes-agent/hermes_cli/web_server.py` lines 9941-9991: actual API routes are
`@app.get("/api/skills/content")` and `@app.put("/api/skills/content")`.

Closes #140