### PR TITLE
fix(#425): live log updates + auto-scroll

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/logs/LogsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/logs/LogsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -123,6 +124,12 @@ fun LogsScreen(
 
     LaunchedEffect(Unit) {
         viewModel.loadLogs()
+    }
+
+    // Auto-refresh logs via polling while the screen is visible
+    DisposableEffect(Unit) {
+        viewModel.startAutoRefresh()
+        onDispose { viewModel.stopAutoRefresh() }
     }
 
     ToastEffect(toastMessage = state.toastMessage, onClearToast = viewModel::clearToast)

--- a/app/src/main/java/com/m57/hermescontrol/ui/logs/LogsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/logs/LogsScreen.kt
@@ -130,7 +130,7 @@ fun LogsScreen(
     // Auto-scroll to bottom when new logs arrive (unless paused)
     LaunchedEffect(filteredLogs.size, pauseScroll) {
         if (!pauseScroll && filteredLogs.isNotEmpty()) {
-            listState.animateScrollToItem(filteredLogs.size)
+            listState.scrollToItem(Int.MAX_VALUE)
         }
     }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/logs/LogsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/logs/LogsViewModel.kt
@@ -5,10 +5,14 @@ import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.safeApiCall
 import com.m57.hermescontrol.ui.common.ToastHost
 import com.m57.hermescontrol.ui.common.safeLaunchLoad
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 
 data class LogsUiState(
     val isLoading: Boolean = false,
@@ -21,7 +25,14 @@ class LogsViewModel : ViewModel(), ToastHost {
     private val _uiState = MutableStateFlow(LogsUiState())
     val uiState: StateFlow<LogsUiState> = _uiState.asStateFlow()
 
+    @Volatile
+    private var loadInProgress = false
+
+    private var autoRefreshJob: Job? = null
+
     fun loadLogs() {
+        if (loadInProgress) return
+        loadInProgress = true
         safeLaunchLoad(
             apiCall = { safeApiCall { ApiClient.hermesApi.getLogs(lines = 1000) } },
             onStart = { _uiState.update { it.copy(isLoading = true, errorMessage = null) } },
@@ -29,6 +40,7 @@ class LogsViewModel : ViewModel(), ToastHost {
                 val body = data
                 val logsList = body.lines ?: body.logs ?: emptyList()
                 _uiState.update { it.copy(isLoading = false, logs = logsList) }
+                loadInProgress = false
             },
             onError = { errorMsg ->
                 _uiState.update {
@@ -37,8 +49,27 @@ class LogsViewModel : ViewModel(), ToastHost {
                         errorMessage = "Failed to load logs: $errorMsg",
                     )
                 }
+                loadInProgress = false
             },
         )
+    }
+
+    /** Start auto-refreshing logs every 5 seconds. */
+    fun startAutoRefresh() {
+        if (autoRefreshJob?.isActive == true) return
+        autoRefreshJob =
+            viewModelScope.launch {
+                while (isActive) {
+                    delay(5_000)
+                    loadLogs()
+                }
+            }
+    }
+
+    /** Stop auto-refreshing logs. */
+    fun stopAutoRefresh() {
+        autoRefreshJob?.cancel()
+        autoRefreshJob = null
     }
 
     override fun clearToast() {

--- a/app/src/main/java/com/m57/hermescontrol/ui/logs/LogsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/logs/LogsViewModel.kt
@@ -1,6 +1,7 @@
 package com.m57.hermescontrol.ui.logs
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.safeApiCall
 import com.m57.hermescontrol.ui.common.ToastHost


### PR DESCRIPTION
## Problem

The Logs screen doesn't auto-scroll to the bottom and doesn't update on its own — users have to pull-to-refresh every time to see new log entries.

## Root cause

Two separate issues:
1. **Auto-scroll** used `animateScrollToItem(filteredLogs.size)` which needs the `LazyColumn` to be laid out before it can animate — the first load fires before layout completes, so the scroll silently fails
2. **No live updates** — `loadLogs()` is a one-shot HTTP fetch that only runs on screen open + pull-to-refresh. There's no WebSocket log streaming or polling

## Fix (2 commits)

### 1. Auto-scroll (`966e050`)
```kotlin
// Before
listState.animateScrollToItem(filteredLogs.size)

// After
listState.scrollToItem(Int.MAX_VALUE)
```
`scrollToItem` is instant and works without layout dependency. `Int.MAX_VALUE` is the standard Compose "scroll to end" pattern.

### 2. Live log polling (`a1ec2db`)
- Added `loadInProgress` guard to prevent duplicate concurrent loads
- Added `startAutoRefresh()` / `stopAutoRefresh()` that polls `GET /api/logs` every **5 seconds** via `viewModelScope`
- Wired with `DisposableEffect(Unit)` — polling only runs while the log screen is visible, stops on navigation away

## Testing
- `./ktlint` — clean ✅

Closes #425