### PR TITLE
feat: add Neon Noir theme preset

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/theme/Theme.kt
+++ b/app/src/main/java/com/m57/hermescontrol/theme/Theme.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.platform.LocalContext
 
 enum class ThemePreference { SYSTEM, LIGHT, DARK }
 
-enum class ThemePreset { DEFAULT, MONOCHROME, GRUVBOX, CATPPUCCIN, AMOLED }
+enum class ThemePreset { DEFAULT, MONOCHROME, GRUVBOX, CATPPUCCIN, AMOLED, NEON_NOIR }
 
 enum class BottomNavDisplayMode { ICON_AND_TEXT, ICON_ONLY, TEXT_ONLY }
 
@@ -226,6 +226,76 @@ private val AmoledDarkColorScheme =
         outline = Color(0xFF3A3A4A),
     )
 
+private val NeonNoirDarkColorScheme =
+    darkColorScheme(
+        primary = Color(0xFFFF6BF4),
+        onPrimary = Color(0xFF1A001A),
+        primaryContainer = Color(0xFF3A003A),
+        onPrimaryContainer = Color(0xFFFFCCF2),
+        secondary = Color(0xFFA78BFA),
+        onSecondary = Color(0xFF0F0B1A),
+        secondaryContainer = Color(0xFF2B1F59),
+        onSecondaryContainer = Color(0xFFD9CCFF),
+        tertiary = Color(0xFF60F0FF),
+        onTertiary = Color(0xFF003B40),
+        tertiaryContainer = Color(0xFF004F59),
+        onTertiaryContainer = Color(0xFFBFFAFF),
+        background = Color(0xFF0F0B1A),
+        onBackground = Color(0xFFE8E0F0),
+        surface = Color(0xFF1A1530),
+        onSurface = Color(0xFFE8E0F0),
+        surfaceVariant = Color(0xFF2B2540),
+        onSurfaceVariant = Color(0xFF9A90B0),
+        surfaceTint = Color(0xFFFF6BF4),
+        surfaceContainer = Color(0xFF1A1530),
+        surfaceContainerHigh = Color(0xFF252040),
+        surfaceContainerHighest = Color(0xFF2F2A50),
+        inverseSurface = Color(0xFFE8E0F0),
+        inverseOnSurface = Color(0xFF0F0B1A),
+        error = Color(0xFFFF3D68),
+        onError = Color.White,
+        errorContainer = Color(0xFF3A0A14),
+        onErrorContainer = Color(0xFFFFB3C0),
+        outline = Color(0xFF3A3060),
+        outlineVariant = Color(0xFF2E2545),
+        scrim = Color(0xFF000000),
+    )
+
+private val NeonNoirLightColorScheme =
+    lightColorScheme(
+        primary = Color(0xFFC440A8),
+        onPrimary = Color.White,
+        primaryContainer = Color(0xFFFFD9F2),
+        onPrimaryContainer = Color(0xFF3A003A),
+        secondary = Color(0xFF7C4DFF),
+        onSecondary = Color.White,
+        secondaryContainer = Color(0xFFEDE0FF),
+        onSecondaryContainer = Color(0xFF1E0066),
+        tertiary = Color(0xFF0098A6),
+        onTertiary = Color.White,
+        tertiaryContainer = Color(0xFFBFFAFF),
+        onTertiaryContainer = Color(0xFF003B40),
+        background = Color(0xFFF5F0FA),
+        onBackground = Color(0xFF0F0B1A),
+        surface = Color.White,
+        onSurface = Color(0xFF0F0B1A),
+        surfaceVariant = Color(0xFFEDE6F5),
+        onSurfaceVariant = Color(0xFF7A7090),
+        surfaceTint = Color(0xFFC440A8),
+        surfaceContainer = Color(0xFFFDF8FF),
+        surfaceContainerHigh = Color(0xFFF0EDF5),
+        surfaceContainerHighest = Color(0xFFE6E0ED),
+        inverseSurface = Color(0xFF0F0B1A),
+        inverseOnSurface = Color(0xFFE8E0F0),
+        error = Color(0xFFB3261E),
+        onError = Color.White,
+        errorContainer = Color(0xFFF9DEDC),
+        onErrorContainer = Color(0xFF410E0B),
+        outline = Color(0xFFBFB8CC),
+        outlineVariant = Color(0xFFD9D2E3),
+        scrim = Color(0xFF000000),
+    )
+
 @Composable
 fun HermesControlTheme(
     themePreference: ThemePreference = LocalThemePreference.current,
@@ -259,6 +329,7 @@ fun HermesControlTheme(
                     ThemePreset.GRUVBOX -> if (darkTheme) GruvboxDarkColorScheme else GruvboxLightColorScheme
                     ThemePreset.CATPPUCCIN -> if (darkTheme) CatppuccinDarkColorScheme else CatppuccinLightColorScheme
                     ThemePreset.AMOLED -> if (darkTheme) AmoledDarkColorScheme else HermesLightColorScheme
+                    ThemePreset.NEON_NOIR -> if (darkTheme) NeonNoirDarkColorScheme else NeonNoirLightColorScheme
                 }
             }
         }
@@ -314,6 +385,32 @@ fun HermesControlTheme(
                     errorContainer = Color(0xFFE6E9EF),
                     info = Color(0xFF1E66F5),
                     infoContainer = Color(0xFFE6E9EF),
+                )
+            }
+
+            themePreset == ThemePreset.NEON_NOIR && darkTheme -> {
+                HermesStatusColors(
+                    success = Color(0xFF6FEA8B),
+                    successContainer = Color(0xFF0A3A14),
+                    warning = Color(0xFFFFB347),
+                    warningContainer = Color(0xFF3A2000),
+                    error = Color(0xFFFF3D68),
+                    errorContainer = Color(0xFF3A0A14),
+                    info = Color(0xFF60F0FF),
+                    infoContainer = Color(0xFF003B40),
+                )
+            }
+
+            themePreset == ThemePreset.NEON_NOIR && !darkTheme -> {
+                HermesStatusColors(
+                    success = Color(0xFF1B873A),
+                    successContainer = Color(0xFFD7F5E0),
+                    warning = Color(0xFFB87800),
+                    warningContainer = Color(0xFFFFEAB3),
+                    error = Color(0xFFB3261E),
+                    errorContainer = Color(0xFFF9DEDC),
+                    info = Color(0xFF2E6FBD),
+                    infoContainer = Color(0xFFD4E7FF),
                 )
             }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
@@ -862,6 +862,7 @@ private fun AppearanceSection(
                         ThemePreset.GRUVBOX -> stringResource(R.string.theme_preset_gruvbox)
                         ThemePreset.CATPPUCCIN -> stringResource(R.string.theme_preset_catppuccin)
                         ThemePreset.AMOLED -> stringResource(R.string.theme_preset_amoled)
+                        ThemePreset.NEON_NOIR -> stringResource(R.string.theme_preset_neon_noir)
                     },
                 )
             }
@@ -894,6 +895,10 @@ private fun AppearanceSection(
                                     ThemePreset.AMOLED ->
                                         stringResource(
                                             R.string.theme_preset_amoled,
+                                        )
+                                    ThemePreset.NEON_NOIR ->
+                                        stringResource(
+                                            R.string.theme_preset_neon_noir,
                                         )
                                 },
                             )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,6 +172,7 @@
     <string name="theme_preset_gruvbox">Gruvbox</string>
     <string name="theme_preset_catppuccin">Catppuccin</string>
     <string name="theme_preset_amoled">AMOLED Black (Dark only)</string>
+    <string name="theme_preset_neon_noir">Neon Noir</string>
 
     <!-- Connect Screen -->
     <string name="connect_selected_profile">Profile: %1$s</string>


### PR DESCRIPTION
## Summary

Adds **Neon Noir** — a cyberpunk-pink theme preset to Hermes Mobile 🌟

### Changes

- **Theme.kt** — Added `NEON_NOIR` to `ThemePreset` enum, full dark + light color schemes, and matching status colors
- **SettingsScreen.kt** — Display label + dropdown menu item for the new preset
- **strings.xml** — New string resource `theme_preset_neon_noir`

### Colors (Dark Mode)

| Role | Color | Hex |
|------|-------|-----|
| Primary | Slay Pink | `#FF6BF4` |
| Secondary | Purple Haze | `#A78BFA` |
| Tertiary | Cyan Dream | `#60F0FF` |
| Background | Deep Void | `#0F0B1A` |
| Surface | Midnight Velvet | `#1A1530` |
| Success | Goblin Green | `#6FEA8B` |
| Error | Oops Red | `#FF3D68` |
| Warning | Warning Mango | `#FFB347` |

### Light Mode

A softer but still vibrant version with `#C440A8` primary on `#F5F0FA` background — because we stan inclusivity.

### Verification

- [x] ktlint --format passes on all modified files
- [ ] CI verification pending (no local Android SDK)
- [x] Theme selector dropdown includes Neon Noir
- [x] Both dark and light modes have contrast-verified color pairs