### PR TITLE
fix(#280): decouple WebSocket message parsing from network reader thread

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
@@ -13,9 +13,13 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -83,10 +87,23 @@ object HermesWsClient {
 
     // ── Public observable stream ─────────────────────────────────────────
 
-    private val _events = MutableSharedFlow<WsEvent>(extraBufferCapacity = 64)
+    private val rawMessages = MutableSharedFlow<String>(extraBufferCapacity = 64)
 
     /** Collect this from ViewModels to receive all parsed [WsEvent]s. */
-    val events: SharedFlow<WsEvent> = _events.asSharedFlow()
+    val events: SharedFlow<WsEvent> =
+        rawMessages
+            .buffer()
+            .map { text ->
+                try {
+                    val rpc = gson.fromJson(text, JsonRpcResponse::class.java)
+                    EventParser.parse(rpc, text)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to parse message", e)
+                    WsEvent.Unknown(text)
+                }
+            }
+            .flowOn(Dispatchers.IO)
+            .shareIn(wsScope, SharingStarted.Eagerly)
 
     // ── Connection status flow ──────────────────────────────────────────
     private val _connectionStatus = MutableStateFlow(ConnectionStatus.DISCONNECTED)
@@ -209,10 +226,6 @@ object HermesWsClient {
             }
     }
 
-    private fun emit(event: WsEvent) {
-        _events.tryEmit(event)
-    }
-
     // ── Listener ─────────────────────────────────────────────────────────
 
     private class WsListenerImpl : WebSocketListener() {
@@ -234,14 +247,7 @@ object HermesWsClient {
             // AI reply tokens and tool output — never stream to logcat in
             // release builds.
             if (BuildConfig.DEBUG) Log.d(TAG, "← $text")
-            try {
-                val rpc = gson.fromJson(text, JsonRpcResponse::class.java)
-                val event = EventParser.parse(rpc, text)
-                emit(event)
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to parse message", e)
-                emit(WsEvent.Unknown(text))
-            }
+            rawMessages.tryEmit(text)
         }
 
         override fun onClosing(


### PR DESCRIPTION
Fix issue #280 on hermes mobile repo

**Severity:** High
**File:** `data/ws/HermesWsClient.kt:236`

`onMessage` parses incoming JSON text on the OkHttp dispatcher thread. The SharedFlow downstream has no backpressure strategy, so a slow collector causes buffer back-pressure that blocks the WS reader thread.

**Impact:** WS reader thread blocked → delayed messages → perceived lag.

**Fix:**
Parse JSON in a coroutine context, not on the WS reader thread. Use `Flow.buffer()` or `conflate()` to decouple the reader from the collector.

---
*PR created automatically by Jules for task [1342989347423439633](https://jules.google.com/task/1342989347423439633) started by @Hy4ri*