### PR TITLE
fix(#218): fallback to Untitled for empty or blank session titles

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
@@ -100,7 +100,9 @@ fun SessionsScreen(
                                 modifier = Modifier.padding(spacing.md),
                             ) {
                                 Text(
-                                    text = session.title ?: stringResource(R.string.history_untitled),
+                                    text =
+                                        session.title?.takeIf { it.isNotBlank() }
+                                            ?: stringResource(R.string.history_untitled),
                                     style = MaterialTheme.typography.titleMedium,
                                     fontWeight = FontWeight.Bold,
                                 )


### PR DESCRIPTION
Closes #218