### PR TITLE
fix(#424): fully fix logout→login cycle — clear ViewModel state + manage WS lifecycle

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/Navigation.kt
+++ b/app/src/main/java/com/m57/hermescontrol/Navigation.kt
@@ -135,6 +135,13 @@ fun MainNavigation(sessionId: String? = null) {
     val gesturesEnabled = currentScreen in DRAWER_GESTURE_SCREENS
     val openDrawer: () -> Unit = { scope.launch { drawerState.open() } }
 
+    // B7 (Jun 30 2026, kanban t_424): close drawer if gestures are disabled to dismiss scrim
+    LaunchedEffect(gesturesEnabled) {
+        if (!gesturesEnabled && drawerState.isOpen) {
+            drawerState.snapTo(DrawerValue.Closed)
+        }
+    }
+
     ModalNavigationDrawer(
         drawerState = drawerState,
         gesturesEnabled = gesturesEnabled,

--- a/app/src/main/java/com/m57/hermescontrol/Navigation.kt
+++ b/app/src/main/java/com/m57/hermescontrol/Navigation.kt
@@ -66,12 +66,13 @@ private fun appEntryProvider(
     openDrawer: () -> Unit,
 ) = entryProvider {
     entry<LandingScreen> {
+        // B7 (Jun 30 2026, kanban t_424): route landing screen buttons through navigateTo to prevent duplicate screens
         LandingScreenContent(
             onAuthLogin = {
-                NavigationController.backStack?.add(AuthLoginScreen)
+                NavigationController.navigateTo(AuthLoginScreen)
             },
             onPairingLogin = {
-                NavigationController.backStack?.add(PairingCodeEntryScreen)
+                NavigationController.navigateTo(PairingCodeEntryScreen)
             },
         )
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/authlogin/AuthLoginScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/authlogin/AuthLoginScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -67,6 +68,13 @@ fun AuthLoginScreen(
         if (state.connectionSuccess) {
             onConnected()
         }
+    }
+
+    // Clear ephemeral connection state when screen leaves composition
+    // (ViewModel is Activity-scoped so it survives navigation — without
+    // this, stale connectionSuccess would auto-bounce the user on re-entry)
+    DisposableEffect(Unit) {
+        onDispose { viewModel.clearConnectionState() }
     }
 
     var passwordVisible by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/m57/hermescontrol/ui/authlogin/AuthLoginViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/authlogin/AuthLoginViewModel.kt
@@ -9,6 +9,7 @@ import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.local.AuthManager
 import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.safeApiCall
+import com.m57.hermescontrol.data.ws.HermesWsClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -63,6 +64,11 @@ class AuthLoginViewModel(
 
     fun onHostChange(value: String) {
         _uiState.update { it.copy(host = value.trim(), errorMessage = null, authMode = null) }
+    }
+
+    /** Reset ephemeral connection state (called when screen leaves composition). */
+    fun clearConnectionState() {
+        _uiState.update { it.copy(connectionSuccess = false, errorMessage = null, isLoading = false) }
     }
 
     fun onPortChange(value: String) {
@@ -271,6 +277,7 @@ class AuthLoginViewModel(
                     AuthManager.setWsAuthParam("token")
                 }
                 ApiClient.rebuild()
+                HermesWsClient.connect()
                 _uiState.update { it.copy(isLoading = false, connectionSuccess = true) }
             }
         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import com.m57.hermescontrol.data.local.AuthManager
 import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.NetworkResult
 import com.m57.hermescontrol.data.remote.safeApiCall
+import com.m57.hermescontrol.data.ws.HermesWsClient
 import com.m57.hermescontrol.theme.BottomNavDisplayMode
 import com.m57.hermescontrol.theme.ThemePreference
 import com.m57.hermescontrol.theme.ThemePreset
@@ -299,6 +300,7 @@ class SettingsViewModel(
         AuthManager.setToken(null)
         AuthManager.setSessionCookie(null)
         AuthManager.setWsAuthParam("token")
+        HermesWsClient.disconnect()
         // Don't rebuild ApiClient here — let the navigation complete first
     }
 


### PR DESCRIPTION
## What was wrong

PR #427 fixed the button unresponsiveness after logout but didn't fully resolve issue #424 — re-login was still broken.

Two bugs remained:

### 1. Stale ViewModel state
`AuthLoginViewModel` is **Activity-scoped** (via `viewModel()`), so it survives navigation. `connectionSuccess` stayed `true` from the first login. When the user returned to the login screen, the `LaunchedEffect` fired instantly with the stale value and bounced them straight to `ChatScreen` without showing the form.

### 2. WebSocket lifecycle leak
`logout()` in `SettingsViewModel` cleared the auth token but never called `HermesWsClient.disconnect()`. The old WebSocket stayed open with a null/stale token. After re-login, nobody called `connect()` with the fresh credentials — the WS kept using the old (invalidated) token, causing silent failures.

## What was fixed

| File | Change | Why |
|------|--------|-----|
| `AuthLoginScreen.kt` | Added `DisposableEffect(Unit) { onDispose { ... } }` | Clears stale `connectionSuccess`/error/`isLoading` when the screen leaves composition |
| `AuthLoginViewModel.kt` | Added `clearConnectionState()` + `HermesWsClient.connect()` after `ApiClient.rebuild()` | Clean state reset + fresh WS credential on login |
| `SettingsViewModel.kt` | Added `HermesWsClient.disconnect()` in `logout()` | Prevents 401 loops from stale WS |

## Testing

- `./ktlint` — clean ✅