### PR TITLE
ci(#71): change foreground service type from dataSync to remoteMessaging

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING" />
 
     <application
         android:allowBackup="true"
@@ -27,7 +27,7 @@
 
         <service
             android:name=".notification.ChatNotificationService"
-            android:foregroundServiceType="dataSync"
+            android:foregroundServiceType="remoteMessaging"
             android:exported="false" />
 
         <receiver

--- a/app/src/main/java/com/m57/hermescontrol/notification/ChatNotificationService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/notification/ChatNotificationService.kt
@@ -29,6 +29,16 @@ import kotlinx.coroutines.launch
  * is backgrounded and posts a notification when a new assistant reply
  * completes (MessageComplete event) while the app is not in the foreground.
  *
+ * FGS type: `remoteMessaging` — indefinite listener that maintains a
+ * long-lived connection to a remote server for receiving messages. This is
+ * the correct type per Android 14+ policy (dataSync has a time budget and
+ * is intended for finite sync operations).
+ *
+ * Channel importance: IMPORTANCE_MIN — the ongoing notification is a
+ * persistent indicator, not an alert. PRIORITY_MIN matches.
+ * The separate `hermes_chat` channel uses IMPORTANCE_HIGH for actual
+ * message notifications, which is correct.
+ *
  * Lifecycle:
  * - Started by [NotificationHelper.start] when the user sends a message and
  *   the app is about to go to the background (called from ChatScreen's


### PR DESCRIPTION
## Summary
Changes the foreground service type from `dataSync` to `remoteMessaging` for the indefinite WebSocket keep-alive service.

## Why
- `dataSync` has a defined time budget per Android 14+ policy — intended for finite sync operations. An indefinite listener risks being killed or flagged.
- `remoteMessaging` is designed for long-lived connections that receive messages from a remote server — exactly this use case.

## Changes
| File | Change |
|------|--------|
| `AndroidManifest.xml` | `FOREGROUND_SERVICE_DATA_SYNC` → `FOREGROUND_SERVICE_REMOTE_MESSAGING` permission |
| `AndroidManifest.xml` | `foregroundServiceType=\remoteMessaging\` |
| `ChatNotificationService.kt` | Added doc block explaining FGS type choice and channel importance alignment |

## Verification
- ✅ compileSdk=36 → `remoteMessaging` type available (API 34+)
- ✅ minSdk=26 → pre-API-34 devices ignore the type attribute
- ✅ ktlint clean on modified Kotlin file
- ✅ Service channel already uses `IMPORTANCE_MIN` / `PRIORITY_MIN` — consistent

Closes #71