### PR TITLE
fix(#424): login screen buttons unresponsive after logout

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/Navigation.kt
+++ b/app/src/main/java/com/m57/hermescontrol/Navigation.kt
@@ -111,13 +111,7 @@ fun MainNavigation(sessionId: String? = null) {
     val hasToken = !token.isNullOrBlank()
     val startScreen: NavKey = if (hasToken) ChatScreen else LandingScreen
 
-    val backStack = remember { NavBackStack(startScreen) }
-    LaunchedEffect(startScreen) {
-        if (backStack.lastOrNull() != startScreen) {
-            backStack.clear()
-            backStack.add(startScreen)
-        }
-    }
+    val backStack = remember(startScreen) { NavBackStack(startScreen) }
     NavigationController.backStack = backStack
 
     val currentScreen = backStack.lastOrNull() ?: startScreen


### PR DESCRIPTION
## Problem

After logging out (or any path that clears the auth token), navigating back to the login screen shows the UI but buttons don't respond to taps. This happens because:

- `Navigation.kt` used a `LaunchedEffect(startScreen)` that mutated the same `NavBackStack` by calling `clear()` + `add()`
- Navigation3's internal state doesn't handle this mutation cleanly, causing duplicate screen entries that compete for touch events

## Fix

Replace the `LaunchedEffect` mutation pattern with `remember(startScreen)` keyed recreation:

```kotlin
// Before: temp same NavBackStack object
val backStack = remember { NavBackStack(startScreen) }
LaunchedEffect(startScreen) {
    if (backStack.lastOrNull() != startScreen) {
        backStack.clear()
        backStack.add(startScreen)
    }
}

// After: fresh NavBackStack per startScreen value
val backStack = remember(startScreen) { NavBackStack(startScreen) }
```

When `startScreen` changes (e.g. `ChatScreen` → `LandingScreen` on logout), Compose creates a brand new, clean `NavBackStack` — no stale entries, no mutation, no touch-event conflicts.

## Testing

- `./ktlint` — clean ✅

Closes #424