### PR TITLE
Fix multi-profile token leakage fallback bug (#258)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
@@ -135,8 +135,7 @@ object AuthManager {
     fun getToken(): String? {
         val selectedId = getSelectedProfileId()
         if (selectedId != null) {
-            val token = getProfileToken(selectedId)
-            if (token != null) return token
+            return getProfileToken(selectedId)
         }
         return requirePrefs().getString(KEY_TOKEN, null)
     }

--- a/app/src/test/java/com/m57/hermescontrol/data/local/AuthManagerTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/local/AuthManagerTest.kt
@@ -139,11 +139,11 @@ class AuthManagerTest {
     }
 
     @Test
-    fun testGetToken_fallsBackToGlobalWhenProfileTokenMissing() {
+    fun testGetToken_returnsNullWhenProfileTokenMissing() {
         every { mockPrefs.getString("selected_profile_id", null) } returns "prof-1"
         every { mockPrefs.getString("token_prof-1", null) } returns null // no profile token
         every { mockPrefs.getString("auth_token", null) } returns "global-token"
-        assertEquals("global-token", AuthManager.getToken())
+        assertNull(AuthManager.getToken())
     }
 
     @Test
@@ -293,18 +293,18 @@ class AuthManagerTest {
     }
 
     @Test
-    fun testGetToken_fallsBackToGlobalWhenSelectedProfileLacksToken() {
-        // Profile A is selected but has no token → falls back to global
+    fun testGetToken_returnsNullWhenSelectedProfileLacksToken() {
+        // Profile A is selected but has no token → should return null, not global
         every { mockPrefs.getString("selected_profile_id", null) } returns "prof-a"
         every { mockPrefs.getString("token_prof-a", null) } returns null
         every { mockPrefs.getString("auth_token", null) } returns "shared-global-token"
 
-        assertEquals("shared-global-token", AuthManager.getToken())
+        assertNull(AuthManager.getToken())
 
-        // Switch to Profile B, which also has no token → same global fallback
+        // Switch to Profile B, which also has no token → should return null
         every { mockPrefs.getString("selected_profile_id", null) } returns "prof-b"
         every { mockPrefs.getString("token_prof-b", null) } returns null
-        assertEquals("shared-global-token", AuthManager.getToken())
+        assertNull(AuthManager.getToken())
     }
 
     @Test
@@ -314,11 +314,11 @@ class AuthManagerTest {
         every { mockPrefs.getString("token_prof-a", null) } returns "token-a"
         assertEquals("token-a", AuthManager.getToken())
 
-        // Profile B has no token, but global exists
+        // Profile B has no token, but global exists → should return null
         every { mockPrefs.getString("selected_profile_id", null) } returns "prof-b"
         every { mockPrefs.getString("token_prof-b", null) } returns null
         every { mockPrefs.getString("auth_token", null) } returns "fallback"
-        assertEquals("fallback", AuthManager.getToken())
+        assertNull(AuthManager.getToken())
 
         // Profile C has its own token too
         every { mockPrefs.getString("selected_profile_id", null) } returns "prof-c"


### PR DESCRIPTION
This PR addresses issue #258 by fixing a bug in `AuthManager.getToken()` where a profile without a token would incorrectly fall back to using the global token. This posed a security risk as it could lead to token leakage across different hosts/profiles. 

The fallback logic has been removed, ensuring that `getToken()` strictly returns `null` when a specific profile lacks its own credentials, enforcing proper re-authentication rather than incorrectly reusing another profile's token. Related unit tests have been updated and validated to reflect this change.

---
*PR created automatically by Jules for task [3962442505701511783](https://jules.google.com/task/3962442505701511783) started by @Hy4ri*