### PR TITLE
fix(#204): dynamically reset and reload chat title when creating or switching sessions

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -500,6 +500,7 @@ class ChatViewModel(
                         isLoading = false,
                         messages = emptyList(),
                         streamingMessage = null,
+                        chatTitle = "Hermes",
                     )
                 }
                 addSystemMessage("Session created", persist = true)
@@ -783,6 +784,7 @@ class ChatViewModel(
                 isLoading = true,
                 messages = emptyList(),
                 streamingMessage = null,
+                chatTitle = "Hermes",
             )
         }
         streamingMessageId = null
@@ -816,7 +818,7 @@ class ChatViewModel(
         streamingMessageId = null
 
         _uiState.update {
-            val title = it.sessions.find { s -> s.id == sessionId }?.title ?: it.chatTitle
+            val title = it.sessions.find { s -> s.id == sessionId }?.title ?: "Hermes"
             it.copy(
                 isLoading = true,
                 messages = emptyList(),
@@ -841,6 +843,8 @@ class ChatViewModel(
         }
         // Step 3: Load fresh messages from REST and merge
         loadSessionMessages(sessionId)
+        // Step 4: Refresh session list to get latest titles
+        loadSessions()
     }
 
     private fun loadCachedMessages(sessionId: String) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -359,6 +359,8 @@ class ChatViewModel(
                 dao.upsert(msgToPersist.toEntity(sid))
             }
         }
+        // Refresh session list to catch newly generated titles
+        loadSessions()
     }
 
     private fun handleMessageDone(event: WsEvent.MessageDone) {


### PR DESCRIPTION
Closes #204