### PR TITLE
🧹 Extract hardcoded 'todo' string to constant in KanbanScreen

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
@@ -48,6 +48,8 @@ import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.HermesScaffold
 import com.m57.hermescontrol.ui.common.LoadingState
 
+private const val DEFAULT_COLUMN = "todo"
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun KanbanScreen(
@@ -185,7 +187,7 @@ fun KanbanScreen(
                         AddTaskDialog(
                             onDismiss = { showAddTaskDialog = false },
                             onConfirm = { title, desc ->
-                                viewModel.createTask(title, desc, state.columns.firstOrNull()?.name ?: "todo")
+                                viewModel.createTask(title, desc, state.columns.firstOrNull()?.name ?: DEFAULT_COLUMN)
                                 showAddTaskDialog = false
                             },
                         )


### PR DESCRIPTION
🎯 **What:** The code health issue regarding a hardcoded string ("todo") used as a default column name in `KanbanScreen.kt` was addressed.
💡 **Why:** Extracting the hardcoded string into a named constant improves code maintainability, readability, and prevents "magic strings" from proliferating in the UI codebase.
✅ **Verification:** Verified by ensuring the code compiles successfully, local JVM tests pass (`./gradlew testDebugUnitTest`), and code review approved the change as functional and safe.
✨ **Result:** The hardcoded value targeted in the specific line of code has been successfully refactored to use `DEFAULT_COLUMN`.

---
*PR created automatically by Jules for task [7326020399680365085](https://jules.google.com/task/7326020399680365085) started by @Hy4ri*