### PR TITLE
fix(#261): redact token from websocket connection log in debug mode

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
@@ -163,7 +163,8 @@ object HermesWsClient {
         val url = AuthManager.wsUrl()
         // B2 (Jun 18 2026, kanban t_8884db16): url contains the auth token
         // as a query param — never stream to logcat in release builds.
-        if (BuildConfig.DEBUG) Log.d(TAG, "Connecting to $url")
+        val safeUrl = url.replace(Regex("token=[^&]+"), "token=REDACTED")
+        if (BuildConfig.DEBUG) Log.d(TAG, "Connecting to $safeUrl")
 
         val request = Request.Builder().url(url).build()
         webSocket = okHttpClient.newWebSocket(request, WsListenerImpl())


### PR DESCRIPTION
Redacts the token query parameter from the URL before logging it to logcat in debug mode. This prevents sensitive token leakage on rooted devices or via adb logcat as requested in SEC-08.

#261
---
*PR created automatically by Jules for task [18184456101390899616](https://jules.google.com/task/18184456101390899616) started by @Hy4ri*