### PR TITLE
Fix: Conditionally apply animateContentSize on AssistantBubble

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatBubble.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatBubble.kt
@@ -318,7 +318,7 @@ private fun AssistantBubble(
                 modifier =
                     Modifier
                         .widthIn(max = maxWidth)
-                        .animateContentSize()
+                        .let { if (!message.isStreaming) it.animateContentSize() else it }
                         .clip(
                             RoundedCornerShape(
                                 topStart = 4.dp,


### PR DESCRIPTION
Fixes #272. Unconditionally using `animateContentSize()` on a streaming chat bubble caused Jetpack Compose to trigger a layout animation for every single token appended. This wasted GPU cycles and contributed to streaming jank.

Changes made:
- Modified the modifier chain in `AssistantBubble` inside `ChatBubble.kt`.
- Applied `animateContentSize()` conditionally via `let { if (!message.isStreaming) it.animateContentSize() else it }`.

Impact:
- Eliminates performance issues (PERF-04) during active message streaming in the chat screen. The layout animation will now only occur once when the final (non-streaming) message state is reached. No regressions expected as this modifier change applies exclusively to the `isStreaming` state toggle.

---
*PR created automatically by Jules for task [12711053044192618783](https://jules.google.com/task/12711053044192618783) started by @Hy4ri*