### PR TITLE
fix(#374): prevent typing effect replay on finalized messages (blink fix)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -1102,7 +1102,7 @@ private fun ChatMessageList(
             val isLastMessage = index == messages.lastIndex
             val isAssistant = message.role == MessageRole.ASSISTANT
 
-            if (typingEffectEnabled && isLastMessage && isAssistant &&
+            if (typingEffectEnabled && isLastMessage && isAssistant && message.isStreaming &&
                 lastAnimatedMessageId != message.id
             ) {
                 StreamingBubbleWithTypingEffect(


### PR DESCRIPTION
## Description

Fixes #374

**Root cause**: When `MessageComplete` fires, the reducer atomically moves the streaming message into the `messages` list and clears `streamingMessage`. The messages list's typing effect condition (`lastAnimatedMessageId != message.id`) didn't account for the fact that **this message was already rendered** with a typing effect in the streaming slot. Since the streaming slot's `StreamingBubbleWithTypingEffect` never updates `lastAnimatedMessageId` (no `onAnimationComplete` callback passed there), the newly arrived finalized message triggers the typing effect **from scratch** — replaying words one by one on already-complete content. That's the blink or double-loading effect.

**Fix**: Added `message.isStreaming` to the messages-list typing effect condition (line 1105). Messages finalized via `MessageComplete`/ `MessageDone` always have `isStreaming = false`, so they skip the replay. The streaming slot's `StreamingBubbleWithTypingEffect` continues to handle the animation during active streaming — no regression there.

**Change**: 1 line in `ChatScreen.kt`

**Verification**:
- [x] ktlint pass
- [ ] CI pipeline run