### PR TITLE
feat(#216): dynamic command autocomplete from server catalog, remove stop button

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -397,7 +397,9 @@ private fun ChatInputBar(
             Column {
                 // Build command list from dynamic catalog (pairs = [name, description])
                 val allCommands = commandCatalog.pairs.associate { (name, desc) -> name to desc }
-                val commandNames = allCommands.keys.toList()
+                // Commands hidden from suggestion menu (still work when manually typed)
+                val hiddenSlashDisplay = setOf("/stop", "/interrupt")
+                val commandNames = allCommands.keys.filter { it !in hiddenSlashDisplay }
 
                 androidx.compose.animation.AnimatedVisibility(
                     visible = inputText.startsWith("/") && !inputText.contains(" "),

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -54,14 +54,12 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilledTonalButton
-import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -106,6 +104,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.m57.hermescontrol.NavigationController
 import com.m57.hermescontrol.R
+import com.m57.hermescontrol.data.ws.CommandCatalog
 import com.m57.hermescontrol.data.ws.ConnectionStatus
 import com.m57.hermescontrol.notification.NotificationHelper
 import com.m57.hermescontrol.theme.StatusRed
@@ -294,9 +293,9 @@ fun ChatScreen(
                         }
                     }
                 },
-                onInterrupt = viewModel::interruptSession,
                 isAgentTyping = state.isAgentTyping,
                 isConnected = state.isConnected,
+                commandCatalog = state.commandCatalog,
             )
         }
     }
@@ -365,9 +364,9 @@ private fun ChatInputBar(
     inputText: String,
     onInputChange: (String) -> Unit,
     onSend: () -> Unit,
-    onInterrupt: () -> Unit,
     isAgentTyping: Boolean,
     isConnected: Boolean,
+    commandCatalog: CommandCatalog,
 ) {
     // Allow sending slash commands even while agent is typing
     val isSlashCommand = inputText.startsWith("/")
@@ -396,23 +395,16 @@ private fun ChatInputBar(
             elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
         ) {
             Column {
-                val commands =
-                    listOf(
-                        "/help",
-                        "/status",
-                        "/sessions",
-                        "/stats",
-                        "/system",
-                        "/new",
-                        "/stop",
-                        "/interrupt",
-                    )
+                // Build command list from dynamic catalog (pairs = [name, description])
+                val allCommands = commandCatalog.pairs.associate { (name, desc) -> name to desc }
+                val commandNames = allCommands.keys.toList()
+
                 androidx.compose.animation.AnimatedVisibility(
                     visible = inputText.startsWith("/") && !inputText.contains(" "),
                     enter = androidx.compose.animation.fadeIn() + androidx.compose.animation.expandVertically(),
                     exit = androidx.compose.animation.fadeOut() + androidx.compose.animation.shrinkVertically(),
                 ) {
-                    val filteredCommands = commands.filter { it.startsWith(inputText, ignoreCase = true) }
+                    val filteredCommands = commandNames.filter { it.startsWith(inputText, ignoreCase = true) }
                     if (filteredCommands.isNotEmpty()) {
                         androidx.compose.material3.Surface(
                             modifier =
@@ -431,18 +423,7 @@ private fun ChatInputBar(
                                 modifier = Modifier.heightIn(max = 200.dp),
                             ) {
                                 items(filteredCommands, key = { it }) { cmd ->
-                                    val description =
-                                        when (cmd) {
-                                            "/help" -> stringResource(R.string.command_help_desc)
-                                            "/status" -> stringResource(R.string.command_status_desc)
-                                            "/sessions" -> stringResource(R.string.command_sessions_desc)
-                                            "/stats" -> stringResource(R.string.command_stats_desc)
-                                            "/system" -> stringResource(R.string.command_system_desc)
-                                            "/new" -> stringResource(R.string.command_new_desc)
-                                            "/stop" -> stringResource(R.string.command_stop_desc)
-                                            "/interrupt" -> stringResource(R.string.command_stop_desc)
-                                            else -> ""
-                                        }
+                                    val description = allCommands[cmd] ?: ""
                                     DropdownMenuItem(
                                         text = {
                                             Row(
@@ -526,26 +507,6 @@ private fun ChatInputBar(
                             imageVector = Icons.AutoMirrored.Filled.Send,
                             contentDescription = stringResource(R.string.chat_send_desc),
                         )
-                    }
-
-                    // Compact stop icon — visible only while agent is streaming
-                    if (isAgentTyping) {
-                        Spacer(modifier = Modifier.width(4.dp))
-                        FilledTonalIconButton(
-                            onClick = onInterrupt,
-                            modifier =
-                                Modifier
-                                    .size(32.dp)
-                                    .testTag("interrupt_button"),
-                            shape = CircleShape,
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.Stop,
-                                contentDescription = stringResource(R.string.content_desc_interrupt),
-                                modifier = Modifier.size(18.dp),
-                                tint = MaterialTheme.colorScheme.error,
-                            )
-                        }
                     }
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,16 +91,8 @@
     <string name="chat_tool_fallback">Tool</string>
     <string name="chat_tool_show_raw">Show Raw JSON</string>
     <string name="chat_tool_show_parsed">Show Parsed Output</string>
-    <string name="command_help_desc">Show help menu</string>
-    <string name="command_status_desc">Check gateway and platform status</string>
-    <string name="command_sessions_desc">List all chat sessions</string>
-    <string name="command_stats_desc">Check system resource usage (stats)</string>
-    <string name="command_system_desc">Check system resource usage (system)</string>
-    <string name="command_new_desc">Create a new chat session</string>
-    <string name="command_stop_desc">Interrupt the active run</string>
     <string name="content_desc_new_chat">New Chat</string>
     <string name="content_desc_scroll_to_bottom">Scroll to bottom</string>
-    <string name="content_desc_interrupt">Interrupt</string>
     <string name="content_desc_copy">Copy</string>
     <string name="content_desc_edit">Edit</string>
 


### PR DESCRIPTION
## Summary

This PR finishes the remaining work from PR #395 for issue #216 — the command system was added but:

1. **The `/` menu autocomplete was still hardcoded** — only 8 commands (`/help`, `/status`, `/sessions`, `/stats`, `/system`, `/new`, `/stop`, `/interrupt`), no skills or server-driven commands shown.
2. **The Stop button still existed** — a physical `FilledTonalIconButton` interrupt button next to send.
3. **`/stop` and `/interrupt` still showed in slash suggestions** — misleading since there's no physical stop button anymore.

## Changes

### Dynamic Command Autocomplete (`ChatInputBar`)

- Replaced the hardcoded `val commands = listOf(…)` with a dynamic list derived from `commandCatalog.pairs` (the server's `commands.catalog` RPC response)
- Descriptions now come from the catalog instead of a `when` block that mapped 8 known commands
- **All commands** from the server are shown, including skills and aliases — no more hardcoded subset

### Remove Stop Button

- Deleted the `FilledTonalIconButton` stop icon that appeared when `isAgentTyping = true`
- Removed the `onInterrupt` callback from `ChatInputBar` (users use `/stop` or `/interrupt` as slash commands instead)
- Removed unused imports: `Icons.Filled.Stop`, `FilledTonalIconButton`, `content_desc_interrupt` string resource

### Hide `/stop` and `/interrupt` from Suggestions

- Added `hiddenSlashDisplay` filter so these commands don't appear in the autocomplete popup (they still work when manually typed via `SlashCommandDispatcher`)
- Removed 7 stale `command_*_desc` string resources (`command_help_desc`, `command_status_desc`, `command_sessions_desc`, `command_stats_desc`, `command_system_desc`, `command_new_desc`, `command_stop_desc`) — replaced by server catalog descriptions
- Removed unused `content_desc_interrupt` string

## Files Changed

| File | Changes |
|---|---|
| `ChatScreen.kt` | Dynamic catalog, remove stop button, filter stop/interrupt from suggestions |
| `strings.xml` | Removed 8 unused string resources |

## Testing

- `./ktlint --format` passes cleanly ✓
- No local Android SDK — CI will verify compilation and unit tests

Closes #216