### PR TITLE
Fix data exposure via Android backup (SEC-04)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,8 @@
     <application
         android:name=".HermesControlApp"
         android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -6,8 +6,6 @@
    See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <exclude domain="database" path="hermes_control.db" />
+    <exclude domain="sharedpref" path="hermes_secure_prefs.xml" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -5,15 +5,11 @@
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="database" path="hermes_control.db" />
+        <exclude domain="sharedpref" path="hermes_secure_prefs.xml" />
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="database" path="hermes_control.db" />
+        <exclude domain="sharedpref" path="hermes_secure_prefs.xml" />
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
This PR fixes issue #257 by preventing sensitive application data from being extracted via Android's backup features.

It sets up the correct data extraction and full backup rules in the XML files to exclude `hermes_control.db` and `hermes_secure_prefs.xml` and applies these rules in the `AndroidManifest.xml`.

---
*PR created automatically by Jules for task [16766256261883479610](https://jules.google.com/task/16766256261883479610) started by @Hy4ri*