### PR TITLE
fix(nav): keep NavKey implementation names in proguard

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -46,3 +46,8 @@
 
 # ── BuildConfig ───────────────────────────────────────────────────────────
 -keep class com.m57.hermescontrol.BuildConfig { *; }
+
+# ── Navigation (NavKey Names) ─────────────────────────────────────────────
+# Keep screen object class names because their simpleNames are used for bottom nav selection and storage.
+-keep class * implements androidx.navigation3.runtime.NavKey { *; }
+


### PR DESCRIPTION
Avoids obfuscating screen classes/objects so their simpleNames match preferences.