### PR TITLE
fix(#273): optimize gesture detector to prevent thrashing during streaming

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatBubble.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatBubble.kt
@@ -10,10 +10,9 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -53,6 +52,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalUriHandler
@@ -129,7 +129,6 @@ fun ChatBubble(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun UserBubble(
     message: ChatMessage,
@@ -203,13 +202,13 @@ private fun UserBubble(
                             ),
                         ).background(brush = gradientBrush)
                         .testTag("chat_bubble_user")
-                        .combinedClickable(
-                            role = Role.Button,
-                            onClick = {},
-                            onLongClick = {
-                                showCopyButton = true
-                            },
-                        ),
+                        .pointerInput(message.id) {
+                            detectTapGestures(
+                                onLongPress = {
+                                    showCopyButton = true
+                                },
+                            )
+                        },
                 color = Color.Transparent,
                 tonalElevation = 0.dp,
             ) {
@@ -270,7 +269,6 @@ private fun UserBubble(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun AssistantBubble(
     message: ChatMessage,
@@ -327,13 +325,13 @@ private fun AssistantBubble(
                                 bottomEnd = 16.dp,
                             ),
                         ).testTag("chat_bubble_assistant")
-                        .combinedClickable(
-                            role = Role.Button,
-                            onClick = {},
-                            onLongClick = {
-                                showCopyButton = true
-                            },
-                        ),
+                        .pointerInput(message.id) {
+                            detectTapGestures(
+                                onLongPress = {
+                                    showCopyButton = true
+                                },
+                            )
+                        },
                 color = bubbleColor,
                 border =
                     BorderStroke(


### PR DESCRIPTION
Fixes #273

Replaced `.combinedClickable` with `.pointerInput` keyed on `message.id` instead of the mutating message content. This prevents the gesture detection pipeline from being torn down and rebuilt on every single token during message streaming.

Also removed the empty `onClick = {}` consumer that came with `combinedClickable`, which resolves the issue where users were unable to click markdown links embedded inside the chat bubbles.

---
*PR created automatically by Jules for task [1447643164802163414](https://jules.google.com/task/1447643164802163414) started by @Hy4ri*