### PR TITLE
chore(#376): add dependabot for Gradle and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## Description

Add Dependabot configuration to automatically keep dependencies up to date.

## What it tracks

| Ecosystem | Scope | Schedule |
|-----------|-------|----------|
| **Gradle** | `libs.versions.toml` + `build.gradle.kts` | Weekly |
| **GitHub Actions** | Workflow steps (`actions/*`) | Weekly |

## Behaviour

- Opens individual PRs per out-of-date dependency (up to 10 at a time)
- Labels every PR with `dependencies`
- Uses `chore:` commit prefix for clean Conventional Commits
- You review → CI runs → merge if green

Closes #376 (remaining item)