### PR TITLE
fix(#295): update test count, correct AGENTS.md DAO return type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,8 @@ touch events and become unresponsive.
 ### Room Persistence
 
 - `ChatMessageEntity` / `ChatMessageDao` / `HermesDatabase` — chat messages survive
-  app kills.
+  app kills. `getMessagesForSession()` returns `suspend fun ...: List<ChatMessageEntity>`
+  (not `Flow` — the caller controls the coroutine scope).
 - Room 2.7.x requires `room { schemaDirectory("$projectDir/schemas") }` DSL.
 - `ChatViewModel` extends `AndroidViewModel` (needs Application for DB access).
 

--- a/TEST_READY.md
+++ b/TEST_READY.md
@@ -5,7 +5,7 @@ This document provides a summary of test readiness, including test suite executi
 ## Execution and Expected Outcome
 - **Test Runner Command**: `nix develop --command ./gradlew test`
 - **Expected Outcome**: All tests pass successfully.
-- **Total Test Count**: 123 tests
+- **Total Test Count**: 275 tests
 
 ---
 
@@ -22,7 +22,7 @@ This document provides a summary of test readiness, including test suite executi
 | ChatViewModelTest.kt | 9 |
 | AuthManagerTest.kt | 8 |
 | EventParserTest.kt | 6 |
-| **Total** | **123** |
+| **Total** | **275** |
 
 ---
 


### PR DESCRIPTION
## Closes #295 (B1 + B2)

### B1 — TEST_READY.md test count drift
Updated the test count from **123 → 275** in two places (summary line and totals table row). The actual `@Test`/`@ParameterizedTest` count grew as new suites were added.

### B2 — AGENTS.md wrong return type
`ChatMessageDao.getMessagesForSession()` is a `suspend fun` returning `List<ChatMessageEntity>`, not `Flow`. Added an inline note to the DAO section in AGENTS.md.

Closes #295