### PR TITLE
fix(#240): notification tap race condition opens new chat instead of correct session

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -73,6 +73,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -131,9 +132,22 @@ fun ChatScreen(
     val context = LocalContext.current
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
 
+    // Publish the notification session ID to the ViewModel synchronously
+    // during composition — BEFORE any WebSocket event (GatewayReady) can be
+    // processed. This ensures GatewayReady sees the pending session and
+    // resumes it instead of creating a new empty chat (issue #240).
+    SideEffect {
+        viewModel.initialSessionId = sessionId
+    }
+
     // Switch to the session from a notification tap or history screen when provided.
+    // Keyed on connectionStatus so switchSession only fires after the WS is
+    // connected — otherwise SESSION_RESUME is silently dropped (webSocket is
+    // null before onOpen). GatewayReady also handles initialSessionId as a
+    // fallback for the race where it fires before this effect.
     val pendingSessionId = NavigationController.pendingSessionId
-    LaunchedEffect(sessionId, pendingSessionId) {
+    LaunchedEffect(sessionId, pendingSessionId, state.connectionStatus) {
+        if (state.connectionStatus != ConnectionStatus.CONNECTED) return@LaunchedEffect
         val target = if (!sessionId.isNullOrBlank()) sessionId else pendingSessionId
         if (!target.isNullOrBlank()) {
             viewModel.switchSession(target)

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -137,6 +137,16 @@ class ChatViewModel(
 
     // ── WS Event Handling ────────────────────────────────────────────────
 
+    /**
+     * Session ID to resume when the WebSocket connects. Set synchronously by
+     * [ChatScreen] via `SideEffect` during composition — before any WS event
+     * can be processed. This prevents the race where [GatewayReady] fires
+     * before ChatScreen's `LaunchedEffect` can call [switchSession], causing
+     * [createNewSession] to create an empty chat that overwrites the
+     * notification session (issue #240).
+     */
+    var initialSessionId: String? = null
+
     private fun handleWsEvent(event: WsEvent) {
         when (event) {
             is WsEvent.GatewayReady -> {
@@ -144,7 +154,13 @@ class ChatViewModel(
                 addSystemMessage("Connected to Hermes")
                 loadSessions()
                 if (_uiState.value.currentSessionId == null) {
-                    createNewSession()
+                    val initial = initialSessionId
+                    if (!initial.isNullOrBlank()) {
+                        initialSessionId = null
+                        switchSession(initial)
+                    } else {
+                        createNewSession()
+                    }
                 }
             }
 

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -129,6 +129,36 @@ class ChatViewModelTest {
         }
 
     @Test
+    fun testGatewayReady_withInitialSessionId_switchesToIt() =
+        runTest {
+            val viewModel = ChatViewModel(app, startCleanup = false)
+            advanceUntilIdle()
+
+            // Set the initial session ID (normally done by ChatScreen SideEffect)
+            viewModel.initialSessionId = "session-from-notification"
+            mockConnectionStatus.value = ConnectionStatus.CONNECTED
+            mockEventsFlow.emit(WsEvent.GatewayReady(null))
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertTrue(state.isConnected)
+            // Should NOT have called createNewSession — switchSession was used instead
+            assertEquals("session-from-notification", state.currentSessionId)
+
+            // Verify SESSION_RESUME was sent instead of SESSION_CREATE
+            verify { HermesWsClient.send(WsMethods.SESSION_LIST, any(), any()) }
+            verify {
+                HermesWsClient.send(
+                    WsMethods.SESSION_RESUME,
+                    mapOf("session_id" to "session-from-notification"),
+                    any(),
+                )
+            }
+            // SESSION_CREATE must NOT be sent
+            verify(inverse = true) { HermesWsClient.send(WsMethods.SESSION_CREATE, any(), any()) }
+        }
+
+    @Test
     fun testSessionCreateRpcResult() =
         runTest {
             var createReqId = ""


### PR DESCRIPTION
## Root Cause

Race condition between `GatewayReady` auto-creating a session and `ChatScreen` LaunchedEffect calling `switchSession`.

**Race scenario (app killed → tap notification on a fast LAN):**

1. `GatewayReady` fires → `currentSessionId == null` → `createNewSession()` → sends `SESSION_CREATE` RPC
2. `LaunchedEffect` fires → `switchSession(notificationSessionId)` → sets `currentSessionId = notificationSessionId`
3. `SESSION_CREATE` response arrives → **overwrites** `currentSessionId = newSessionId` → **new empty chat**

The `SESSION_CREATE` response handler unconditionally sets `currentSessionId`, overwriting the correct session.

**Secondary issue:** Even in the non-race case, `SESSION_RESUME` was silently dropped because `switchSession` sent it before the WebSocket connected (`webSocket?.send(json) ?: Log.w(...)`).

## Fix (two-pronged)

### 1. `ChatViewModel.kt` — `initialSessionId` field + GatewayReady guard

- New `var initialSessionId: String? = null` field, set synchronously by ChatScreen via `SideEffect` during composition (before any WS event can arrive).
- In `GatewayReady`, if `currentSessionId == null`, check `initialSessionId` first:
  - If set → `switchSession(initialSessionId)` (resumes the notification session)
  - If null → `createNewSession()` (original behavior for normal app open)

### 2. `ChatScreen.kt` — wait for connection before switching

- Added `SideEffect { viewModel.initialSessionId = sessionId }` to publish the notification session ID before any WS event.
- Added `state.connectionStatus` as a `LaunchedEffect` key, with a `if (state.connectionStatus != CONNECTED) return@LaunchedEffect` guard — ensures `SESSION_RESUME` is only sent when the WebSocket is actually connected.

## Verification

- `testGatewayReady_createsSessionIfNoneExists` — unchanged (no `initialSessionId` → still calls `createNewSession`)
- `testGatewayReady_withInitialSessionId_switchesToIt` — NEW: verifies `GatewayReady` with `initialSessionId` calls `switchSession` (`SESSION_RESUME`), NOT `createNewSession` (`SESSION_CREATE`)

Fixes #240