### PR TITLE
refactor(#104): prune unused ChatMessageDao APIs and stale test stubs

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/local/ChatMessageDao.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/ChatMessageDao.kt
@@ -4,13 +4,9 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ChatMessageDao {
-    @Query("SELECT * FROM chat_messages WHERE session_id = :sessionId ORDER BY timestamp ASC")
-    fun observeMessagesForSession(sessionId: String): Flow<List<ChatMessageEntity>>
-
     @Query("SELECT * FROM chat_messages WHERE session_id = :sessionId ORDER BY timestamp ASC")
     suspend fun getMessagesForSession(sessionId: String): List<ChatMessageEntity>
 
@@ -19,29 +15,4 @@ interface ChatMessageDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertAll(messages: List<ChatMessageEntity>)
-
-    @Query("UPDATE chat_messages SET content = :content, is_streaming = 0 WHERE id = :id")
-    suspend fun finalizeMessage(
-        id: String,
-        content: String,
-    )
-
-    @Query("UPDATE chat_messages SET content = :content WHERE id = :id")
-    suspend fun updateContent(
-        id: String,
-        content: String,
-    )
-
-    @Query("DELETE FROM chat_messages WHERE session_id = :sessionId")
-    suspend fun deleteMessagesForSession(sessionId: String)
-
-    @Query(
-        "DELETE FROM chat_messages WHERE session_id NOT IN " +
-            "(SELECT DISTINCT session_id FROM chat_messages " +
-            "ORDER BY timestamp DESC LIMIT :keepSessions)",
-    )
-    suspend fun pruneOldSessions(keepSessions: Int)
-
-    @Query("SELECT COUNT(*) FROM chat_messages")
-    suspend fun count(): Int
 }

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -68,13 +67,9 @@ class ChatViewModelTest {
         every { HermesWsClient.disconnect() } returns Unit
         every { mockDb.chatMessageDao() } returns mockDao
         every { HermesDatabase.get(any()) } returns mockDb
-        every { mockDao.observeMessagesForSession(any()) } returns flowOf(emptyList())
         coEvery { mockDao.getMessagesForSession(any()) } returns emptyList()
         coEvery { mockDao.upsert(any()) } returns Unit
         coEvery { mockDao.upsertAll(any()) } returns Unit
-        coEvery { mockDao.finalizeMessage(any(), any()) } returns Unit
-        coEvery { mockDao.deleteMessagesForSession(any()) } returns Unit
-        coEvery { mockDao.count() } returns 0
 
         // Default mock stubs for requests returning unique IDs
         var reqCount = 0


### PR DESCRIPTION
## Summary
Removes 6 unused methods from `ChatMessageDao` and their corresponding test stubs, reducing the persistence surface to only what production code actually calls.

## Removed methods
| Method | Status |
|--------|--------|
| `observeMessagesForSession()` | Only stubbed in test — no production caller |
| `updateContent()` | No callers anywhere |
| `finalizeMessage()` | Only stubbed in test — no production caller |
| `deleteMessagesForSession()` | Only stubbed in test — no production caller |
| `pruneOldSessions()` | No callers anywhere |
| `count()` | Only stubbed in test — no production caller |

## Test cleanup
- Removed stubs for all 6 methods from `ChatViewModelTest.kt`
- Removed orphaned `flowOf` import

## Verification
- ✅ ktlint clean on modified files
- ✅ zero remaining references to any removed method across the entire codebase

## Kept
- `getMessagesForSession()` — called in ChatViewModel
- `upsert()` — called throughout ChatViewModel
- `upsertAll()` — called in ChatViewModel

Closes #104