### PR TITLE
fix: Ensure chat notifications are private on lock screen

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/notification/ChatNotificationService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/notification/ChatNotificationService.kt
@@ -113,6 +113,7 @@ class ChatNotificationService : Service() {
                 .setContentText(text)
                 .setStyle(NotificationCompat.BigTextStyle().bigText(text))
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
                 .setAutoCancel(true)
                 .setContentIntent(buildContentIntent(sessionId))
 


### PR DESCRIPTION
This PR addresses issue #262 by ensuring that chat notification previews are hidden on the lock screen. This resolves the reported security concern (SEC-09) where message content could leak to anyone viewing a locked device.

The fix involves setting the visibility of the notification built in `ChatNotificationService.showReplyNotification` to `NotificationCompat.VISIBILITY_PRIVATE`.

Local compilation and tests (`assembleDebug` and `testDebugUnitTest`) pass successfully.

---
*PR created automatically by Jules for task [6317215213059620063](https://jules.google.com/task/6317215213059620063) started by @Hy4ri*