### PR TITLE
Fix main-thread decryption block in MainNavigation

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/Navigation.kt
+++ b/app/src/main/java/com/m57/hermescontrol/Navigation.kt
@@ -326,7 +326,8 @@ private fun appEntryProvider(
 
 @Composable
 fun MainNavigation(sessionId: String? = null) {
-    val hasToken = !AuthManager.getToken().isNullOrBlank()
+    val token by AuthManager.tokenFlow.collectAsState()
+    val hasToken = !token.isNullOrBlank()
     val startScreen: NavKey = if (hasToken) ChatScreen else ConnectScreen
 
     val backStack = rememberNavBackStack(startScreen)

--- a/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
@@ -57,6 +57,10 @@ object AuthManager {
 
     private val _bottomNavDisplayModeFlow = MutableStateFlow<BottomNavDisplayMode>(BottomNavDisplayMode.ICON_AND_TEXT)
     val bottomNavDisplayModeFlow: StateFlow<BottomNavDisplayMode> = _bottomNavDisplayModeFlow.asStateFlow()
+
+    private val _tokenFlow = MutableStateFlow<String?>(null)
+    val tokenFlow: StateFlow<String?> = _tokenFlow.asStateFlow()
+
     private val gson = com.google.gson.Gson()
 
     /**
@@ -84,6 +88,7 @@ object AuthManager {
             _useDynamicColorsFlow.value = isUseDynamicColors()
             _themePresetFlow.value = getThemePreset()
             _bottomNavDisplayModeFlow.value = getBottomNavDisplayMode()
+            _tokenFlow.value = getToken()
         }
     }
 
@@ -119,6 +124,9 @@ object AuthManager {
         token: String?,
     ) {
         requirePrefs().edit().putString("token_$profileId", token).apply()
+        if (getSelectedProfileId() == profileId) {
+            _tokenFlow.value = token
+        }
     }
 
     fun getSelectedProfileId(): String? {
@@ -128,6 +136,7 @@ object AuthManager {
 
     fun setSelectedProfileId(id: String?) {
         requirePrefs().edit().putString(KEY_SELECTED_PROFILE_ID, id).apply()
+        _tokenFlow.value = getToken()
     }
 
     // ── Token ────────────────────────────────────────────────────────────
@@ -147,6 +156,7 @@ object AuthManager {
             setProfileToken(selectedId, token)
         } else {
             requirePrefs().edit().putString(KEY_TOKEN, token).apply()
+            _tokenFlow.value = token
         }
     }
 


### PR DESCRIPTION
Fixes performance issue PERF-10 (#278) where `MainNavigation` was blocked by synchronous calls to `AuthManager.getToken()`. Resolves by introducing an in-memory cached `tokenFlow` synced with shared preferences.

---
*PR created automatically by Jules for task [1262313074460001567](https://jules.google.com/task/1262313074460001567) started by @Hy4ri*