### PR TITLE
fix(#271): extract Gson instance in ChatViewModel

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -411,7 +411,7 @@ class ChatViewModel(
         var orphanToPersist: ChatMessage? = null
         val sessionId = _uiState.value.currentSessionId
 
-        val contentJson = event.data?.let { Gson().toJson(it) } ?: ""
+        val contentJson = event.data?.let { gson.toJson(it) } ?: ""
         val toolMessage =
             ChatMessage(
                 role = MessageRole.TOOL,
@@ -460,7 +460,7 @@ class ChatViewModel(
                         it.toolStatus == ToolStatus.RUNNING
                 }
             if (toolIdx >= 0) {
-                val contentJson = event.data?.let { Gson().toJson(it) } ?: ""
+                val contentJson = event.data?.let { gson.toJson(it) } ?: ""
                 val updated =
                     messages[toolIdx].copy(
                         toolStatus = ToolStatus.COMPLETED,
@@ -1141,5 +1141,9 @@ class ChatViewModel(
         super.onCleared()
         pendingCleanupJob?.cancel()
         wsClient.disconnect()
+    }
+
+    companion object {
+        private val gson = Gson()
     }
 }


### PR DESCRIPTION
Extracted the `Gson()` instantiation in `ChatViewModel.kt` to a companion object to avoid creating a new `Gson` instance on every `ToolStart` and `ToolComplete` event handler call. This change reduces garbage collection pressure by caching reflection setup, type adapters, and factories.

Impact:
- Reduces memory allocations and CPU cycles during multi-step tool chains and streaming.
- Safely maintains existing parsing behavior while addressing the `PERF-03` review finding.

Closes #271

---
*PR created automatically by Jules for task [8201429702154103882](https://jules.google.com/task/8201429702154103882) started by @Hy4ri*