### PR TITLE
perf(#203): parallelize API calls in ModelViewModel for faster loading

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/model/ModelViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/ModelViewModel.kt
@@ -10,6 +10,7 @@ import com.m57.hermescontrol.data.remote.NetworkResult
 import com.m57.hermescontrol.data.remote.safeApiCall
 import com.m57.hermescontrol.ui.common.ToastHost
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -32,18 +33,22 @@ class ModelViewModel : ViewModel(), ToastHost {
     fun loadModelOptions() {
         _uiState.update { it.copy(isLoading = true, errorMessage = null) }
         viewModelScope.launch {
-            val responseResult =
-                withContext(Dispatchers.IO) {
+            val responseResultDeferred =
+                async(Dispatchers.IO) {
                     safeApiCall { ApiClient.hermesApi.getModelOptions() }
                 }
-            val activeProfileNameResResult =
-                withContext(Dispatchers.IO) {
+            val activeProfileNameResResultDeferred =
+                async(Dispatchers.IO) {
                     safeApiCall { ApiClient.hermesApi.getActiveProfile() }
                 }
-            val profilesResResult =
-                withContext(Dispatchers.IO) {
+            val profilesResResultDeferred =
+                async(Dispatchers.IO) {
                     safeApiCall { ApiClient.hermesApi.getProfiles() }
                 }
+
+            val responseResult = responseResultDeferred.await()
+            val activeProfileNameResResult = activeProfileNameResResultDeferred.await()
+            val profilesResResult = profilesResResultDeferred.await()
 
             when (responseResult) {
                 is NetworkResult.Success -> {


### PR DESCRIPTION
## What

Parallelizes the three API calls in `ModelViewModel.loadModelOptions()` so they run concurrently instead of sequentially.

## Why

Closes #203. The Model tab was making three sequential network requests (`getModelOptions`, `getActiveProfile`, `getProfiles`) — each waiting for the previous to finish. This adds up to sum-of-3 latency on every load/refresh.

## How

Replaced three `withContext(Dispatchers.IO)` blocks with `async(Dispatchers.IO)` + `.await()`. All three calls now fire in parallel; total load time drops from sum-of-3 to max-of-3 latencies.

```diff
-withContext(Dispatchers.IO) { getModelOptions() }
-withContext(Dispatchers.IO) { getActiveProfile() }
-withContext(Dispatchers.IO) { getProfiles() }
+async(Dispatchers.IO) { getModelOptions() }
+async(Dispatchers.IO) { getActiveProfile() }
+async(Dispatchers.IO) { getProfiles() }
+// then .await() all three
```

## Verification

- [x] ktlint passes
- [x] All three calls still complete before state is updated (same correctness guarantees)
- [x] `selectModel()` still calls `loadModelOptions()` which now returns faster
- [x] Zero behavioral change — just parallelism