### PR TITLE
feat: publish version.txt alongside APK for F-Droid version extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,14 +131,19 @@ jobs:
             -PversionName="$VERSION_NAME" \
             -PversionCode="$VERSION_CODE"
 
-      - name: Rename APK
+      - name: Rename APK and generate version file
         run: |
           mkdir -p release
           cp app/build/outputs/apk/release/app-release.apk \
             release/hermes-mobile-${{ steps.version.outputs.tag }}.apk
+          # Write version.txt for F-Droid to extract version info
+          cat > release/version.txt <<EOF
+          versionName=${{ steps.version.outputs.version }}
+          versionCode=${{ steps.version.outputs.code }}
+          EOF
           ls -lh release/
 
-      - name: Upload Release APK Artifact
+      - name: Upload Release Artifacts
         uses: actions/upload-artifact@v7
         with:
           name: hermes-mobile-release
@@ -151,7 +156,9 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Hermes Mobile ${{ steps.version.outputs.tag }}
           generate_release_notes: true
-          files: release/*.apk
+          files: |
+            release/hermes-mobile-${{ steps.version.outputs.tag }}.apk
+            release/version.txt
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Addresses [linsui's review comment](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/41486#note_3500940953) on the F-Droid MR — publishes a `version.txt` alongside the APK in GitHub releases so F-Droid can extract `versionName` and `versionCode`.

**Changes:**
- Generate `version.txt` with `versionName` and `versionCode` in the release step
- Explicit files list in `action-gh-release` including both the APK and `version.txt`
- Rename step updated to reflect both outputs