### PR TITLE
perf: add composite index to fix chat session loading latency (fixes #276)

### DIFF
--- a/app/schemas/com.m57.hermescontrol.data.local.HermesDatabase/2.json
+++ b/app/schemas/com.m57.hermescontrol.data.local.HermesDatabase/2.json
@@ -1,0 +1,83 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "b0a33c5fd32118982236698f395f519b",
+    "entities": [
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `session_id` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `tool_name` TEXT, `tool_status` TEXT, `is_streaming` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolName",
+            "columnName": "tool_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toolStatus",
+            "columnName": "tool_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isStreaming",
+            "columnName": "is_streaming",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_session_id_timestamp",
+            "unique": false,
+            "columnNames": [
+              "session_id",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_session_id_timestamp` ON `${TABLE_NAME}` (`session_id`, `timestamp`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b0a33c5fd32118982236698f395f519b')"
+    ]
+  }
+}

--- a/app/src/main/java/com/m57/hermescontrol/data/local/ChatMessageEntity.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/ChatMessageEntity.kt
@@ -12,7 +12,10 @@ import androidx.room.PrimaryKey
  * thread. The [timestamp] field preserves original ordering even if Room
  * reorders internally.
  */
-@Entity(tableName = "chat_messages")
+@Entity(
+    tableName = "chat_messages",
+    indices = [androidx.room.Index(value = ["session_id", "timestamp"])],
+)
 data class ChatMessageEntity(
     @PrimaryKey
     val id: String,

--- a/app/src/main/java/com/m57/hermescontrol/data/local/HermesDatabase.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/HermesDatabase.kt
@@ -23,7 +23,10 @@ abstract class HermesDatabase : RoomDatabase() {
         private val MIGRATION_1_2 =
             object : Migration(1, 2) {
                 override fun migrate(db: SupportSQLiteDatabase) {
-                    db.execSQL("CREATE INDEX IF NOT EXISTS `index_chat_messages_session_id_timestamp` ON `chat_messages` (`session_id`, `timestamp`)")
+                    db.execSQL(
+                        "CREATE INDEX IF NOT EXISTS `index_chat_messages_session_id_timestamp` " +
+                            "ON `chat_messages` (`session_id`, `timestamp`)",
+                    )
                 }
             }
 

--- a/app/src/main/java/com/m57/hermescontrol/data/local/HermesDatabase.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/HermesDatabase.kt
@@ -4,11 +4,13 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.m57.hermescontrol.BuildConfig
 
 @Database(
     entities = [ChatMessageEntity::class],
-    version = 1,
+    version = 2,
     exportSchema = true,
 )
 abstract class HermesDatabase : RoomDatabase() {
@@ -18,6 +20,13 @@ abstract class HermesDatabase : RoomDatabase() {
         @Volatile
         private var instance: HermesDatabase? = null
 
+        private val MIGRATION_1_2 =
+            object : Migration(1, 2) {
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL("CREATE INDEX IF NOT EXISTS `index_chat_messages_session_id_timestamp` ON `chat_messages` (`session_id`, `timestamp`)")
+                }
+            }
+
         fun get(context: Context): HermesDatabase =
             instance ?: synchronized(this) {
                 instance ?: Room
@@ -25,7 +34,8 @@ abstract class HermesDatabase : RoomDatabase() {
                         context.applicationContext,
                         HermesDatabase::class.java,
                         "hermes_control.db",
-                    ).apply {
+                    ).addMigrations(MIGRATION_1_2)
+                    .apply {
                         if (BuildConfig.DEBUG) {
                             fallbackToDestructiveMigration(false)
                         }


### PR DESCRIPTION
Fixes a performance issue with loading chat sessions as reported in #276.

Detailed changes:
- Added a composite index for `session_id` and `timestamp` columns in `ChatMessageEntity` to optimize the `getMessagesForSession` query and avoid full table scans.
- Incremented the Room database version from 1 to 2 in `HermesDatabase`.
- Created and registered a migration (`MIGRATION_1_2`) that adds the necessary composite index to the SQLite database.
- Added generated schema 2.json.

This modification reduces linearly increasing chat load latency to O(1) indexing operations, directly addressing the PERF-08 code review report.

---
*PR created automatically by Jules for task [13183787656053690381](https://jules.google.com/task/13183787656053690381) started by @Hy4ri*