### PR TITLE
feat(#221): add Activate button to profile cards for switching profiles

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/profiles/ProfilesScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/profiles/ProfilesScreen.kt
@@ -209,6 +209,18 @@ fun ProfilesScreen(
 
                                         Spacer(modifier = Modifier.height(16.dp))
 
+                                        if (!isActive) {
+                                            Button(
+                                                onClick = { viewModel.selectActiveProfile(profile.name) },
+                                                modifier =
+                                                    Modifier
+                                                        .fillMaxWidth()
+                                                        .padding(bottom = 8.dp),
+                                            ) {
+                                                Text(stringResource(R.string.profiles_action_activate))
+                                            }
+                                        }
+
                                         Row(
                                             modifier = Modifier.fillMaxWidth(),
                                             horizontalArrangement = Arrangement.End,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -294,6 +294,7 @@
     <string name="profiles_empty_desc">Connection profiles from Hermes will appear here.</string>
     <string name="profiles_label_model">Model: %1$s</string>
     <string name="profiles_label_provider">Provider: %1$s</string>
+    <string name="profiles_action_activate">Activate</string>
     <string name="profiles_action_edit_soul">Edit Soul</string>
     <string name="profiles_action_set_model">Set Model</string>
     <string name="profiles_content_desc_active">Active Profile</string>


### PR DESCRIPTION
## What

Adds a prominent **Activate** button to inactive profile cards on the Profiles screen, making it obvious that tapping switches the active Hermes profile.

## Why

Closes #221. The card tap already switched profiles (via `onClick` → `selectActiveProfile`), but it wasn't visually discoverable — users had no way to know tapping a card would activate it. The Activate button makes this explicit.

## Changes

- **ProfilesScreen.kt** — Added a full-width `Button` labeled "Activate" that calls `viewModel.selectActiveProfile()`, shown only on inactive profile cards
- **strings.xml** — Added `profiles_action_activate` string resource

## Verification

- [x] ktlint passes
- [x] Card tap still switches profiles (backward compat)
- [x] Activate button only shows for inactive profiles
- [x] Active profile still shows checkmark icon