### PR TITLE
feat: rename app from 'Hermes Control' to 'Hermes Mobile'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,14 +115,14 @@ jobs:
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
         run: |
-          echo "$KEYSTORE_BASE64" | base64 -d > hermes-control-release.keystore.jks
-          ls -lh hermes-control-release.keystore.jks
+          echo "$KEYSTORE_BASE64" | base64 -d > hermes-mobile-release.keystore.jks
+          ls -lh hermes-mobile-release.keystore.jks
 
       - name: Build Release APK
         env:
           VERSION_NAME: ${{ steps.version.outputs.version }}
           VERSION_CODE: ${{ steps.version.outputs.code }}
-          KEYSTORE_PATH: ${{ github.workspace }}/hermes-control-release.keystore.jks
+          KEYSTORE_PATH: ${{ github.workspace }}/hermes-mobile-release.keystore.jks
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
@@ -135,13 +135,13 @@ jobs:
         run: |
           mkdir -p release
           cp app/build/outputs/apk/release/app-release.apk \
-            release/hermes-control-${{ steps.version.outputs.tag }}.apk
+            release/hermes-mobile-${{ steps.version.outputs.tag }}.apk
           ls -lh release/
 
       - name: Upload Release APK Artifact
         uses: actions/upload-artifact@v7
         with:
-          name: hermes-control-release
+          name: hermes-mobile-release
           path: release/*.apk
           retention-days: 90
 
@@ -149,7 +149,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
-          name: Hermes Control ${{ steps.version.outputs.tag }}
+          name: Hermes Mobile ${{ steps.version.outputs.tag }}
           generate_release_notes: true
           files: release/*.apk
           prerelease: false

--- a/app/src/main/java/com/m57/hermescontrol/theme/Color.kt
+++ b/app/src/main/java/com/m57/hermescontrol/theme/Color.kt
@@ -2,7 +2,7 @@ package com.m57.hermescontrol.theme
 
 import androidx.compose.ui.graphics.Color
 
-// Hermes Control brand palette — v3 (Material You rewrite).
+// Hermes Mobile brand palette — v3 (Material You rewrite).
 //
 // On Android 12+ (API 31+) the app uses dynamic colour derived from the user's
 // wallpaper — this palette is NOT used for primary/surface roles on those

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">HermesControl</string>
+    <string name="app_name">HermesMobile</string>
 
     <!-- Chat -->
     <string name="chat_send_desc">Send</string>
@@ -132,7 +132,7 @@
     <string name="settings_save_success">✅ Settings saved</string>
     <string name="settings_action_test_connection">Test Connection</string>
     <string name="settings_sec_about">About</string>
-    <string name="settings_about_app_name">⚡ Hermes Control</string>
+    <string name="settings_about_app_name">⚡ Hermes Mobile</string>
     <string name="settings_about_version">Version</string>
     <string name="settings_about_build">Build</string>
     <string name="settings_about_debug">Debug</string>
@@ -393,7 +393,7 @@
     <string name="auth_login_success">Connected!</string>
 
     <!-- Landing Screen -->
-    <string name="landing_title">Hermes Control</string>
+    <string name="landing_title">Hermes Mobile</string>
     <string name="landing_subtitle">Control panel for Hermes Agent</string>
     <string name="landing_action_auth_login">Auth Login</string>
     <string name="landing_action_pairing_login">Pairing Login</string>


### PR DESCRIPTION
## Description

Renames the app's display name from **Hermes Control** → **Hermes Mobile** across all user-facing strings.

## Changes

| File | Change |
|------|--------|
| `res/values/strings.xml` | `app_name`: `HermesControl` → `HermesMobile` |
| `res/values/strings.xml` | `settings_about_app_name`: `⚡ Hermes Control` → `⚡ Hermes Mobile` |
| `res/values/strings.xml` | `landing_title`: `Hermes Control` → `Hermes Mobile` |
| `theme/Color.kt` | Comment updated to match new name |

## Not changed

- **Package name** (`com.m57.hermescontrol`) — changing it would create a new Play Store listing and break OAuth redirects
- `AndroidManifest.xml` — already references `@string/app_name` so it picks up the change automatically

## Screenshots

No visual changes expected beyond what the name says — launcher icon label, landing screen title, and About section will now say "Hermes Mobile".