### PR TITLE
fix: optimize chat autoscroll performance during streaming

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -212,7 +212,7 @@ fun ChatScreen(
     }
 
     // Auto-scroll to bottom on new messages
-    LaunchedEffect(state.messages.size, state.streamingMessage?.content?.length, state.isThinking) {
+    LaunchedEffect(state.messages.size, state.streamingMessage != null, state.isThinking) {
         val totalItems =
             state.messages.size +
                 (if (state.streamingMessage != null) 1 else 0) +


### PR DESCRIPTION
Fixes issue #274 where auto-scroll LaunchedEffect cancels and restarts on every single token.

Changes made:
- Updated `LaunchedEffect` keys in `ChatScreen.kt` from `state.streamingMessage?.content?.length` to `state.streamingMessage != null`.
- Ensures the auto-scroll animation correctly begins when a stream starts without restarting the coroutine unnecessarily.

Impact:
- Reduces recomposition cost and job cancellations, significantly improving UI smoothness during chat generation.
- Fixes #274.

---
*PR created automatically by Jules for task [16605559560247791455](https://jules.google.com/task/16605559560247791455) started by @Hy4ri*