### PR TITLE
fix(#148): prevent chatTitle flash when switching sessions

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -475,8 +475,11 @@ class ChatViewModel(
                         )
                     }
                 _uiState.update { state ->
-                    val title = sessions.find { s -> s.id == state.currentSessionId }?.title ?: "Hermes"
-                    state.copy(sessions = sessions, chatTitle = title)
+                    val newTitle = sessions.find { s -> s.id == state.currentSessionId }?.title
+                    state.copy(
+                        sessions = sessions,
+                        chatTitle = newTitle ?: state.chatTitle,
+                    )
                 }
             }
 
@@ -492,11 +495,9 @@ class ChatViewModel(
                 // overwrite any message the user sent between switchSession() and
                 // the server ack, making the chat appear to go blank.
                 _uiState.update {
-                    val title = it.sessions.find { s -> s.id == sessionId }?.title ?: "Hermes"
                     it.copy(
                         isLoading = false,
                         currentSessionId = sessionId,
-                        chatTitle = title,
                     )
                 }
                 addSystemMessage("Session resumed")
@@ -766,7 +767,7 @@ class ChatViewModel(
         streamingMessageId = null
 
         _uiState.update {
-            val title = it.sessions.find { s -> s.id == sessionId }?.title ?: "Hermes"
+            val title = it.sessions.find { s -> s.id == sessionId }?.title ?: it.chatTitle
             it.copy(
                 isLoading = true,
                 messages = emptyList(),


### PR DESCRIPTION
## Root Cause
Three code paths independently write `chatTitle`, creating a race:
1. `switchSession()` — sets title by looking up session in `it.sessions`
2. `SESSION_LIST` handler — overwrites with `sessions.find(...) ?: \Hermes\`
3. `SESSION_RESUME` handler — overwrites with `it.sessions.find(...) ?: \Hermes\`

When `SESSION_LIST` or `SESSION_RESUME` responses arrive after `switchSession()`, they find the session absent from a stale list and revert the title to the default \Hermes\.

## Fixes
1. **`switchSession()`**: fall back to `it.chatTitle` instead of \Hermes\ when session not found in list — preserves whatever title was already there
2. **`SESSION_RESUME` handler**: removed the `chatTitle` update entirely — title was already set by `switchSession()` before the RPC was sent
3. **`SESSION_LIST` handler**: only overwrite `chatTitle` when the session IS found in the new list; otherwise keep the current title

## Verification
- ✅ ktlint clean
- ✅ 0 existing tests assert on `chatTitle` — no test regressions

Closes #148