### PR TITLE
feat(#129): remove redundant source archive, add About version card

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,15 +135,6 @@ jobs:
             -PversionName="$VERSION_NAME" \
             -PversionCode="$VERSION_CODE"
 
-      - name: Create source archive
-        run: |
-          mkdir -p release
-          git archive --format=tar.gz \
-            -o release/hermes-control-${{ steps.version.outputs.tag }}-source.tar.gz \
-            --prefix=hermes-control-${{ steps.version.outputs.tag }}/ \
-            ${{ github.sha }}
-          ls -lh release/
-
       - name: Rename APK
         run: |
           mkdir -p release
@@ -155,9 +146,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: hermes-control-release
-          path: |
-            release/*.apk
-            release/*-source.tar.gz
+          path: release/*.apk
           retention-days: 90
 
       - name: Create GitHub Release
@@ -166,9 +155,7 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Hermes Control ${{ steps.version.outputs.tag }}
           generate_release_notes: true
-          files: |
-            release/*.apk
-            release/*-source.tar.gz
+          files: release/*.apk
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,12 @@ android {
         // Falls back to defaults for local development.
         versionCode = (project.findProperty("versionCode") as? String)?.toIntOrNull() ?: 1
         versionName = (project.findProperty("versionName") as? String) ?: "1.0-dev"
+
+        // Embed git commit SHA for the About card in Settings
+        val gitSha = providers.exec {
+            commandLine("git", "rev-parse", "--short", "HEAD")
+        }.standardOutput.asText.get().trim()
+        buildConfigField("String", "GIT_SHA", "\"$gitSha\"")
     }
 
     signingConfigs {

--- a/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -396,16 +397,65 @@ fun SettingsScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // App version info
-            Text(
-                text = "v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.align(Alignment.CenterHorizontally),
-            )
+            // ── About section ─────────────────────────────────────────
+            SectionCard(title = "About") {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "⚡ Hermes Control",
+                        style =
+                            MaterialTheme.typography.titleMedium.copy(
+                                fontWeight = FontWeight.Bold,
+                            ),
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                Spacer(modifier = Modifier.height(8.dp))
+
+                InfoRow(label = "Version", value = "v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+                InfoRow(
+                    label = "Build",
+                    value = if (BuildConfig.DEBUG) "Debug" else "Release",
+                )
+                if (BuildConfig.GIT_SHA.isNotBlank()) {
+                    InfoRow(label = "Commit", value = BuildConfig.GIT_SHA)
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = "https://github.com/Hy4ri/hermes-mobile",
+                    style =
+                        MaterialTheme.typography.bodySmall.copy(
+                            color = MaterialTheme.colorScheme.primary,
+                        ),
+                )
+            }
 
             Spacer(modifier = Modifier.height(16.dp))
         }
+    }
+}
+
+@Composable
+private fun InfoRow(
+    label: String,
+    value: String,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+        )
     }
 }
 


### PR DESCRIPTION
## Changes

### 1. Remove redundant source archive from release workflow (`release.yml`)
- Removed the "Create source archive" step (lines 138-145) that ran `git archive` and uploaded a `.tar.gz` — GitHub already auto-generates source archives for every release
- Removed `release/*-source.tar.gz` from the artifact upload path and the `softprops/action-gh-release` files list

### 2. Add `GIT_SHA` to BuildConfig (`build.gradle.kts`)
- New `buildConfigField("String", "GIT_SHA", ...)` populated at build time via `git rev-parse --short HEAD`
- Available as `BuildConfig.GIT_SHA` at runtime for the About card

### 3. Replace standalone version label with proper About card (`SettingsScreen.kt`)
- Replaced the tiny centered `Text("v$VERSION ($CODE)")` with a dedicated `SectionCard("About")` showing:
  - App name header ("⚡ Hermes Control")
  - **Version** — `v{X.Y.Z} (buildCode)`
  - **Build** — "Debug" or "Release" from `BuildConfig.DEBUG`
  - **Commit** — short SHA from `BuildConfig.GIT_SHA` (only shown when non-empty)
  - GitHub repo URL
- New `InfoRow` helper composable for label/value pairs

## Before vs After

**Before:** A tiny `labelSmall` text at the bottom of the scroll column, easy to miss.

**After:** A full SectionCard with the app name, version, build type, commit SHA, and a link to the repo — making it immediately visible and giving users an easy reference for issue reports.

Closes #129