### PR TITLE
⚡ [perf] Avoid intermediate allocation when mapping bottomNavKeys

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/Navigation.kt
+++ b/app/src/main/java/com/m57/hermescontrol/Navigation.kt
@@ -197,7 +197,7 @@ fun MainNavigation(sessionId: String? = null) {
     // recomposes and reflects choices instantly.
     val bottomNavItemsState by AuthManager.bottomNavItemsFlow.collectAsState()
     val bottomNavItems = resolveBottomNavItems(bottomNavItemsState)
-    val bottomNavKeys = remember(bottomNavItems) { bottomNavItems.map { it.key }.toSet() }
+    val bottomNavKeys = remember(bottomNavItems) { bottomNavItems.mapTo(mutableSetOf()) { it.key } }
 
     // Sync primary screens to NavigationController
     LaunchedEffect(bottomNavKeys) {


### PR DESCRIPTION
💡 **What:** Replaced `bottomNavItems.map { it.key }.toSet()` with `bottomNavItems.mapTo(mutableSetOf()) { it.key }` inside the `remember` block for `bottomNavKeys` in `Navigation.kt`.

🎯 **Why:** The original code created a temporary `ArrayList` from the `.map` operation, only to iterate through it again to create a `Set`, and then discard the list. This allocation and redundant iteration occurred in the critical recomposition path. By using `mapTo`, the mapping operation populates the resulting `MutableSet` directly in a single pass, avoiding the unnecessary intermediate heap allocation.

📊 **Measured Improvement:** As noted in `AGENTS.md` ("No local Android SDK — CI is the only compilation truth engine"), local compilation and macrobenchmarks are unsupported in the development environment. However, avoiding intermediate collections in Compose's recomposition path is an established best practice to minimize memory churn and garbage collection pauses, which inherently improves frametime consistency.

---
*PR created automatically by Jules for task [3611041217022845300](https://jules.google.com/task/3611041217022845300) started by @Hy4ri*