### PR TITLE
Fix #266: Clear profile-slot token on 401 error

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/connect/ConnectViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/connect/ConnectViewModel.kt
@@ -188,6 +188,9 @@ class ConnectViewModel(private val app: Application) : ViewModel() {
                                 when (err.code) {
                                     401 -> {
                                         AuthManager.setToken(null)
+                                        if (AuthManager.getSelectedProfileId() != null) {
+                                            AuthManager.setProfileToken(AuthManager.getSelectedProfileId()!!, null)
+                                        }
                                         app.getString(R.string.connect_error_401)
                                     }
 

--- a/app/src/test/java/com/m57/hermescontrol/ui/connect/ConnectViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/connect/ConnectViewModelTest.kt
@@ -219,6 +219,35 @@ class ConnectViewModelTest {
             viewModel.connect()
             advanceUntilIdle()
 
+            verify { AuthManager.setToken(null) }
+
+            val state = viewModel.uiState.value
+            assertFalse(state.isConnecting)
+            assertFalse(state.connectionSuccess)
+            assertEquals("Invalid token (401 Unauthorized)", state.errorMessage)
+        }
+
+    @Test
+    fun testConnect_failure_unauthorized_clearsProfileToken() =
+        runTest {
+            every { AuthManager.getSelectedProfileId() } returns "prof-1"
+
+            val viewModel = ConnectViewModel(mockApp)
+            viewModel.onTokenChange("invalid-token")
+            viewModel.onHostChange("127.0.0.1")
+            viewModel.onPortChange("9119")
+
+            val mockResponse = mockk<Response<StatusResponse>>()
+            every { mockResponse.isSuccessful } returns false
+            every { mockResponse.code() } returns 401
+            coEvery { mockApiService.getStatus() } returns mockResponse
+
+            viewModel.connect()
+            advanceUntilIdle()
+
+            verify { AuthManager.setToken(null) }
+            verify { AuthManager.setProfileToken("prof-1", null) }
+
             val state = viewModel.uiState.value
             assertFalse(state.isConnecting)
             assertFalse(state.connectionSuccess)


### PR DESCRIPTION
This PR addresses issue #266 by ensuring that the profile-slot token is cleared when a 401 error occurs during the connection process.

**Changes:**
- `ConnectViewModel.kt`: Added logic to clear the selected profile token (if one exists) using `AuthManager.setProfileToken(..., null)` when a 401 error is received.
- `ConnectViewModelTest.kt`: Added unit tests to ensure that the global token and the profile token are correctly cleared on a 401 error.

**Impact:**
- Resolves security report SEC-13 where invalid tokens persisted in profile slots.
- No impact on valid connection flows. All existing tests pass.

---
*PR created automatically by Jules for task [10147111663401300773](https://jules.google.com/task/10147111663401300773) started by @Hy4ri*