### PR TITLE
fix(#130): fix compilation errors in scroll-to-bottom FAB

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -80,6 +80,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -103,6 +104,7 @@ import com.m57.hermescontrol.notification.NotificationHelper
 import com.m57.hermescontrol.theme.StatusRed
 import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.HermesScaffold
+import kotlinx.coroutines.launch
 
 @Composable
 fun ChatScreen(
@@ -118,6 +120,7 @@ fun ChatScreen(
             state.messages.isNotEmpty() && listState.canScrollForward
         }
     }
+    val scrollScope = rememberCoroutineScope()
     var inputText by rememberSaveable { mutableStateOf("") }
     val snackbarHostState = remember { SnackbarHostState() }
     val isDark = isSystemInDarkTheme()
@@ -533,7 +536,7 @@ fun ChatScreen(
                 }
 
                 // Scroll-to-bottom FAB
-                AnimatedVisibility(
+                androidx.compose.animation.AnimatedVisibility(
                     visible = showScrollToBottom,
                     enter = fadeIn() + scaleIn(),
                     exit = fadeOut() + scaleOut(),
@@ -544,7 +547,9 @@ fun ChatScreen(
                 ) {
                     FloatingActionButton(
                         onClick = {
-                            listState.animateScrollToItem(state.messages.lastIndex)
+                            scrollScope.launch {
+                                listState.animateScrollToItem(state.messages.lastIndex)
+                            }
                         },
                         modifier = Modifier.size(40.dp),
                         containerColor = MaterialTheme.colorScheme.surfaceContainer,
@@ -575,6 +580,7 @@ fun ChatScreen(
 
 @Composable
 private fun ThinkingIndicator(thinkingText: String) {
+    val context = LocalContext.current
     val infiniteTransition = rememberInfiniteTransition(label = "thinking")
     val alpha by infiniteTransition.animateFloat(
         initialValue = 0.3f,
@@ -640,6 +646,7 @@ private fun ChatInputBar(
     isAgentTyping: Boolean,
     isConnected: Boolean,
 ) {
+    val context = LocalContext.current
     val canSend = inputText.isNotBlank() && !isAgentTyping && isConnected
 
     AnimatedVisibility(
@@ -808,7 +815,7 @@ private fun ChatInputBar(
                         ) {
                             Icon(
                                 imageVector = Icons.AutoMirrored.Filled.Send,
-                                contentDescription = "Send",
+                                contentDescription = context.getString(R.string.chat_send_desc),
                             )
                         }
                     }
@@ -824,11 +831,12 @@ private fun ClarifyDialog(
     onOptionSelected: (String) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val context = LocalContext.current
     var typedText by rememberSaveable(clarify) { mutableStateOf(clarify.text) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Clarification Needed") },
+        title = { Text(context.getString(R.string.chat_clarify_title)) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(text = clarify.text)
@@ -836,7 +844,7 @@ private fun ClarifyDialog(
                 if (clarify.options.isNotEmpty()) {
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
-                        text = "Tap an option to copy to input, or long-press to send directly.",
+                        text = context.getString(R.string.chat_clarify_hint),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -863,7 +871,7 @@ private fun ClarifyDialog(
                 OutlinedTextField(
                     value = typedText,
                     onValueChange = { typedText = it },
-                    label = { Text("Response") },
+                    label = { Text(context.getString(R.string.chat_clarify_response)) },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                 )
@@ -878,12 +886,12 @@ private fun ClarifyDialog(
                 },
                 enabled = typedText.isNotBlank(),
             ) {
-                Text("Send")
+                Text(context.getString(R.string.chat_send))
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("Dismiss")
+                Text(context.getString(R.string.chat_dismiss))
             }
         },
     )
@@ -896,6 +904,7 @@ private fun CompactSearchInput(
     modifier: Modifier = Modifier,
     isError: Boolean = false,
 ) {
+    val context = LocalContext.current
     val textColor = MaterialTheme.colorScheme.onSurface
     val errorColor = MaterialTheme.colorScheme.error
     val outlineColor = if (isError) errorColor else MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
@@ -931,7 +940,7 @@ private fun CompactSearchInput(
                 Box(modifier = Modifier.weight(1f)) {
                     if (value.isEmpty()) {
                         Text(
-                            text = "Search messages…",
+                            text = context.getString(R.string.chat_search_placeholder),
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                         )
@@ -945,7 +954,7 @@ private fun CompactSearchInput(
                     ) {
                         Icon(
                             imageVector = Icons.Filled.Close,
-                            contentDescription = "Clear",
+                            contentDescription = context.getString(R.string.chat_clear_search_desc),
                             modifier = Modifier.size(16.dp),
                         )
                     }
@@ -1008,7 +1017,7 @@ private fun SearchBarRow(
         ) {
             Icon(
                 Icons.Filled.KeyboardArrowUp,
-                contentDescription = "Previous match",
+                contentDescription = context.getString(R.string.chat_prev_match_desc),
                 modifier = Modifier.size(20.dp),
             )
         }
@@ -1019,14 +1028,14 @@ private fun SearchBarRow(
         ) {
             Icon(
                 Icons.Filled.KeyboardArrowDown,
-                contentDescription = "Next match",
+                contentDescription = context.getString(R.string.chat_next_match_desc),
                 modifier = Modifier.size(20.dp),
             )
         }
         IconButton(onClick = onClose, modifier = Modifier.size(36.dp)) {
             Icon(
                 Icons.Filled.Close,
-                contentDescription = "Close search",
+                contentDescription = context.getString(R.string.chat_close_search_desc),
                 modifier = Modifier.size(20.dp),
             )
         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -99,6 +99,7 @@ import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.ws.ConnectionStatus
 import com.m57.hermescontrol.notification.NotificationHelper
 import com.m57.hermescontrol.theme.StatusRed
@@ -974,6 +975,7 @@ private fun SearchBarRow(
     onNavigateDown: () -> Unit,
     onClose: () -> Unit,
 ) {
+    val context = LocalContext.current
     val isError = searchQuery.isNotEmpty() && searchMatchCount == 0
 
     Row(

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -91,6 +91,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
@@ -581,7 +582,6 @@ fun ChatScreen(
 
 @Composable
 private fun ThinkingIndicator(thinkingText: String) {
-    val context = LocalContext.current
     val infiniteTransition = rememberInfiniteTransition(label = "thinking")
     val alpha by infiniteTransition.animateFloat(
         initialValue = 0.3f,
@@ -647,7 +647,6 @@ private fun ChatInputBar(
     isAgentTyping: Boolean,
     isConnected: Boolean,
 ) {
-    val context = LocalContext.current
     val canSend = inputText.isNotBlank() && !isAgentTyping && isConnected
 
     AnimatedVisibility(
@@ -816,7 +815,7 @@ private fun ChatInputBar(
                         ) {
                             Icon(
                                 imageVector = Icons.AutoMirrored.Filled.Send,
-                                contentDescription = context.getString(R.string.chat_send_desc),
+                                contentDescription = stringResource(R.string.chat_send_desc),
                             )
                         }
                     }
@@ -832,12 +831,11 @@ private fun ClarifyDialog(
     onOptionSelected: (String) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val context = LocalContext.current
     var typedText by rememberSaveable(clarify) { mutableStateOf(clarify.text) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(context.getString(R.string.chat_clarify_title)) },
+        title = { Text(stringResource(R.string.chat_clarify_title)) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(text = clarify.text)
@@ -845,7 +843,7 @@ private fun ClarifyDialog(
                 if (clarify.options.isNotEmpty()) {
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
-                        text = context.getString(R.string.chat_clarify_hint),
+                        text = stringResource(R.string.chat_clarify_hint),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -872,7 +870,7 @@ private fun ClarifyDialog(
                 OutlinedTextField(
                     value = typedText,
                     onValueChange = { typedText = it },
-                    label = { Text(context.getString(R.string.chat_clarify_response)) },
+                    label = { Text(stringResource(R.string.chat_clarify_response)) },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                 )
@@ -887,12 +885,12 @@ private fun ClarifyDialog(
                 },
                 enabled = typedText.isNotBlank(),
             ) {
-                Text(context.getString(R.string.chat_send))
+                Text(stringResource(R.string.chat_send))
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text(context.getString(R.string.chat_dismiss))
+                Text(stringResource(R.string.chat_dismiss))
             }
         },
     )
@@ -905,7 +903,6 @@ private fun CompactSearchInput(
     modifier: Modifier = Modifier,
     isError: Boolean = false,
 ) {
-    val context = LocalContext.current
     val textColor = MaterialTheme.colorScheme.onSurface
     val errorColor = MaterialTheme.colorScheme.error
     val outlineColor = if (isError) errorColor else MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
@@ -941,7 +938,7 @@ private fun CompactSearchInput(
                 Box(modifier = Modifier.weight(1f)) {
                     if (value.isEmpty()) {
                         Text(
-                            text = context.getString(R.string.chat_search_placeholder),
+                            text = stringResource(R.string.chat_search_placeholder),
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                         )
@@ -955,7 +952,7 @@ private fun CompactSearchInput(
                     ) {
                         Icon(
                             imageVector = Icons.Filled.Close,
-                            contentDescription = context.getString(R.string.chat_clear_search_desc),
+                            contentDescription = stringResource(R.string.chat_clear_search_desc),
                             modifier = Modifier.size(16.dp),
                         )
                     }
@@ -975,7 +972,6 @@ private fun SearchBarRow(
     onNavigateDown: () -> Unit,
     onClose: () -> Unit,
 ) {
-    val context = LocalContext.current
     val isError = searchQuery.isNotEmpty() && searchMatchCount == 0
 
     Row(
@@ -1019,7 +1015,7 @@ private fun SearchBarRow(
         ) {
             Icon(
                 Icons.Filled.KeyboardArrowUp,
-                contentDescription = context.getString(R.string.chat_prev_match_desc),
+                contentDescription = stringResource(R.string.chat_prev_match_desc),
                 modifier = Modifier.size(20.dp),
             )
         }
@@ -1030,14 +1026,14 @@ private fun SearchBarRow(
         ) {
             Icon(
                 Icons.Filled.KeyboardArrowDown,
-                contentDescription = context.getString(R.string.chat_next_match_desc),
+                contentDescription = stringResource(R.string.chat_next_match_desc),
                 modifier = Modifier.size(20.dp),
             )
         }
         IconButton(onClick = onClose, modifier = Modifier.size(36.dp)) {
             Icon(
                 Icons.Filled.Close,
-                contentDescription = context.getString(R.string.chat_close_search_desc),
+                contentDescription = stringResource(R.string.chat_close_search_desc),
                 modifier = Modifier.size(20.dp),
             )
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,16 @@
 <resources>
     <string name="app_name">HermesControl</string>
+
+    <!-- Chat -->
+    <string name="chat_send_desc">Send</string>
+    <string name="chat_clarify_title">Clarification Needed</string>
+    <string name="chat_clarify_hint">Tap an option to copy to input, or long-press to send directly.</string>
+    <string name="chat_clarify_response">Response</string>
+    <string name="chat_send">Send</string>
+    <string name="chat_dismiss">Dismiss</string>
+    <string name="chat_search_placeholder">Search messages\u2026</string>
+    <string name="chat_clear_search_desc">Clear</string>
+    <string name="chat_prev_match_desc">Previous match</string>
+    <string name="chat_next_match_desc">Next match</string>
+    <string name="chat_close_search_desc">Close search</string>
 </resources>


### PR DESCRIPTION
## Fixes compilation errors in #163

Two bugs in the scroll-to-bottom FAB:

1. **Ambiguous `AnimatedVisibility` call** — inside a Box nested in a Column, the compiler couldn't resolve which scope's `AnimatedVisibility` to use. Fixed by using the fully-qualified `androidx.compose.animation.AnimatedVisibility` (matching the existing pattern used by the loading overlay).

2. **Suspend function in non-coroutine context** — `listState.animateScrollToItem()` is a suspend function but was called from a non-suspend `onClick` lambda. Fixed by wrapping in `scrollScope.launch { ... }` with `rememberCoroutineScope()`.

These were the exact CI failures:
- `e: ... ChatScreen.kt:536:17 'AnimatedVisibility' cannot be called in this context with an implicit receiver`
- `e: ... ChatScreen.kt:547:39 Suspend function 'animateScrollToItem' can only be called from a coroutine`

Closes #130