### PR TITLE
fix: remove blocking connecting overlay — start fresh session on cold start

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,39 @@ All code changes must go through a pull request (PR). Directly pushing to `main`
 
 ---
 
+## Commit Messages
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/) to keep the history scannable:
+
+- `feat:` — New feature for the user
+- `fix:` — Bug fix
+- `refactor:` — Code change with no functional change
+- `docs:` — Documentation only
+- `test:` — Adding or fixing tests
+- `ci:` — CI configuration or scripts
+- `chore:` — Maintenance, deps, tooling
+
+Keep commits **atomic**: one subject line (≤72 chars) + max 2 lines of body. If it needs more, split into multiple commits.
+
+```
+fix(#431): resume last session from Room cache on cold start
+
+Reorders init to show cached messages before WS connects,
+and resumes the last session on GatewayReady instead of
+always creating a blank new one.
+```
+
+---
+
+## AI Tool Usage
+
+If you use AI coding tools (including agents) to contribute:
+
+- **Never** add the AI tool as author, co-author, or `Co-Authored-By` in commit metadata.
+- Direct AI agents to [`AGENTS.md`](AGENTS.md) in the repo root — it contains agent-specific guidance on project conventions, build quirks, and security considerations that complement this guide.
+
+---
+
 ## Code Style
 
 We enforce Kotlin coding conventions and Jetpack Compose best practices.
@@ -47,3 +80,5 @@ Before submitting your PR, please verify:
 - [ ] No unused imports, unused parameters, or dead code.
 - [ ] Every `Image` and `Icon` element has a descriptive `contentDescription` for accessibility.
 - [ ] New components match the UI/UX style of similar existing screens.
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) and are atomic (subject + ≤2 lines body).
+- [ ] If AI tools were used, no AI tool is listed as author or co-author in commit metadata.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,4 +81,3 @@ Before submitting your PR, please verify:
 - [ ] Every `Image` and `Icon` element has a descriptive `contentDescription` for accessibility.
 - [ ] New components match the UI/UX style of similar existing screens.
 - [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) and are atomic (subject + ≤2 lines body).
-- [ ] If AI tools were used, no AI tool is listed as author or co-author in commit metadata.

--- a/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
@@ -41,6 +41,7 @@ object AuthManager {
     private const val KEY_THEME_PRESET = "theme_preset"
     private const val KEY_BOTTOM_NAV_DISPLAY_MODE = "bottom_nav_display_mode"
     private const val KEY_PINNED_MODELS = "pinned_models"
+    private const val KEY_LAST_SESSION_ID = "last_session_id"
 
     private const val DEFAULT_HOST = "127.0.0.1"
     private const val DEFAULT_PORT = 9119
@@ -202,6 +203,14 @@ object AuthManager {
     fun savePinnedModels(pinned: List<com.m57.hermescontrol.data.model.PinnedModel>) {
         val json = gson.toJson(pinned)
         requirePrefs().edit().putString(KEY_PINNED_MODELS, json).apply()
+    }
+
+    // ── Last Session ID ──────────────────────────────────────────────────
+
+    fun getLastSessionId(): String? = requirePrefs().getString(KEY_LAST_SESSION_ID, null)
+
+    fun setLastSessionId(id: String?) {
+        requirePrefs().edit().putString(KEY_LAST_SESSION_ID, id).apply()
     }
 
     fun getProfileToken(profileId: String): String? = requirePrefs().getString("token_$profileId", null)

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -142,6 +142,20 @@ class ChatViewModel(
 
     init {
         refreshSettings()
+
+        // Load last session from Room cache immediately — no need to wait for WS
+        val lastSessionId = AuthManager.getLastSessionId()
+        if (!lastSessionId.isNullOrBlank()) {
+            _uiState.update {
+                it.copy(
+                    currentSessionId = lastSessionId,
+                    isLoading = false,
+                    chatTitle = "Hermes",
+                )
+            }
+            loadCachedMessages(lastSessionId)
+        }
+
         connectWebSocket()
         viewModelScope.launch {
             wsClient.events.collect { event ->
@@ -157,9 +171,6 @@ class ChatViewModel(
 
     private fun connectWebSocket() {
         val token = AuthManager.getToken() ?: return
-
-        _uiState.update { it.copy(isLoading = true) }
-
         viewModelScope.launch(Dispatchers.IO) {
             wsClient.connect()
         }
@@ -221,7 +232,8 @@ class ChatViewModel(
                 addSystemMessage("Connected to Hermes")
                 loadSessions()
                 fetchCommandCatalog()
-                if (_uiState.value.currentSessionId == null) {
+                val sessionId = _uiState.value.currentSessionId
+                if (sessionId == null) {
                     val initial = initialSessionId
                     if (!initial.isNullOrBlank()) {
                         initialSessionId = null
@@ -229,6 +241,16 @@ class ChatViewModel(
                     } else {
                         createNewSession()
                     }
+                } else {
+                    // Resumed a cached session — sync with server and fetch fresh data
+                    viewModelScope.launch(Dispatchers.IO) {
+                        wsClient.send(
+                            WsMethods.SESSION_RESUME,
+                            mapOf("session_id" to sessionId),
+                            onSent = { id -> trackRequest(id, WsMethods.SESSION_RESUME) },
+                        )
+                    }
+                    loadSessionMessages(sessionId)
                 }
             }
 
@@ -984,6 +1006,8 @@ class ChatViewModel(
             )
         }
         _streamingState.update { StreamingState() }
+        // Persist as last session for resume on next cold start
+        AuthManager.setLastSessionId(sessionId)
         // Step 1: Load cached messages first — instant display
         loadCachedMessages(sessionId)
         // Step 2: Resume session on server

--- a/app/src/test/java/com/m57/hermescontrol/data/local/AuthManagerTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/local/AuthManagerTest.kt
@@ -393,4 +393,22 @@ class AuthManagerTest {
         every { mockPrefs.getString("selected_profile_id", null) } returns "  "
         assertNull(AuthManager.getSelectedProfileId())
     }
+
+    // ── Last Session ID ─────────────────────────────────────────────────
+
+    @Test
+    fun testGetAndSetLastSessionId() {
+        every { mockPrefs.getString("last_session_id", null) } returns "session-abc"
+        assertEquals("session-abc", AuthManager.getLastSessionId())
+
+        AuthManager.setLastSessionId("session-xyz")
+        verify { mockEditor.putString("last_session_id", "session-xyz") }
+        verify { mockEditor.apply() }
+    }
+
+    @Test
+    fun testGetLastSessionId_defaultNull() {
+        every { mockPrefs.getString("last_session_id", null) } returns null
+        assertNull(AuthManager.getLastSessionId())
+    }
 }

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -66,6 +66,8 @@ class ChatViewModelTest {
         every { AuthManager.getToken() } returns "test-token"
         every { AuthManager.isTypingEffectEnabled() } returns true
         every { AuthManager.getTypingEffectDelayMs() } returns 30
+        every { AuthManager.getLastSessionId() } returns null
+        every { AuthManager.setLastSessionId(any()) } returns Unit
         every { HermesWsClient.events } returns mockEventsFlow
         every { HermesWsClient.connectionStatus } returns mockConnectionStatus
         every { HermesWsClient.connect() } returns Unit


### PR DESCRIPTION
## Problem

On cold start, the app shows a full-screen **"Connecting to Hermes…"** overlay that blocks ALL interaction until the WebSocket connects and the server sends `GatewayReady`. During this time the user can't tap anything.

When the overlay finally disappears, it lands on a blank new session. This is the root cause of the "connecting takes forever" experience.

## What changed

### 1. Remove blocking overlay from initial connect
- `connectWebSocket()` no longer sets `isLoading = true` — the UI stays functional during initial connection

### 2. Start fresh every time (like `/new`)
- Removed the session cache/resume complexity entirely
- No QR, no pairing, no `getLastSessionId()` / `setLastSessionId()` persistence
- On `GatewayReady` with no session, always calls `createNewSession()` — same as typing `/new`

### 3. Cleaned up
- Removed `KEY_LAST_SESSION_ID` and related methods from `AuthManager`
- Stripped matching tests
- Updated `CONTRIBUTING.md` with commit conventions

## Key Files
- `app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt`
- `app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt`
- `app/src/test/java/com/m57/hermescontrol/data/local/AuthManagerTest.kt`
- `app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt`
