### PR TITLE
Update GitHub Release Action to use Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           retention-days: 90
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Hermes Control ${{ steps.version.outputs.tag }}


### PR DESCRIPTION
Updates the `softprops/action-gh-release` step in `release.yml` from `v2` to `v3`. This targets Node 24 and resolves the Node 20 deprecation warning shown during CI runs.

---
*PR created automatically by Jules for task [9537188507607267622](https://jules.google.com/task/9537188507607267622) started by @Hy4ri*