### PR TITLE
fix(#253): remove excessive top padding from screens

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/achievements/AchievementsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/achievements/AchievementsScreen.kt
@@ -65,17 +65,16 @@ fun AchievementsScreen(
         onOpenDrawer = onOpenDrawer,
         isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadAchievements() },
-    ) { paddingValues ->
+    ) {
         when {
             state.isLoading && state.achievements.isEmpty() -> {
-                LoadingState(modifier = Modifier.padding(paddingValues))
+                LoadingState()
             }
 
             state.errorMessage != null && state.achievements.isEmpty() -> {
                 ErrorState(
                     message = state.errorMessage ?: "",
                     onRetry = { viewModel.loadAchievements() },
-                    modifier = Modifier.padding(paddingValues),
                 )
             }
 
@@ -84,13 +83,12 @@ fun AchievementsScreen(
                     title = stringResource(R.string.achievements_empty_title),
                     subtitle = stringResource(R.string.achievements_empty_desc),
                     icon = Icons.Filled.Refresh,
-                    modifier = Modifier.padding(paddingValues),
                 )
             }
 
             else -> {
                 LazyColumn(
-                    modifier = Modifier.fillMaxSize().padding(paddingValues),
+                    modifier = Modifier.fillMaxSize(),
                     contentPadding = PaddingValues(16.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/channels/ChannelsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/channels/ChannelsScreen.kt
@@ -69,17 +69,16 @@ fun ChannelsScreen(
         onOpenDrawer = onOpenDrawer,
         isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadPlatforms() },
-    ) { paddingValues ->
+    ) {
         when {
             state.isLoading && state.platforms.isEmpty() -> {
-                LoadingState(modifier = Modifier.padding(paddingValues))
+                LoadingState()
             }
 
             state.errorMessage != null -> {
                 ErrorState(
                     message = state.errorMessage ?: "",
                     onRetry = { viewModel.loadPlatforms() },
-                    modifier = Modifier.padding(paddingValues),
                 )
             }
 
@@ -87,13 +86,12 @@ fun ChannelsScreen(
                 EmptyState(
                     title = stringResource(R.string.channels_empty_title),
                     subtitle = stringResource(R.string.channels_empty_desc),
-                    modifier = Modifier.padding(paddingValues),
                 )
             }
 
             else -> {
                 LazyColumn(
-                    modifier = Modifier.fillMaxSize().padding(paddingValues),
+                    modifier = Modifier.fillMaxSize(),
                     contentPadding = listContentPadding,
                     verticalArrangement = listItemSpacing,
                 ) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
@@ -85,17 +85,16 @@ fun KanbanScreen(
         onOpenDrawer = onOpenDrawer,
         isRefreshing = state.isLoading,
         onRefresh = { viewModel.loadBoards() },
-    ) { paddingValues ->
+    ) {
         when {
             state.isLoading && state.boards.isEmpty() -> {
-                LoadingState(modifier = Modifier.padding(paddingValues))
+                LoadingState()
             }
 
             state.errorMessage != null -> {
                 ErrorState(
                     message = state.errorMessage ?: "",
                     onRetry = { viewModel.loadBoards() },
-                    modifier = Modifier.padding(paddingValues),
                 )
             }
 
@@ -107,11 +106,10 @@ fun KanbanScreen(
                         Text(
                             text = state.errorMessage ?: "",
                             color = MaterialTheme.colorScheme.error,
-                            modifier = Modifier.padding(paddingValues),
                         )
                     } else {
                         Column(
-                            modifier = Modifier.fillMaxSize().padding(paddingValues),
+                            modifier = Modifier.fillMaxSize(),
                         ) {
                             SearchBar(
                                 query = query,


### PR DESCRIPTION
Fixes #253 by removing the redundant `modifier = Modifier.padding(paddingValues)` on `AchievementsScreen.kt`, `KanbanScreen.kt`, and `ChannelsScreen.kt`.

### Reason
`HermesScaffold` applies the `paddingValues` directly to a `Box` wrapping the lambda content:
```kotlin
Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
    content(paddingValues)
}
```
Applying `paddingValues` again on the inner screens leads to excessive top padding, which pushes the content down, wasting vertical space and throwing the layout off-balance, especially on smaller screens.

### Changes
* Removed the redundant `modifier = Modifier.padding(paddingValues)` in `LoadingState`, `ErrorState`, `EmptyState`, `LazyColumn` and other top-level container components in `AchievementsScreen`, `KanbanScreen` and `ChannelsScreen`.

### Impact
This properly aligns the content with standard Material Design padding guidelines (e.g., typically 16dp via `contentPadding`) across the application, correcting the excessive gap between the top bar and the content. It affects only the presentation logic on those specific screens and introduces no architectural or side-effect regressions.

---
*PR created automatically by Jules for task [12005376368168825541](https://jules.google.com/task/12005376368168825541) started by @Hy4ri*