### PR TITLE
fix(#287): fix empty-state subtitles and content description on Keys and Profiles screens

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/keys/KeysScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/keys/KeysScreen.kt
@@ -102,7 +102,7 @@ fun KeysScreen(
             state.envVars.isEmpty() -> {
                 EmptyState(
                     title = stringResource(R.string.keys_empty_title),
-                    subtitle = stringResource(R.string.toolsets_empty_desc),
+                    subtitle = stringResource(R.string.keys_empty_desc),
                     onAction = { viewModel.loadKeys() },
                     actionLabel = stringResource(R.string.content_desc_refresh),
                     modifier = Modifier.padding(paddingValues),
@@ -232,7 +232,7 @@ fun KeysScreen(
                                                             imageVector = Icons.Filled.Edit,
                                                             contentDescription =
                                                                 stringResource(
-                                                                    R.string.nav_drawer_section_converse,
+                                                                    R.string.content_desc_edit,
                                                                 ),
                                                         )
                                                     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/profiles/ProfilesScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/profiles/ProfilesScreen.kt
@@ -97,7 +97,7 @@ fun ProfilesScreen(
             state.profiles.isEmpty() -> {
                 EmptyState(
                     title = stringResource(R.string.profiles_empty_title),
-                    subtitle = stringResource(R.string.toolsets_empty_desc),
+                    subtitle = stringResource(R.string.profiles_empty_desc),
                     onAction = { viewModel.loadProfiles() },
                     actionLabel = stringResource(R.string.content_desc_refresh),
                     modifier = Modifier.padding(paddingValues),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@
     <string name="content_desc_scroll_to_bottom">Scroll to bottom</string>
     <string name="content_desc_interrupt">Interrupt</string>
     <string name="content_desc_copy">Copy</string>
+    <string name="content_desc_edit">Edit</string>
 
     <!-- Settings Screen -->
     <string name="settings_sec_connection">Connection</string>
@@ -286,6 +287,7 @@
 
     <!-- Profiles Screen -->
     <string name="profiles_empty_title">No profiles available</string>
+    <string name="profiles_empty_desc">Connection profiles from Hermes will appear here.</string>
     <string name="profiles_label_model">Model: %1$s</string>
     <string name="profiles_label_provider">Provider: %1$s</string>
     <string name="profiles_action_edit_soul">Edit Soul</string>
@@ -335,6 +337,7 @@
 
     <!-- Keys Screen -->
     <string name="keys_empty_title">No environment keys reported</string>
+    <string name="keys_empty_desc">Environment keys from Hermes will appear here.</string>
     <string name="keys_label_not_configured">Not configured</string>
     <string name="keys_action_toggle_visibility">Toggle Visibility</string>
 


### PR DESCRIPTION
Fixes copy-paste errors on Keys and Profiles screens for the empty state descriptions, as well as fixing the contentDescription of the edit icon on the Keys screen. Closes #287.

---
*PR created automatically by Jules for task [6415400599067338767](https://jules.google.com/task/6415400599067338767) started by @Hy4ri*