### PR TITLE
fix(#284): remove dead code across API, models, WS client, and docs

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/local/ChatMessageEntity.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/ChatMessageEntity.kt
@@ -9,7 +9,7 @@ import androidx.room.PrimaryKey
  * UI model but is stored independently so it survives process death.
  *
  * Messages are scoped by [sessionId] so switching sessions loads the right
- * thread. The [createdAt] field preserves original ordering even if Room
+ * thread. The [timestamp] field preserves original ordering even if Room
  * reorders internally.
  */
 @Entity(tableName = "chat_messages")

--- a/app/src/main/java/com/m57/hermescontrol/data/model/PluginInfo.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/PluginInfo.kt
@@ -28,10 +28,6 @@ data class PluginsHubResponse(
     val plugins: List<PluginInfo>,
 )
 
-data class TogglePluginRequest(
-    val enabled: Boolean,
-)
-
 data class AgentPluginInstallBody(
     val identifier: String,
     val force: Boolean = false,

--- a/app/src/main/java/com/m57/hermescontrol/data/model/Profile.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/Profile.kt
@@ -37,7 +37,3 @@ data class UpdateProfileModelRequest(
     val provider: String,
     val model: String,
 )
-
-data class UpdateProfileDescriptionRequest(
-    val description: String,
-)

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -37,7 +37,6 @@ import com.m57.hermescontrol.data.model.SystemStatsResponse
 import com.m57.hermescontrol.data.model.ToggleSkillRequest
 import com.m57.hermescontrol.data.model.Toolset
 import com.m57.hermescontrol.data.model.ToolsetToggleRequest
-import com.m57.hermescontrol.data.model.UpdateProfileDescriptionRequest
 import com.m57.hermescontrol.data.model.UpdateProfileModelRequest
 import com.m57.hermescontrol.data.model.UpdateProfileSoulRequest
 import com.m57.hermescontrol.data.model.UpdateRawConfigRequest
@@ -77,9 +76,6 @@ interface HermesApiService {
 
     @GET("api/system/stats")
     suspend fun getSystemStats(): Response<SystemStatsResponse>
-
-    @GET("api/config")
-    suspend fun getConfig(): Response<Map<String, Any?>>
 
     @GET("api/skills")
     suspend fun getSkills(): Response<List<Skill>>
@@ -147,12 +143,6 @@ interface HermesApiService {
     suspend fun updateProfileModel(
         @Path("name") name: String,
         @Body body: UpdateProfileModelRequest,
-    ): Response<Unit>
-
-    @PUT("api/profiles/{name}/description")
-    suspend fun updateProfileDescription(
-        @Path("name") name: String,
-        @Body body: UpdateProfileDescriptionRequest,
     ): Response<Unit>
 
     @GET("api/tools/toolsets")

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
@@ -1,6 +1,7 @@
 package com.m57.hermescontrol.data.ws
 
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import com.google.gson.Gson
 import com.m57.hermescontrol.BuildConfig
 import com.m57.hermescontrol.data.local.AuthManager
@@ -102,6 +103,7 @@ object HermesWsClient {
 
     // ── Connection helpers ────────────────────────────────────────────────
 
+    @VisibleForTesting
     val isConnected: Boolean get() = connected.get()
 
     /** Open a WebSocket connection using settings from [AuthManager]. */


### PR DESCRIPTION
Closes #284

## Changes

Removes 6 dead-code findings from the automated code review (CODE-01 through CODE-06):

| Finding | File | Change |
|---------|------|--------|
| **CODE-01** | `HermesApiService.kt` + `Profile.kt` | Removed `updateProfileDescription()` endpoint and `UpdateProfileDescriptionRequest` DTO — zero callers |
| **CODE-02** | `HermesApiService.kt` | Removed `getConfig()` — app uses `getRawConfig()` instead |
| **CODE-03** | `PluginInfo.kt` | Removed `TogglePluginRequest` DTO — never referenced in production |
| **CODE-05** | `HermesWsClient.kt` | Marked `isConnected` with `@VisibleForTesting` — only used in tests |
| **CODE-06** | `ChatMessageEntity.kt` | Fixed KDoc: `[createdAt]` → `[timestamp]` to match the actual field name |

## Stats
- **5 files changed**, **3 insertions**, **19 deletions**
- All changed files pass `ktlint` locally
- Only dead/unused code removed — zero functional impact

## Verification
Each finding was confirmed against the live `main` branch before removal (verified 2026-06-22, commit `60bf6e8`).

---

> Skipping CODE-04 (legacy WS callbacks `onMessage`/etc.) for a separate PR since it requires test refactoring.