### PR TITLE
fix(#144): add timestamp to tool/command message bubbles

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatBubble.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatBubble.kt
@@ -675,6 +675,15 @@ private fun ToolBubble(
                         }
                     }
                 }
+
+                // Timestamp — consistent with UserBubble/AssistantBubble
+                val textColor = if (isDarkTheme) Color.White else Color.Black
+                Text(
+                    text = formatTimestamp(message.timestamp),
+                    color = textColor.copy(alpha = 0.5f),
+                    style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier.align(Alignment.End).padding(top = 4.dp),
+                )
             }
         }
     }


### PR DESCRIPTION
## Changes
- Added `formatTimestamp(message.timestamp)` to `ToolBubble` composable, matching the pattern used by `UserBubble` and `AssistantBubble`
- Uses `labelSmall` style with reduced opacity (`alpha = 0.5f`)
- Aligned to `Alignment.End` (right side) with `top = 4.dp` padding
- Placed inside the `Column` after the expanded content block, so it shows regardless of collapse/expand state
- Does not interfere with `expanded` / `showRawJson` toggle behavior

Closes #144