### PR TITLE
fix(#366): skip redundant REST call on tab switch-back

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -773,6 +773,11 @@ class ChatViewModel(
     fun refreshCurrentSession() {
         val sessionId = _uiState.value.currentSessionId ?: return
         loadCachedMessages(sessionId)
+        // Skip the REST call if we already have messages — the WebSocket keeps
+        // the UI current. The REST endpoint can 404 on tab switch-back when the
+        // WS session ID doesn't round-trip through the resolver (issue #366),
+        // showing a misleading error banner while the connection is fine.
+        if (_uiState.value.messages.isNotEmpty()) return
         loadSessionMessages(sessionId)
     }
 


### PR DESCRIPTION
## Description

Prevents a misleading 404 error banner that briefly appears when switching back to the Chat tab after visiting another tab.

## Root Cause

The `DisposableEffect` lifecycle observer in `ChatLifecycleEffects` fires `ON_START` retroactively every time the ChatScreen composable re-enters composition (tab switch-back), because the Activity is already in RESUMED state. This calls `refreshCurrentSession()` → `loadSessionMessages()` → REST `GET /api/sessions/{id}/messages`, which can return 404 when the WS session ID doesn't round-trip through the REST resolver.

## Fix

Skip the REST call in `refreshCurrentSession()` if we already have messages loaded. The WebSocket keeps the UI current in real-time, so the REST call is only needed on initial session load. Cached messages from Room load instantly regardless.

## Related

Closes #366