### PR TITLE
docs: add GitHub issue templates (bug report + feature request)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: 🐛 Bug report
+description: Report a bug or unexpected behaviour
+title: '[bug] '
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+<!-- A clear and concise description of what the bug is. -->
+
+## To reproduce
+
+Steps to reproduce the behaviour:
+
+1. Go to '…'
+2. Tap on '…'
+3. Scroll to '…'
+4. See error
+
+## Expected behaviour
+
+<!-- What should have happened instead? -->
+
+## Screenshots / screen recordings
+
+<!-- If applicable, add screenshots or a screen recording to help explain the problem. -->
+
+## Environment
+
+- Device: <!-- e.g. Pixel 8, Samsung Galaxy S24 -->
+- Android version: <!-- e.g. Android 14, Android 15 -->
+- App version: <!-- e.g. v1.2.3, or the commit SHA -->
+- Hermes dashboard version: <!-- if known -->
+
+## Additional context
+
+<!--
+  Anything else? Error logs, crash reports (adb logcat), network trace, etc.
+  Remove any sensitive info (tokens, hostnames) before pasting.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discussion
+    url: https://github.com/Hy4ri/hermes-mobile/discussions
+    about: For questions, ideas, or general discussion

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: ✨ Feature request
+description: Suggest an idea, enhancement, UX improvement, or refactor
+title: '[enhancement] '
+labels: enhancement
+assignees: ''
+---
+
+## Problem / motivation
+
+<!--
+  What problem would this solve? Why is this needed?
+  e.g. "It's frustrating when …" or "The app currently lacks …"
+-->
+
+## Proposed solution
+
+<!-- A clear description of what you want to happen. -->
+
+## Alternative approaches
+
+<!-- Any alternative solutions or features you've considered. -->
+
+## Screenshots / mockups
+
+<!-- If applicable, add sketches, screenshots from other apps, or wireframes. -->
+
+## Additional context
+
+<!--
+  Any other details: links to similar features in other apps, relevant issues,
+  API endpoints that would be consumed, etc.
+-->


### PR DESCRIPTION
## Summary

Adds `.github/ISSUE_TEMPLATE/` with structured templates for bugs and feature requests.

## Type of change

- [x] 📝 Documentation

## What changed

- `config.yml` — disables blank issues, links to Discussions
- `bug_report.md` — structured bug report with reproduction steps, environment info, screenshot slot, and bracket-prefix `[bug]` title convention
- `feature_request.md` — enhancement/UX/refactor template with problem/motivation, proposed solution, alternatives, and `[enhancement]` title convention

## Checklist

- [x] ktlint passes — N/A, markdown only
- [x] CI is green