### PR TITLE
🧪 [test] Add coverage for malformed Base64 decoding in ConnectViewModel

### DIFF
--- a/app/src/test/java/com/m57/hermescontrol/ui/connect/ConnectViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/connect/ConnectViewModelTest.kt
@@ -36,6 +36,7 @@ class ConnectViewModelTest {
 
         mockkObject(AuthManager)
         mockkObject(ApiClient)
+        mockkStatic(android.util.Base64::class)
 
         mockApiService = mockk()
         every { ApiClient.hermesApi } returns mockApiService
@@ -292,4 +293,33 @@ class ConnectViewModelTest {
             assertFalse(state.connectionSuccess)
             assertEquals("Connection failed: Something went wrong", state.errorMessage)
         }
+
+    @Test
+    fun testOnPairingString_malformedBase64_showsError() {
+        val viewModel = ConnectViewModel()
+
+        // Mock Base64.decode to throw IllegalArgumentException for an invalid short string
+        every { android.util.Base64.decode(any<String>(), any()) } throws IllegalArgumentException("bad base64")
+
+        viewModel.onPairingString("short-invalid-string")
+
+        val state = viewModel.uiState.value
+        assertEquals("Malformed pairing string — expected URL or Base64-encoded JSON", state.errorMessage)
+    }
+
+    @Test
+    fun testOnPairingString_malformedBase64_validRawToken() {
+        val viewModel = ConnectViewModel()
+
+        // Mock Base64.decode to throw IllegalArgumentException
+        every { android.util.Base64.decode(any<String>(), any()) } throws IllegalArgumentException("bad base64")
+
+        // A string that is >= 32 chars and alphanumeric matching the raw token regex
+        val validToken = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+        viewModel.onPairingString(validToken)
+
+        val state = viewModel.uiState.value
+        assertEquals(validToken, state.token)
+        assertNull(state.errorMessage)
+    }
 }


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap where the error path for parsing malformed Base64 payloads in `ConnectViewModel.onPairingString` was untested.
📊 **Coverage:**
  * Tested the scenario where `Base64.decode` throws an `IllegalArgumentException` and the fallback logic accurately identifies an invalid token format (e.g. string is too short).
  * Tested the scenario where the malformed Base64 string actually matches a valid raw token format (>= 32 chars, alphanumeric), ensuring the app correctly updates the state with the raw token without showing an error message.
✨ **Result:** Improved test coverage and reliability for the pairing mechanism error handling path.

Used MockK `mockkStatic` to mock `android.util.Base64` which is an Android framework class that usually throws a runtime stub exception when run in local JVM tests.

---
*PR created automatically by Jules for task [11730725806557959839](https://jules.google.com/task/11730725806557959839) started by @Hy4ri*