### PR TITLE
perf: Add stable keys to Lazy list items for performance

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/achievements/AchievementsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/achievements/AchievementsScreen.kt
@@ -101,7 +101,7 @@ fun AchievementsScreen(
                             placeholder = "Search achievements...",
                         )
                     }
-                    items(filteredAchievements) { achievement ->
+                    items(filteredAchievements, key = { it.id }) { achievement ->
                         val pct = achievement.progress_pct?.toFloat()?.div(100f) ?: 0f
 
                         Card(

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -716,7 +716,7 @@ private fun ChatInputBar(
                             LazyColumn(
                                 modifier = Modifier.heightIn(max = 200.dp),
                             ) {
-                                items(filteredCommands) { cmd ->
+                                items(filteredCommands, key = { it }) { cmd ->
                                     val description =
                                         when (cmd) {
                                             "/help" -> stringResource(R.string.command_help_desc)

--- a/app/src/main/java/com/m57/hermescontrol/ui/common/SharedComponents.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/common/SharedComponents.kt
@@ -246,7 +246,7 @@ fun FilterChipRow(
             ),
         horizontalArrangement = Arrangement.spacedBy(spacing.sm),
     ) {
-        items(chips) { chip ->
+        items(chips, key = { it }) { chip ->
             FilterChip(
                 selected = chip == selectedChip,
                 onClick = { onChipSelected(chip) },

--- a/app/src/main/java/com/m57/hermescontrol/ui/cron/CronJobsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/cron/CronJobsScreen.kt
@@ -96,7 +96,7 @@ fun CronJobsScreen(
                     contentPadding = listContentPadding,
                     verticalArrangement = listItemSpacing,
                 ) {
-                    items(state.jobs) { job ->
+                    items(state.jobs, key = { it.id }) { job ->
                         Card(
                             modifier = Modifier.fillMaxWidth(),
                             colors =

--- a/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
@@ -156,7 +156,7 @@ fun KanbanScreen(
                                     contentPadding = PaddingValues(16.dp),
                                     horizontalArrangement = Arrangement.spacedBy(16.dp),
                                 ) {
-                                    items(state.columns) { column ->
+                                    items(state.columns, key = { it.name }) { column ->
                                         val colName = column.name
                                         val colTasks =
                                             filteredTasks.filter {
@@ -185,7 +185,7 @@ fun KanbanScreen(
                                                 modifier = Modifier.weight(1f),
                                                 verticalArrangement = Arrangement.spacedBy(8.dp),
                                             ) {
-                                                items(colTasks) { task ->
+                                                items(colTasks, key = { it.id }) { task ->
                                                     TaskCard(
                                                         task = task,
                                                         onMoveLeft =

--- a/app/src/main/java/com/m57/hermescontrol/ui/keys/KeysScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/keys/KeysScreen.kt
@@ -132,7 +132,7 @@ fun KeysScreen(
                                     placeholder = "Search keys...",
                                 )
                             }
-                            items(filteredEnvVars.toList()) { (key, config) ->
+                            items(filteredEnvVars.toList(), key = { it.first }) { (key, config) ->
                                 var isEditing by remember { mutableStateOf(false) }
                                 val revealedVal = state.revealedValues[key]
                                 val isRevealed = revealedVal != null

--- a/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
@@ -123,7 +123,7 @@ fun McpServersScreen(
                                     placeholder = "Search MCP servers...",
                                 )
                             }
-                            items(filteredServers) { server ->
+                            items(filteredServers, key = { it.name }) { server ->
                                 Card(
                                     modifier = Modifier.fillMaxWidth(),
                                     colors =

--- a/app/src/main/java/com/m57/hermescontrol/ui/model/ModelScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/ModelScreen.kt
@@ -141,7 +141,7 @@ fun ModelScreen(
                                     placeholder = "Search models...",
                                 )
                             }
-                            items(filteredProviders) { provider ->
+                            items(filteredProviders, key = { it.slug }) { provider ->
                                 val isExpanded = expandedProviderSlug == provider.slug
                                 val isCurrent = provider.is_current == true
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/pairing/PairingScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/pairing/PairingScreen.kt
@@ -128,7 +128,7 @@ fun PairingScreen(
                                     }
                                 }
 
-                                items(pending) { item ->
+                                items(pending, key = { "${it.platform}_${it.code ?: it.user_id}" }) { item ->
                                     Card(
                                         modifier = Modifier.fillMaxWidth(),
                                         colors =
@@ -208,7 +208,7 @@ fun PairingScreen(
                                     }
                                 }
                             } else {
-                                items(approved) { item ->
+                                items(approved, key = { "${it.platform}_${it.user_id}" }) { item ->
                                     Card(
                                         modifier = Modifier.fillMaxWidth(),
                                     ) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/plugins/PluginsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/plugins/PluginsScreen.kt
@@ -126,7 +126,7 @@ fun PluginsScreen(
                                     placeholder = "Search plugins...",
                                 )
                             }
-                            items(filteredPlugins) { plugin ->
+                            items(filteredPlugins, key = { it.name }) { plugin ->
                                 Card(modifier = Modifier.fillMaxWidth()) {
                                     Column(modifier = Modifier.padding(16.dp)) {
                                         Row(

--- a/app/src/main/java/com/m57/hermescontrol/ui/profiles/ProfilesScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/profiles/ProfilesScreen.kt
@@ -125,7 +125,7 @@ fun ProfilesScreen(
                             contentPadding = PaddingValues(16.dp),
                             verticalArrangement = Arrangement.spacedBy(12.dp),
                         ) {
-                            items(state.profiles) { profile ->
+                            items(state.profiles, key = { it.name }) { profile ->
                                 val isActive = profile.name == state.activeProfileName
                                 Card(
                                     modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
@@ -105,7 +105,7 @@ fun SessionsScreen(
                             placeholder = "Search sessions...",
                         )
                     }
-                    items(filteredSessions) { session ->
+                    items(filteredSessions, key = { it.id }) { session ->
                         Card(
                             modifier =
                                 Modifier

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -244,7 +244,7 @@ fun SkillsScreen(
                             }
                         }
                     } else {
-                        items(filtered) { skill ->
+                        items(filtered, key = { it.name }) { skill ->
                             Card(
                                 modifier = Modifier.fillMaxWidth(),
                                 colors =

--- a/app/src/main/java/com/m57/hermescontrol/ui/toolsets/ToolsetsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/toolsets/ToolsetsScreen.kt
@@ -140,7 +140,7 @@ fun ToolsetsScreen(
                                     placeholder = "Search toolsets...",
                                 )
                             }
-                            items(filteredToolsets) { toolset ->
+                            items(filteredToolsets, key = { it.name }) { toolset ->
                                 Card(
                                     modifier = Modifier.fillMaxWidth(),
                                     colors =

--- a/app/src/main/java/com/m57/hermescontrol/ui/webhooks/WebhooksScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/webhooks/WebhooksScreen.kt
@@ -199,7 +199,7 @@ fun WebhooksScreen(
                                     }
                                 }
                             } else {
-                                items(filteredSubscriptions) { sub ->
+                                items(filteredSubscriptions, key = { it.name }) { sub ->
                                     Card(
                                         modifier = Modifier.fillMaxWidth(),
                                     ) {


### PR DESCRIPTION
Added stable `key` parameters to `items(...)` and `itemsIndexed(...)` calls across 13 screens. This prevents Compose from treating all list mutations as full item replacements and eliminates unnecessary full list recompositions during state updates.

Modifications applied to:
- KeysScreen.kt, SharedComponents.kt, AchievementsScreen.kt, PluginsScreen.kt
- SessionsScreen.kt, CronJobsScreen.kt, McpServersScreen.kt, PairingScreen.kt
- ToolsetsScreen.kt, ChatScreen.kt, ModelScreen.kt, SkillsScreen.kt
- KanbanScreen.kt, ProfilesScreen.kt, WebhooksScreen.kt

Note: LogsScreen.kt was left without a key because logs are string lines that can be duplicated, and using `.hashCode()` would cause a "Key was already used" crash. Positional indexing is safer there.

Fixes #279

---
*PR created automatically by Jules for task [2368696559371582709](https://jules.google.com/task/2368696559371582709) started by @Hy4ri*