### PR TITLE
fix(#263): log parse error in getConnectionProfiles

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
@@ -103,6 +103,9 @@ object AuthManager {
                 >() {}.type
             gson.fromJson(json, type) ?: emptyList()
         } catch (e: Exception) {
+            if (com.m57.hermescontrol.BuildConfig.DEBUG) {
+                android.util.Log.w("AuthManager", "Failed to parse connection profiles", e)
+            }
             emptyList()
         }
     }


### PR DESCRIPTION
Adds a debug log to AuthManager.getConnectionProfiles when JSON parsing fails, instead of silently swallowing the exception and returning an empty list. This helps diagnose corrupted or malicious connection profile data without affecting production stability.

#263
---
*PR created automatically by Jules for task [5680696123998567003](https://jules.google.com/task/5680696123998567003) started by @Hy4ri*