### PR TITLE
fix(#364): filter models at model level in search, not provider level

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/model/ModelScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/ModelScreen.kt
@@ -190,14 +190,22 @@ fun ModelScreen(
                                         )
 
                                         val models = provider.models.orEmpty()
-                                        if (models.isEmpty()) {
+                                        val filteredModels =
+                                            if (query.isBlank()) {
+                                                models
+                                            } else {
+                                                models.filter {
+                                                    it.contains(query, ignoreCase = true)
+                                                }
+                                            }
+                                        if (filteredModels.isEmpty()) {
                                             Text(
                                                 text = stringResource(R.string.model_no_models),
                                                 style = MaterialTheme.typography.bodyMedium,
                                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                             )
                                         } else {
-                                            models.forEach { model ->
+                                            filteredModels.forEach { model ->
                                                 val isActive =
                                                     state.activeProfile?.provider == provider.slug &&
                                                         state.activeProfile?.model == model


### PR DESCRIPTION
## What

Changes the model search in the Model tab to filter at the **model level** instead of the provider level.

**Before:** Searching for a model name showed entire providers (all their models) if any model matched — noisy and hard to scan.

**After:** When a search query is active, each expanded provider only shows the matching models. Providers with zero matches are still hidden entirely.

## How

In `ModelScreen.kt`, added a `filteredModels` derived list between the raw `models` list and the `forEach` rendering loop. When `query` is non-blank, only models containing the query text are shown:

```kotlin
val filteredModels =
    if (query.isBlank()) models
    else models.filter { it.contains(query, ignoreCase = true) }
```

## Example

Searching \gpt-4\ now shows:
- **ProviderA** → [gpt-4-turbo, gpt-4o]  ← only matched models
- **ProviderB** → [gpt-4]                 ← only matched models
- **ProviderC** → (hidden — no match)

Closes #364