### PR TITLE
Fix performance issue by caching typing effect settings in ChatUiState

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -174,6 +174,7 @@ fun ChatScreen(
                     androidx.lifecycle.Lifecycle.Event.ON_START -> {
                         NotificationHelper.setAppForeground(context, true)
                         NotificationHelper.stop(context)
+                        viewModel.refreshSettings()
                         viewModel.refreshCurrentSession()
                     }
 
@@ -441,13 +442,11 @@ fun ChatScreen(
 
                         val isLastMessage = index == state.messages.lastIndex
                         val isAssistant = message.role == MessageRole.ASSISTANT
-                        val typingEnabled = AuthManager.isTypingEffectEnabled()
-                        val typingDelayMs = AuthManager.getTypingEffectDelayMs()
 
-                        if (typingEnabled && isLastMessage && isAssistant && lastAnimatedMessageId != message.id) {
+                        if (state.typingEffectEnabled && isLastMessage && isAssistant && lastAnimatedMessageId != message.id) {
                             StreamingBubbleWithTypingEffect(
                                 streaming = message,
-                                typingDelayMs = typingDelayMs,
+                                typingDelayMs = state.typingEffectDelayMs,
                                 isDark = isDark,
                                 onAnimationComplete = {
                                     lastAnimatedMessageId = message.id
@@ -466,13 +465,10 @@ fun ChatScreen(
                     // Streaming message — rendered separately for O(1) updates
                     state.streamingMessage?.let { streaming ->
                         item(key = "streaming-${streaming.id}") {
-                            val typingEnabled = AuthManager.isTypingEffectEnabled()
-                            val typingDelayMs = AuthManager.getTypingEffectDelayMs()
-
-                            if (typingEnabled && streaming.isStreaming) {
+                            if (state.typingEffectEnabled && streaming.isStreaming) {
                                 StreamingBubbleWithTypingEffect(
                                     streaming = streaming,
-                                    typingDelayMs = typingDelayMs,
+                                    typingDelayMs = state.typingEffectDelayMs,
                                     isDark = isDark,
                                 )
                             } else {

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -104,7 +104,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.m57.hermescontrol.NavigationController
 import com.m57.hermescontrol.R
-import com.m57.hermescontrol.data.local.AuthManager
 import com.m57.hermescontrol.data.ws.ConnectionStatus
 import com.m57.hermescontrol.notification.NotificationHelper
 import com.m57.hermescontrol.theme.StatusRed
@@ -443,7 +442,11 @@ fun ChatScreen(
                         val isLastMessage = index == state.messages.lastIndex
                         val isAssistant = message.role == MessageRole.ASSISTANT
 
-                        if (state.typingEffectEnabled && isLastMessage && isAssistant && lastAnimatedMessageId != message.id) {
+                        if (state.typingEffectEnabled &&
+                            isLastMessage &&
+                            isAssistant &&
+                            lastAnimatedMessageId != message.id
+                        ) {
                             StreamingBubbleWithTypingEffect(
                                 streaming = message,
                                 typingDelayMs = state.typingEffectDelayMs,

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -57,6 +57,9 @@ data class ChatUiState(
     val searchQuery: String = "",
     val searchMatchIndices: List<Int> = emptyList(),
     val currentSearchMatchIndex: Int = -1,
+    // Cached settings
+    val typingEffectEnabled: Boolean = true,
+    val typingEffectDelayMs: Int = 30,
 ) {
     /** Convenience — derived from [connectionStatus]. */
     val isConnected: Boolean get() = connectionStatus == ConnectionStatus.CONNECTED
@@ -112,6 +115,7 @@ class ChatViewModel(
         )
 
     init {
+        refreshSettings()
         connectWebSocket()
         viewModelScope.launch {
             wsClient.events.collect { event ->
@@ -811,6 +815,15 @@ class ChatViewModel(
         val sessionId = _uiState.value.currentSessionId ?: return
         loadCachedMessages(sessionId)
         loadSessionMessages(sessionId)
+    }
+
+    fun refreshSettings() {
+        _uiState.update { state ->
+            state.copy(
+                typingEffectEnabled = AuthManager.isTypingEffectEnabled(),
+                typingEffectDelayMs = AuthManager.getTypingEffectDelayMs(),
+            )
+        }
     }
 
     fun switchSession(sessionId: String) {

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -64,6 +64,8 @@ class ChatViewModelTest {
         mockConnectionStatus.value = ConnectionStatus.DISCONNECTED
 
         every { AuthManager.getToken() } returns "test-token"
+        every { AuthManager.isTypingEffectEnabled() } returns true
+        every { AuthManager.getTypingEffectDelayMs() } returns 30
         every { HermesWsClient.events } returns mockEventsFlow
         every { HermesWsClient.connectionStatus } returns mockConnectionStatus
         every { HermesWsClient.connect() } returns Unit


### PR DESCRIPTION
Moves AuthManager calls for typing effect settings out of Jetpack Compose `LazyColumn` item lambdas to prevent severe frame drops during streaming (due to repeated EncryptedSharedPreferences decryption on the main thread). Settings are now cached in `ChatUiState` and refreshed in `ChatViewModel`.
#269
---
*PR created automatically by Jules for task [2818540619019066046](https://jules.google.com/task/2818540619019066046) started by @Hy4ri*