### PR TITLE
fix: remove invalid assignees field from issue template frontmatter

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,6 @@ name: 🐛 Bug report
 description: Report a bug or unexpected behaviour
 title: '[bug] '
 labels: bug
-assignees: ''
 ---
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,6 @@ name: ✨ Feature request
 description: Suggest an idea, enhancement, UX improvement, or refactor
 title: '[enhancement] '
 labels: enhancement
-assignees: ''
 ---
 
 ## Problem / motivation


### PR DESCRIPTION
Fixes the issue templates not showing up. The `assignees: ''` value in the YAML frontmatter caused GitHub to silently ignore the templates, falling back to blank issue + discussions.
