### PR TITLE
fix(#206): read clarify.request question/choices from gateway

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/ws/EventParser.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/EventParser.kt
@@ -81,8 +81,14 @@ object EventParser {
             }
 
             "clarify.request" -> {
-                val text = payload?.get("text") as? String
-                val rawOptions = payload?.get("options")
+                // Gateway sends "question"/"choices" — fall back to "text"/"options" for any
+                // older client or test that still uses the legacy field names. (Issue #206)
+                val text =
+                    payload?.get("question") as? String
+                        ?: payload?.get("text") as? String
+                val rawOptions =
+                    payload?.get("choices")
+                        ?: payload?.get("options")
                 val clarifyId = payload?.get("clarify_id") as? String ?: payload?.get("request_id") as? String
 
                 @Suppress("UNCHECKED_CAST")

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -842,7 +842,7 @@ private fun ClarifyDialog(
     onOptionSelected: (String) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    var typedText by rememberSaveable(clarify.text) { mutableStateOf(clarify.text) }
+    var typedText by rememberSaveable(clarify.text) { mutableStateOf("") }
 
     AlertDialog(
         onDismissRequest = onDismiss,

--- a/app/src/test/java/com/m57/hermescontrol/data/ws/EventParserTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/ws/EventParserTest.kt
@@ -173,6 +173,31 @@ class EventParserTest {
         assertEquals(listOf("Yes", "No"), clarifyEvent.options)
     }
 
+    @Test
+    fun testParseClarifyRequest_withQuestionFields_parsesSuccessfully() {
+        val response =
+            WsResponse(
+                id = null,
+                result = null,
+                error = null,
+                method = "event",
+                params =
+                    mapOf(
+                        "type" to "clarify.request",
+                        "payload" to
+                            mapOf(
+                                "question" to "Which environment?",
+                                "choices" to listOf("staging", "production"),
+                            ),
+                    ),
+            )
+        val event = EventParser.parse(response)
+        assertTrue(event is WsEvent.ClarifyRequest)
+        val clarifyEvent = event as WsEvent.ClarifyRequest
+        assertEquals("Which environment?", clarifyEvent.text)
+        assertEquals(listOf("staging", "production"), clarifyEvent.options)
+    }
+
     // ── TEST-07: Untested subtypes ─────────────────────────────────────
 
     @Test

--- a/app/src/test/java/com/m57/hermescontrol/data/ws/EventParserTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/ws/EventParserTest.kt
@@ -176,7 +176,8 @@ class EventParserTest {
     @Test
     fun testParseClarifyRequest_withQuestionFields_parsesSuccessfully() {
         val response =
-            WsResponse(
+            JsonRpcResponse(
+                jsonrpc = "2.0",
                 id = null,
                 result = null,
                 error = null,


### PR DESCRIPTION
## Problem

The Hermes TUI gateway sends `clarify.request` WebSocket events with `"question"` and `"choices"` fields in the payload:

```python
"clarify.request", sid, {"question": q, "choices": c}
```

But `EventParser.kt` was reading `"text"` and `"options"` — so both resolved to `null` → `orEmpty()` → the dialog body collapsed to just the input box.

Users saw only the response field with no question text or options.

## Fix

`EventParser.kt` now reads `"question"`/`"choices"` first, falling back to `"text"`/`"options"` for backward compatibility.

## Testing

- Existing test (`text`/`options` legacy format) still passes.
- New test added for the `question`/`choices` format the gateway actually sends.

Closes #206