### PR TITLE
fix(#297): dependency hygiene — okhttp.logging debugImpl, crypto stable, LeakCanary

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -119,13 +119,14 @@ dependencies {
   implementation(libs.androidx.compose.material.icons.extended)
   // Tooling
   debugImplementation(libs.androidx.compose.ui.tooling)
+  debugImplementation(libs.leakcanary.android)
   // Instrumented tests
   androidTestImplementation(libs.androidx.compose.ui.test.junit4)
   debugImplementation(libs.androidx.compose.ui.test.manifest)
 
   // Networking
   implementation(libs.okhttp)
-  implementation(libs.okhttp.logging)
+  debugImplementation(libs.okhttp.logging)
   implementation(libs.retrofit)
   implementation(libs.retrofit.converter.gson)
   implementation(libs.gson)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,10 +18,11 @@ kotlin = "2.3.20"
 ksp = "2.3.9"
 nav3Core = "1.0.1"
 lifecycleViewmodelNav3 = "2.10.0"
+leakcanary = "2.14"
 okhttp = "4.12.0"
 retrofit = "2.11.0"
 gson = "2.11.0"
-securityCrypto = "1.1.0-alpha06"
+securityCrypto = "1.0.0"
 mockk = "1.13.12"
 room = "2.7.1"
 
@@ -49,6 +50,7 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", vers
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit5" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatform" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanary" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "nav3Core" }


### PR DESCRIPTION
## Summary

Closes #297 — three dependency hygiene fixes from the Part 6-D code review.

### Changes

**D1 — `okhttp.logging` → `debugImplementation`**
The logging interceptor was `implementation`-scoped, meaning it gets bundled into the release APK even at `Level.NONE`. Moved to `debugImplementation` so it's excluded from release builds entirely. The code in `ApiClient.kt` already gates the level on `BuildConfig.DEBUG`, so behavior is preserved.

**D2 — `security-crypto`: `1.1.0-alpha06` → `1.0.0`**
Downgraded to the stable, production-tested release. The alpha adds API churn with no documented benefit for this app's use case (EncryptedSharedPreferences).

**D3 — Added LeakCanary v2.14 as `debugImplementation`**
For an app with a singleton WebSocket, foreground service, and notification receivers, LeakCanary is essential during development. Auto-installs via ContentProvider — no manual init needed.

### Verification

- ✅ All changes verified against the repo's state at commit `60bf6e8`
- ✅ No Kotlin source files modified — only `build.gradle.kts` and `libs.versions.toml`
- ✅ `ktlint` not needed (no `.kt` files touched)

### CI Notes

No local Android SDK available — CI will verify compilation, lint, and tests on push.