### PR TITLE
fix: correct FilterChipRow and EmptyState API mismatches in Skills screen

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/model/Skill.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/Skill.kt
@@ -6,7 +6,7 @@ data class Skill(
     val category: String?,
     val enabled: Boolean,
     val content: String? = null,
-    val source: String? = null,  // built-in, hub, optional
+    val source: String? = null, // built-in, hub, optional
     val pinned: Boolean? = null,
     val linked_files: List<String>? = null,
 )

--- a/app/src/main/java/com/m57/hermescontrol/data/model/Skill.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/Skill.kt
@@ -6,10 +6,31 @@ data class Skill(
     val category: String?,
     val enabled: Boolean,
     val content: String? = null,
+    val source: String? = null,  // built-in, hub, optional
+    val pinned: Boolean? = null,
+    val linked_files: List<String>? = null,
 )
 
 data class HubSkill(
     val name: String,
     val description: String?,
     val source: String?,
+    val category: String? = null,
+)
+
+data class SkillHubInstallRequest(
+    val identifier: String,
+    val profile: String? = null,
+)
+
+data class SkillHubUninstallRequest(
+    val name: String,
+    val profile: String? = null,
+)
+
+data class SkillScanResponse(
+    val identifier: String,
+    val passed: Boolean? = null,
+    val issues: List<String>? = null,
+    val warnings: List<String>? = null,
 )

--- a/app/src/main/java/com/m57/hermescontrol/data/model/Skill.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/Skill.kt
@@ -1,5 +1,7 @@
 package com.m57.hermescontrol.data.model
 
+import com.google.gson.annotations.SerializedName
+
 data class Skill(
     val name: String,
     val description: String?,
@@ -16,6 +18,23 @@ data class HubSkill(
     val description: String?,
     val source: String?,
     val category: String? = null,
+    val identifier: String? = null,
+    @SerializedName("trust_level") val trustLevel: String? = null,
+    val repo: String? = null,
+    val tags: List<String>? = null,
+)
+
+data class SkillHubSearchResponse(
+    val results: List<HubSkill>,
+    @SerializedName("source_counts") val sourceCounts: Map<String, Int>? = null,
+    @SerializedName("timed_out") val timedOut: List<String>? = null,
+    val installed: Map<String, SkillHubInstalledEntry>? = null,
+)
+
+data class SkillHubInstalledEntry(
+    val name: String? = null,
+    @SerializedName("trust_level") val trustLevel: String? = null,
+    @SerializedName("scan_verdict") val scanVerdict: String? = null,
 )
 
 data class SkillHubInstallRequest(

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -69,6 +69,7 @@ import com.m57.hermescontrol.data.model.SetActiveProfileRequest
 import com.m57.hermescontrol.data.model.Skill
 import com.m57.hermescontrol.data.model.SkillContentResponse
 import com.m57.hermescontrol.data.model.SkillHubInstallRequest
+import com.m57.hermescontrol.data.model.SkillHubSearchResponse
 import com.m57.hermescontrol.data.model.SkillHubUninstallRequest
 import com.m57.hermescontrol.data.model.SkillScanResponse
 import com.m57.hermescontrol.data.model.StatusResponse
@@ -164,7 +165,7 @@ interface HermesApiService {
         @Query("q") q: String,
         @Query("source") source: String? = null,
         @Query("limit") limit: Int? = null,
-    ): Response<List<HubSkill>>
+    ): Response<SkillHubSearchResponse>
 
     @GET("api/skills/hub/preview")
     suspend fun previewHubSkill(

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -29,7 +29,6 @@ import com.m57.hermescontrol.data.model.EnvVarRevealRequest
 import com.m57.hermescontrol.data.model.EnvVarRevealResponse
 import com.m57.hermescontrol.data.model.EnvVarUpdate
 import com.m57.hermescontrol.data.model.HookResponse
-import com.m57.hermescontrol.data.model.HubSkill
 import com.m57.hermescontrol.data.model.KanbanBoardResponse
 import com.m57.hermescontrol.data.model.KanbanBoardsResponse
 import com.m57.hermescontrol.data.model.KanbanTask

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -68,6 +68,9 @@ import com.m57.hermescontrol.data.model.SessionStatsResponse
 import com.m57.hermescontrol.data.model.SetActiveProfileRequest
 import com.m57.hermescontrol.data.model.Skill
 import com.m57.hermescontrol.data.model.SkillContentResponse
+import com.m57.hermescontrol.data.model.SkillHubInstallRequest
+import com.m57.hermescontrol.data.model.SkillHubUninstallRequest
+import com.m57.hermescontrol.data.model.SkillScanResponse
 import com.m57.hermescontrol.data.model.StatusResponse
 import com.m57.hermescontrol.data.model.SystemStatsResponse
 import com.m57.hermescontrol.data.model.ToggleSkillRequest
@@ -156,10 +159,35 @@ interface HermesApiService {
     @GET("api/skills")
     suspend fun getSkills(): Response<List<Skill>>
 
-    @POST("api/skills/hub/search")
+    @GET("api/skills/hub/search")
     suspend fun searchSkillsHub(
         @Query("q") q: String,
+        @Query("source") source: String? = null,
+        @Query("limit") limit: Int? = null,
     ): Response<List<HubSkill>>
+
+    @GET("api/skills/hub/preview")
+    suspend fun previewHubSkill(
+        @Query("identifier") identifier: String,
+    ): Response<SkillContentResponse>
+
+    @GET("api/skills/hub/scan")
+    suspend fun scanHubSkill(
+        @Query("identifier") identifier: String,
+    ): Response<SkillScanResponse>
+
+    @GET("api/skills/hub/sources")
+    suspend fun getHubSources(): Response<List<String>>
+
+    @POST("api/skills/hub/install")
+    suspend fun installHubSkill(
+        @Body body: SkillHubInstallRequest,
+    ): Response<ActionResponse>
+
+    @POST("api/skills/hub/uninstall")
+    suspend fun uninstallHubSkill(
+        @Body body: SkillHubUninstallRequest,
+    ): Response<ActionResponse>
 
     @PUT("api/skills/toggle")
     suspend fun toggleSkill(

--- a/app/src/main/java/com/m57/hermescontrol/ui/common/SharedComponents.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/common/SharedComponents.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -230,35 +231,28 @@ fun SearchBar(
 // ── FilterChipRow — horizontally scrollable filter chips ───────────────
 
 @Composable
-fun FilterChipRow(
-    chips: List<String>,
-    selectedChip: String?,
-    onChipSelected: (String) -> Unit,
+fun <T> FilterChipRow(
+    chips: List<T>,
+    selectedChip: T?,
+    onChipSelected: (T) -> Unit,
     modifier: Modifier = Modifier,
+    chipLabel: @Composable (T) -> Unit = { Text(it.toString()) },
 ) {
     val spacing = LocalSpacing.current
     LazyRow(
         modifier = modifier.fillMaxWidth(),
         contentPadding =
-            androidx.compose.foundation.layout.PaddingValues(
+            PaddingValues(
                 horizontal = spacing.md,
                 vertical = spacing.xs,
             ),
         horizontalArrangement = Arrangement.spacedBy(spacing.sm),
     ) {
-        items(chips, key = { it }) { chip ->
+        items(chips, key = { it.toString() }) { chip ->
             FilterChip(
                 selected = chip == selectedChip,
                 onClick = { onChipSelected(chip) },
-                label = {
-                    Text(
-                        if (chip == "All") {
-                            stringResource(R.string.skills_category_all)
-                        } else {
-                            chip
-                        },
-                    )
-                },
+                label = { chipLabel(chip) },
             )
         }
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/profiles/ProfilesViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/profiles/ProfilesViewModel.kt
@@ -332,7 +332,7 @@ class ProfilesViewModel :
                     _uiState.update {
                         it.copy(
                             isSearchingHub = false,
-                            hubSearchResults = result.data,
+                            hubSearchResults = result.data?.results.orEmpty(),
                         )
                     }
                 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -684,8 +684,7 @@ fun SkillPreviewDialog(
                 Box(
                     modifier =
                         Modifier
-                            .fillMaxSize()
-                            .padding(padding),
+                            .fillMaxSize(),
                 ) {
                     when {
                         isLoading -> LoadingState()
@@ -804,8 +803,7 @@ fun SkillEditorDialog(
                 Box(
                     modifier =
                         Modifier
-                            .fillMaxSize()
-                            .padding(padding),
+                            .fillMaxSize(),
                 ) {
                     when {
                         isLoading -> {

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -4,16 +4,27 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Extension
-import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Preview
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -22,6 +33,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -37,13 +49,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.m57.hermescontrol.R
-import com.m57.hermescontrol.theme.LocalSpacing
+import com.m57.hermescontrol.data.model.HubSkill
+import com.m57.hermescontrol.data.model.Skill
 import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.FilterChipRow
@@ -58,263 +72,87 @@ import com.m57.hermescontrol.ui.common.listItemSpacing
 @Composable
 fun SkillsScreen(
     modifier: Modifier = Modifier,
-    onOpenDrawer: (() -> Unit)? = null,
-    viewModel: SkillsViewModel = viewModel { SkillsViewModel() },
+    onOpenDrawer: () -> Unit = {},
+    viewModel: SkillsViewModel = viewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
-    val spacing = LocalSpacing.current
     var query by remember { mutableStateOf("") }
-    val statuses = listOf("All Statuses", "Enabled", "Disabled")
     var selectedStatus by remember { mutableStateOf("All Statuses") }
-    val categories =
-        remember(state.skills) {
-            listOf("All") +
-                state.skills
-                    .mapNotNull { it.category }
-                    .distinct()
-                    .sorted()
-        }
     var selectedCategory by remember { mutableStateOf("All") }
 
     LaunchedEffect(Unit) {
         viewModel.loadSkills()
     }
 
-    ToastEffect(toastMessage = state.toastMessage, onClearToast = viewModel::clearToast)
-
-    val filtered =
-        remember(state.skills, query, selectedStatus, selectedCategory) {
-            state.skills.filter { skill ->
-                val matchesQuery =
-                    if (query.isBlank()) {
-                        true
-                    } else {
-                        skill.name.contains(query, ignoreCase = true) ||
-                            skill.category?.contains(query, ignoreCase = true) == true ||
-                            skill.description?.contains(query, ignoreCase = true) == true
-                    }
-
-                val matchesStatus =
-                    when (selectedStatus) {
-                        "Enabled" -> skill.enabled
-                        "Disabled" -> !skill.enabled
-                        else -> true
-                    }
-
-                val matchesCategory =
-                    if (selectedCategory == "All") {
-                        true
-                    } else {
-                        skill.category == selectedCategory
-                    }
-
-                matchesQuery && matchesStatus && matchesCategory
-            }
-        }
-
     HermesScaffold(
-        title = { Text(stringResource(R.string.screen_skills)) },
-        navigationIcon = onOpenDrawer?.let { NavIcon.Menu(it) },
-        isRefreshing = state.isLoading,
-        onRefresh = { viewModel.loadSkills() },
-    ) {
-        when {
-            state.isLoading && state.skills.isEmpty() -> {
-                LoadingState()
-            }
-
-            state.errorMessage != null -> {
-                ErrorState(
-                    message = state.errorMessage ?: stringResource(R.string.error_unknown),
-                    onRetry = { viewModel.loadSkills() },
-                )
-            }
-
-            state.skills.isEmpty() -> {
-                EmptyState(
-                    title = stringResource(R.string.skills_no_skills),
-                    subtitle = stringResource(R.string.skills_no_skills_desc),
-                    icon = Icons.Filled.Extension,
-                )
-            }
-
-            else -> {
-                LazyColumn(
-                    modifier = Modifier.fillMaxWidth(),
-                    contentPadding = listContentPadding,
-                    verticalArrangement = listItemSpacing,
-                ) {
-                    item {
-                        SearchBar(
-                            query = query,
-                            onQueryChange = { query = it },
-                            placeholder = stringResource(R.string.skills_search_placeholder),
-                        )
-                    }
-                    item {
-                        Column(
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = spacing.md),
-                            verticalArrangement = Arrangement.spacedBy(spacing.xs),
-                        ) {
-                            Text(
-                                text = stringResource(R.string.skills_filter_status),
-                                style = MaterialTheme.typography.labelMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Row(
-                                horizontalArrangement = Arrangement.spacedBy(spacing.xs),
-                            ) {
-                                statuses.forEach { status ->
-                                    FilterChip(
-                                        selected = selectedStatus == status,
-                                        onClick = { selectedStatus = status },
-                                        label = {
-                                            Text(
-                                                when (status) {
-                                                    "All Statuses" -> stringResource(R.string.skills_status_all)
-                                                    "Enabled" -> stringResource(R.string.skills_status_enabled)
-                                                    "Disabled" -> stringResource(R.string.skills_status_disabled)
-                                                    else -> status
-                                                },
-                                            )
-                                        },
-                                    )
-                                }
-                            }
-                        }
-                    }
-                    if (categories.size > 2) {
-                        item {
-                            Column(
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .padding(vertical = spacing.xs),
-                                verticalArrangement = Arrangement.spacedBy(spacing.xs),
-                            ) {
-                                Text(
-                                    text = stringResource(R.string.skills_filter_category),
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.padding(horizontal = spacing.md),
-                                )
-                                FilterChipRow(
-                                    chips = categories,
-                                    selectedChip = selectedCategory,
-                                    onChipSelected = { selectedCategory = it },
-                                )
-                            }
-                        }
-                    }
-                    if (filtered.isEmpty()) {
-                        item {
-                            Box(
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .padding(vertical = spacing.lg),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                Column(
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                    verticalArrangement = Arrangement.spacedBy(spacing.xs),
-                                ) {
-                                    Text(
-                                        text = stringResource(R.string.skills_no_matching),
-                                        style =
-                                            MaterialTheme.typography.titleMedium.copy(
-                                                fontWeight = FontWeight.Bold,
-                                            ),
-                                    )
-                                    Text(
-                                        text = stringResource(R.string.skills_no_matching_desc),
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-                                }
-                            }
-                        }
-                    } else {
-                        items(filtered, key = { it.name }) { skill ->
-                            Card(
-                                modifier = Modifier.fillMaxWidth(),
-                                colors =
-                                    CardDefaults.cardColors(
-                                        containerColor = MaterialTheme.colorScheme.surfaceContainer,
-                                    ),
-                            ) {
-                                Row(
-                                    modifier =
-                                        Modifier
-                                            .fillMaxWidth()
-                                            .padding(spacing.md),
-                                    horizontalArrangement = Arrangement.SpaceBetween,
-                                    verticalAlignment = Alignment.CenterVertically,
-                                ) {
-                                    Row(
-                                        modifier = Modifier.weight(1f),
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Filled.Extension,
-                                            contentDescription = null,
-                                            tint = MaterialTheme.colorScheme.primary,
-                                        )
-                                        Column(modifier = Modifier.weight(1f)) {
-                                            Text(
-                                                text = skill.name,
-                                                style =
-                                                    MaterialTheme.typography.titleMedium.copy(
-                                                        fontWeight = FontWeight.SemiBold,
-                                                    ),
-                                            )
-                                            skill.category?.let { cat ->
-                                                Text(
-                                                    text = cat,
-                                                    style = MaterialTheme.typography.labelSmall,
-                                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                )
-                                            }
-                                            skill.description?.let { desc ->
-                                                Text(
-                                                    text = desc,
-                                                    style = MaterialTheme.typography.bodyMedium,
-                                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                    maxLines = 2,
-                                                )
-                                            }
-                                        }
-                                    }
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                    ) {
-                                        IconButton(
-                                            onClick = { viewModel.loadSkillContent(skill.name) },
-                                        ) {
-                                            Icon(
-                                                imageVector = Icons.Filled.Edit,
-                                                contentDescription = stringResource(R.string.content_desc_edit_skill),
-                                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                            )
-                                        }
-                                        Switch(
-                                            checked = skill.enabled,
-                                            onCheckedChange = { viewModel.toggleSkill(skill) },
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    }
+        modifier = modifier,
+        title = { Text(stringResource(R.string.skills_screen_title)) },
+        navigationIcon = NavIcon.OpenDrawer(onClick = onOpenDrawer),
+        actions = {
+            if (state.viewMode == SkillsViewMode.INSTALLED) {
+                IconButton(onClick = { viewModel.updateSkillsFromHub() }) {
+                    Icon(
+                        imageVector = Icons.Filled.Refresh,
+                        contentDescription = stringResource(R.string.content_desc_update_skills_hub),
+                    )
                 }
+            }
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier.fillMaxSize().padding(padding),
+        ) {
+            // ── View mode tabs ──────────────────────────────────────
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                FilterChip(
+                    selected = state.viewMode == SkillsViewMode.INSTALLED,
+                    onClick = { viewModel.setViewMode(SkillsViewMode.INSTALLED) },
+                    label = { Text("Installed") },
+                )
+                FilterChip(
+                    selected = state.viewMode == SkillsViewMode.HUB,
+                    onClick = { viewModel.setViewMode(SkillsViewMode.HUB) },
+                    label = { Text("Browse Hub") },
+                )
+            }
+
+            when (state.viewMode) {
+                SkillsViewMode.INSTALLED ->
+                    InstalledSkillsView(
+                        state = state,
+                        query = query,
+                        onQueryChange = { query = it },
+                        selectedStatus = selectedStatus,
+                        onStatusChange = { selectedStatus = it },
+                        selectedCategory = selectedCategory,
+                        onCategoryChange = { selectedCategory = it },
+                        onToggle = viewModel::toggleSkill,
+                        onEdit = viewModel::loadSkillContent,
+                        onPreview = viewModel::previewSkill,
+                        onUninstall = viewModel::uninstallSkill,
+                        onSetSourceFilter = viewModel::setSourceFilter,
+                        sourceFilter = state.sourceFilter,
+                        isUninstalling = state.isUninstalling,
+                        uninstallingSkillName = state.uninstallingSkillName,
+                        onRefresh = viewModel::loadSkills,
+                    )
+                SkillsViewMode.HUB ->
+                    HubBrowseView(
+                        state = state,
+                        onSearch = viewModel::searchHub,
+                        onClearSearch = viewModel::clearHubSearch,
+                        onInstall = viewModel::installSkill,
+                        isInstalling = state.isInstalling,
+                        installingSkillName = state.installingSkillName,
+                    )
             }
         }
     }
+
+    // ── Dialogs ────────────────────────────────────────────────────
 
     state.editingSkillName?.let { skillName ->
         SkillEditorDialog(
@@ -328,7 +166,532 @@ fun SkillsScreen(
             onClearSaveSuccess = { viewModel.clearSaveSuccess() },
         )
     }
+
+    state.previewSkillName?.let { skillName ->
+        SkillPreviewDialog(
+            skillName = skillName,
+            isLoading = state.isLoadingPreview,
+            content = state.previewSkillContent,
+            onDismiss = { viewModel.clearPreview() },
+        )
+    }
+
+    ToastEffect(
+        toastMessage = state.toastMessage,
+        onClearToast = viewModel::clearToast,
+    )
 }
+
+// ── Installed Skills View ───────────────────────────────────────────────
+
+@Composable
+private fun InstalledSkillsView(
+    state: SkillsUiState,
+    query: String,
+    onQueryChange: (String) -> Unit,
+    selectedStatus: String,
+    onStatusChange: (String) -> Unit,
+    selectedCategory: String,
+    onCategoryChange: (String) -> Unit,
+    onToggle: (Skill) -> Unit,
+    onEdit: (String) -> Unit,
+    onPreview: (String) -> Unit,
+    onUninstall: (String) -> Unit,
+    onSetSourceFilter: (String?) -> Unit,
+    sourceFilter: String?,
+    isUninstalling: Boolean,
+    uninstallingSkillName: String?,
+    onRefresh: () -> Unit,
+) {
+    val categories =
+        remember(state.skills) {
+            state.skills
+                .mapNotNull { it.category }
+                .distinct()
+                .sorted()
+        }
+    val sources =
+        remember(state.skills) {
+            state.skills
+                .mapNotNull { it.source }
+                .distinct()
+                .sorted()
+        }
+
+    val filteredSkills =
+        remember(state.skills, query, selectedStatus, selectedCategory, sourceFilter) {
+            state.skills.filter { skill ->
+                (
+                    query.isBlank() || skill.name.contains(query, ignoreCase = true) ||
+                        skill.description?.contains(query, ignoreCase = true) == true
+                ) &&
+                    (
+                        selectedStatus == "All Statuses" ||
+                            (selectedStatus == "Enabled" && skill.enabled) ||
+                            (selectedStatus == "Disabled" && !skill.enabled)
+                    ) &&
+                    (selectedCategory == "All" || skill.category == selectedCategory) &&
+                    (sourceFilter == null || skill.source == sourceFilter)
+            }
+        }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        SearchBar(
+            query = query,
+            onQueryChange = onQueryChange,
+            placeholder = stringResource(R.string.skills_search_placeholder),
+        )
+
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            FilterChipRow(
+                chips = listOf("All Statuses", "Enabled", "Disabled"),
+                selectedChip = selectedStatus,
+                onChipSelected = onStatusChange,
+            )
+        }
+
+        if (categories.isNotEmpty() || sources.isNotEmpty()) {
+            FilterChipRow(
+                chips = listOf("All") + categories,
+                selectedChip = selectedCategory,
+                onChipSelected = onCategoryChange,
+            )
+            if (sources.isNotEmpty()) {
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 2.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    FilterChip(
+                        selected = sourceFilter == null,
+                        onClick = { onSetSourceFilter(null) },
+                        label = { Text("All sources", style = MaterialTheme.typography.labelSmall) },
+                    )
+                    sources.forEach { source ->
+                        FilterChip(
+                            selected = sourceFilter == source,
+                            onClick = { onSetSourceFilter(if (sourceFilter == source) null else source) },
+                            label = { Text(source, style = MaterialTheme.typography.labelSmall) },
+                        )
+                    }
+                }
+            }
+        }
+
+        when {
+            state.isLoading -> LoadingState()
+            state.errorMessage != null ->
+                ErrorState(
+                    message = state.errorMessage,
+                    onRetry = onRefresh,
+                )
+            filteredSkills.isEmpty() ->
+                EmptyState(
+                    icon = Icons.Filled.Extension,
+                    title = stringResource(R.string.skills_empty_message),
+                )
+            else ->
+                LazyColumn(
+                    modifier = Modifier.listContentPadding(),
+                    verticalArrangement = Arrangement.spacedBy(listItemSpacing),
+                ) {
+                    items(filteredSkills, key = { it.name }) { skill ->
+                        SkillCard(
+                            skill = skill,
+                            onToggle = { onToggle(skill) },
+                            onEdit = { onEdit(skill.name) },
+                            onPreview = { onPreview(skill.name) },
+                            onUninstall =
+                                if (skill.source == "hub") {
+                                    { onUninstall(skill.name) }
+                                } else {
+                                    null
+                                },
+                            isUninstalling = isUninstalling && uninstallingSkillName == skill.name,
+                        )
+                    }
+                }
+        }
+    }
+}
+
+// ── Skill Card ─────────────────────────────────────────────────────────
+
+@Composable
+private fun SkillCard(
+    skill: Skill,
+    onToggle: () -> Unit,
+    onEdit: () -> Unit,
+    onPreview: () -> Unit,
+    onUninstall: (() -> Unit)?,
+    isUninstalling: Boolean,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+            ),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Extension,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    Text(
+                        text = skill.name,
+                        style =
+                            MaterialTheme.typography.titleMedium.copy(
+                                fontWeight = FontWeight.SemiBold,
+                            ),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    skill.source?.let { source ->
+                        SourceBadge(source = source)
+                    }
+                }
+                skill.category?.let { cat ->
+                    Text(
+                        text = cat,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                skill.description?.let { desc ->
+                    Text(
+                        text = desc,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                IconButton(onClick = onPreview) {
+                    Icon(
+                        imageVector = Icons.Filled.Preview,
+                        contentDescription = stringResource(R.string.content_desc_preview_skill),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                IconButton(onClick = onEdit) {
+                    Icon(
+                        imageVector = Icons.Filled.Edit,
+                        contentDescription = stringResource(R.string.content_desc_edit_skill),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                if (onUninstall != null) {
+                    IconButton(
+                        onClick = onUninstall,
+                        enabled = !isUninstalling,
+                    ) {
+                        if (isUninstalling) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(18.dp),
+                                strokeWidth = 2.dp,
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Filled.CloudOff,
+                                contentDescription = stringResource(R.string.content_desc_uninstall_skill),
+                                tint = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                    }
+                }
+                Switch(
+                    checked = skill.enabled,
+                    onCheckedChange = { onToggle() },
+                )
+            }
+        }
+    }
+}
+
+// ── Source Badge ───────────────────────────────────────────────────────
+
+@Composable
+private fun SourceBadge(source: String) {
+    val (color, label) =
+        when (source) {
+            "hub" -> MaterialTheme.colorScheme.tertiary to "hub"
+            "built-in" -> MaterialTheme.colorScheme.secondary to "built-in"
+            "optional" -> MaterialTheme.colorScheme.outline to "opt"
+            else -> MaterialTheme.colorScheme.outline to source
+        }
+    Surface(
+        color = color.copy(alpha = 0.15f),
+        shape = MaterialTheme.shapes.small,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = color,
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+        )
+    }
+}
+
+// ── Hub Browse View ─────────────────────────────────────────────────────
+
+@Composable
+private fun HubBrowseView(
+    state: SkillsUiState,
+    onSearch: (String) -> Unit,
+    onClearSearch: () -> Unit,
+    onInstall: (String) -> Unit,
+    isInstalling: Boolean,
+    installingSkillName: String?,
+) {
+    var hubQuery by remember { mutableStateOf("") }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        OutlinedTextField(
+            value = hubQuery,
+            onValueChange = { hubQuery = it },
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+            placeholder = { Text(stringResource(R.string.skills_hub_search_placeholder)) },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Filled.Search,
+                    contentDescription = null,
+                )
+            },
+            trailingIcon = {
+                if (hubQuery.isNotEmpty()) {
+                    IconButton(onClick = {
+                        hubQuery = ""
+                        onClearSearch()
+                    }) {
+                        Icon(
+                            imageVector = Icons.Filled.Close,
+                            contentDescription = stringResource(R.string.action_clear),
+                        )
+                    }
+                }
+            },
+            singleLine = true,
+        )
+
+        Button(
+            onClick = { onSearch(hubQuery) },
+            modifier =
+                Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(bottom = 8.dp),
+            enabled = hubQuery.isNotBlank(),
+        ) {
+            Icon(Icons.Filled.Search, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(R.string.skills_hub_search_button))
+        }
+
+        when {
+            state.isHubSearching -> LoadingState()
+            state.hubSearchError != null ->
+                ErrorState(
+                    message = state.hubSearchError,
+                    onRetry = { onSearch(hubQuery) },
+                )
+            state.hubResults.isEmpty() && hubQuery.isNotBlank() && !state.isHubSearching -> {
+                EmptyState(
+                    icon = Icons.Filled.Extension,
+                    title = stringResource(R.string.skills_hub_empty_results),
+                )
+            }
+            state.hubResults.isNotEmpty() ->
+                LazyColumn(
+                    modifier = Modifier.listContentPadding(),
+                    verticalArrangement = Arrangement.spacedBy(listItemSpacing),
+                ) {
+                    items(state.hubResults, key = { it.name }) { hubSkill ->
+                        HubSkillCard(
+                            hubSkill = hubSkill,
+                            onInstall = { onInstall(hubSkill.name) },
+                            isInstalling = isInstalling && installingSkillName == hubSkill.name,
+                        )
+                    }
+                }
+            else -> {
+                EmptyState(
+                    icon = Icons.Filled.Search,
+                    title = stringResource(R.string.skills_hub_search_hint),
+                )
+            }
+        }
+    }
+}
+
+// ── Hub Skill Card ─────────────────────────────────────────────────────
+
+@Composable
+private fun HubSkillCard(
+    hubSkill: HubSkill,
+    onInstall: () -> Unit,
+    isInstalling: Boolean,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+            ),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Extension,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = hubSkill.name,
+                    style =
+                        MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.SemiBold,
+                        ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                hubSkill.source?.let { source ->
+                    SourceBadge(source = source)
+                }
+                hubSkill.description?.let { desc ->
+                    Text(
+                        text = desc,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+            Button(
+                onClick = onInstall,
+                enabled = !isInstalling,
+            ) {
+                if (isInstalling) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary,
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Filled.CloudDownload,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(Modifier.width(4.dp))
+                    Text(stringResource(R.string.skills_hub_install))
+                }
+            }
+        }
+    }
+}
+
+// ── Skill Preview Dialog ───────────────────────────────────────────────
+
+@Composable
+fun SkillPreviewDialog(
+    skillName: String,
+    isLoading: Boolean,
+    content: String?,
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Card(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+            colors =
+                CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                ),
+        ) {
+            HermesScaffold(
+                title = { Text(stringResource(R.string.skills_preview_title, skillName)) },
+                navigationIcon = NavIcon.Back(onBack = onDismiss),
+            ) { padding ->
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(padding),
+                ) {
+                    when {
+                        isLoading -> LoadingState()
+                        content != null -> {
+                            Column(
+                                modifier =
+                                    Modifier
+                                        .fillMaxSize()
+                                        .padding(16.dp)
+                                        .verticalScroll(rememberScrollState()),
+                            ) {
+                                Text(
+                                    text = content,
+                                    style =
+                                        MaterialTheme.typography.bodyMedium.copy(
+                                            fontFamily = FontFamily.Monospace,
+                                        ),
+                                )
+                            }
+                        }
+                        else ->
+                            EmptyState(
+                                icon = Icons.Filled.Extension,
+                                title = stringResource(R.string.skills_preview_empty),
+                            )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Skill Editor Dialog (existing, preserved unchanged) ────────────────
 
 @Composable
 fun SkillEditorDialog(

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -353,66 +353,79 @@ private fun SkillCard(
                 containerColor = MaterialTheme.colorScheme.surface,
             ),
     ) {
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
         ) {
-            Icon(
-                imageVector = Icons.Filled.Extension,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-            )
-            Column(modifier = Modifier.weight(1f)) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    Text(
-                        text = skill.name,
-                        style =
-                            MaterialTheme.typography.titleMedium.copy(
-                                fontWeight = FontWeight.SemiBold,
-                            ),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    skill.source?.let { source ->
-                        SourceBadge(source = source)
-                    }
-                }
-                skill.category?.let { cat ->
-                    Text(
-                        text = cat,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                skill.description?.let { desc ->
-                    Text(
-                        text = desc,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-            }
+            // ── Top row: icon + name + source badge + toggle ──
             Row(
+                modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                IconButton(onClick = onAction) {
-                    Icon(
-                        imageVector = Icons.Filled.Edit,
-                        contentDescription = stringResource(R.string.content_desc_edit_skill),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                Icon(
+                    imageVector = Icons.Filled.Extension,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+                Text(
+                    text = skill.name,
+                    style =
+                        MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.SemiBold,
+                        ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                skill.source?.let { source ->
+                    Spacer(modifier = Modifier.width(6.dp))
+                    SourceBadge(source = source)
                 }
-                if (onUninstall != null) {
+                Spacer(modifier = Modifier.width(8.dp))
+                Switch(
+                    checked = skill.enabled,
+                    onCheckedChange = { onToggle() },
+                )
+            }
+
+            // ── Category ──
+            skill.category?.let { cat ->
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = cat,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // ── Description ──
+            skill.description?.let { desc ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = desc,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            // ── Action buttons row ──
+            if (onUninstall != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    IconButton(onClick = onAction) {
+                        Icon(
+                            imageVector = Icons.Filled.Edit,
+                            contentDescription = stringResource(R.string.content_desc_edit_skill),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
                     IconButton(
                         onClick = onUninstall,
                         enabled = !isUninstalling,
@@ -432,10 +445,21 @@ private fun SkillCard(
                         }
                     }
                 }
-                Switch(
-                    checked = skill.enabled,
-                    onCheckedChange = { onToggle() },
-                )
+            } else {
+                // No uninstall — just the edit button inline
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    IconButton(onClick = onAction) {
+                        Icon(
+                            imageVector = Icons.Filled.Edit,
+                            contentDescription = stringResource(R.string.content_desc_edit_skill),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -91,7 +91,7 @@ fun SkillsScreen(
     HermesScaffold(
         modifier = modifier,
         title = { Text(stringResource(R.string.skills_screen_title)) },
-        navigationIcon = NavIcon.Menu(onClick = onOpenDrawer),
+        navigationIcon = NavIcon.Menu(onOpen = onOpenDrawer),
         actions = {
             if (state.viewMode == SkillsViewMode.INSTALLED) {
                 IconButton(onClick = { viewModel.updateSkillsFromHub() }) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -358,12 +358,6 @@ private fun SkillCard(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Icon(
-                imageVector = Icons.Filled.Extension,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(20.dp).padding(start = 12.dp),
-            )
             Column(
                 modifier = Modifier.weight(1f).padding(16.dp),
             ) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -135,7 +135,6 @@ fun SkillsScreen(
                         onCategoryChange = { selectedCategory = it },
                         onToggle = viewModel::toggleSkill,
                         onEdit = viewModel::loadSkillContent,
-                        onPreview = viewModel::previewSkill,
                         onUninstall = viewModel::uninstallSkill,
                         onSetSourceFilter = viewModel::setSourceFilter,
                         sourceFilter = state.sourceFilter,
@@ -197,11 +196,10 @@ private fun InstalledSkillsView(
     onQueryChange: (String) -> Unit,
     selectedStatus: SkillFilter,
     onStatusChange: (SkillFilter) -> Unit,
-    selectedCategory: String,
-    onCategoryChange: (String) -> Unit,
+    selectedCategory: String?,
+    onCategoryChange: (String?) -> Unit,
     onToggle: (Skill) -> Unit,
     onEdit: (String) -> Unit,
-    onPreview: (String) -> Unit,
     onUninstall: (String) -> Unit,
     onSetSourceFilter: (String?) -> Unit,
     sourceFilter: String?,
@@ -324,8 +322,7 @@ private fun InstalledSkillsView(
                         SkillCard(
                             skill = skill,
                             onToggle = { onToggle(skill) },
-                            onEdit = { onEdit(skill.name) },
-                            onPreview = { onPreview(skill.name) },
+                            onAction = { onEdit(skill.name) },
                             onUninstall =
                                 if (skill.source == "hub") {
                                     { onUninstall(skill.name) }
@@ -346,8 +343,7 @@ private fun InstalledSkillsView(
 private fun SkillCard(
     skill: Skill,
     onToggle: () -> Unit,
-    onEdit: () -> Unit,
-    onPreview: () -> Unit,
+    onAction: () -> Unit,
     onUninstall: (() -> Unit)?,
     isUninstalling: Boolean,
 ) {
@@ -410,14 +406,7 @@ private fun SkillCard(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                IconButton(onClick = onPreview) {
-                    Icon(
-                        imageVector = Icons.Filled.Preview,
-                        contentDescription = stringResource(R.string.content_desc_preview_skill),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                IconButton(onClick = onEdit) {
+                IconButton(onClick = onAction) {
                     Icon(
                         imageVector = Icons.Filled.Edit,
                         contentDescription = stringResource(R.string.content_desc_edit_skill),

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -124,7 +124,7 @@ fun SkillsScreen(
             }
 
             when (state.viewMode) {
-                SkillsViewMode.INSTALLED ->
+                SkillsViewMode.INSTALLED -> {
                     InstalledSkillsView(
                         state = state,
                         query = query,
@@ -142,7 +142,9 @@ fun SkillsScreen(
                         uninstallingSkillName = state.uninstallingSkillName,
                         onRefresh = viewModel::loadSkills,
                     )
-                SkillsViewMode.HUB ->
+                }
+
+                SkillsViewMode.HUB -> {
                     HubBrowseView(
                         state = state,
                         hubQuery = state.hubQuery,
@@ -153,6 +155,7 @@ fun SkillsScreen(
                         isInstalling = state.isInstalling,
                         installingSkillName = state.installingSkillName,
                     )
+                }
             }
         }
     }
@@ -302,23 +305,33 @@ private fun InstalledSkillsView(
         }
 
         when {
-            state.isLoading -> LoadingState()
-            state.errorMessage != null ->
+            state.isLoading -> {
+                LoadingState()
+            }
+
+            state.errorMessage != null -> {
                 ErrorState(
                     message = state.errorMessage,
                     onRetry = onRefresh,
                 )
-            filteredSkills.isEmpty() ->
+            }
+
+            filteredSkills.isEmpty() -> {
                 EmptyState(
                     icon = Icons.Filled.Extension,
                     title = stringResource(R.string.skills_empty_message),
                 )
-            else ->
+            }
+
+            else -> {
                 LazyColumn(
                     modifier = Modifier.padding(listContentPadding),
                     verticalArrangement = listItemSpacing,
                 ) {
-                    items(filteredSkills, key = { it.name }) { skill ->
+                    itemsIndexed(
+                        filteredSkills,
+                        key = { index, skill -> "${skill.name}:${skill.source ?: "unknown"}:$index" },
+                    ) { _, skill ->
                         SkillCard(
                             skill = skill,
                             onToggle = { onToggle(skill) },
@@ -333,6 +346,7 @@ private fun InstalledSkillsView(
                         )
                     }
                 }
+            }
         }
     }
 }
@@ -544,24 +558,33 @@ private fun HubBrowseView(
         }
 
         when {
-            state.isHubSearching -> LoadingState()
-            state.hubSearchError != null ->
+            state.isHubSearching -> {
+                LoadingState()
+            }
+
+            state.hubSearchError != null -> {
                 ErrorState(
                     message = state.hubSearchError,
                     onRetry = { onSearch(hubQuery) },
                 )
+            }
+
             state.hubResults.isEmpty() && hubQuery.isNotBlank() && !state.isHubSearching -> {
                 EmptyState(
                     icon = Icons.Filled.Extension,
                     title = stringResource(R.string.skills_hub_empty_results),
                 )
             }
-            state.hubResults.isNotEmpty() ->
+
+            state.hubResults.isNotEmpty() -> {
                 LazyColumn(
                     modifier = Modifier.weight(1f).padding(listContentPadding),
                     verticalArrangement = listItemSpacing,
                 ) {
-                    items(state.hubResults, key = { "${it.name}:${it.source ?: "unknown"}" }) { hubSkill ->
+                    itemsIndexed(
+                        state.hubResults,
+                        key = { index, hubSkill -> "${hubSkill.name}:${hubSkill.source ?: "unknown"}:$index" },
+                    ) { _, hubSkill ->
                         HubSkillCard(
                             hubSkill = hubSkill,
                             onInstall = { onInstall(hubSkill.name) },
@@ -569,6 +592,8 @@ private fun HubBrowseView(
                         )
                     }
                 }
+            }
+
             else -> {
                 EmptyState(
                     icon = Icons.Filled.Search,
@@ -704,7 +729,10 @@ fun SkillPreviewDialog(
                             .fillMaxSize(),
                 ) {
                     when {
-                        isLoading -> LoadingState()
+                        isLoading -> {
+                            LoadingState()
+                        }
+
                         content != null -> {
                             Column(
                                 modifier =
@@ -722,11 +750,13 @@ fun SkillPreviewDialog(
                                 )
                             }
                         }
-                        else ->
+
+                        else -> {
                             EmptyState(
                                 icon = Icons.Filled.Extension,
                                 title = stringResource(R.string.skills_preview_empty),
                             )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -59,6 +59,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.HubSkill
 import com.m57.hermescontrol.data.model.Skill
+import com.m57.hermescontrol.theme.LocalHermesStatusColors
 import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.FilterChipRow
@@ -70,6 +71,8 @@ import com.m57.hermescontrol.ui.common.ToastEffect
 import com.m57.hermescontrol.ui.common.listContentPadding
 import com.m57.hermescontrol.ui.common.listItemSpacing
 
+private const val CATEGORY_ALL = "All"
+
 @Composable
 fun SkillsScreen(
     modifier: Modifier = Modifier,
@@ -78,8 +81,8 @@ fun SkillsScreen(
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     var query by remember { mutableStateOf("") }
-    var selectedStatus by remember { mutableStateOf("All Statuses") }
-    var selectedCategory by remember { mutableStateOf("All") }
+    var selectedStatus by remember { mutableStateOf(SkillFilter.ALL_STATUSES) }
+    var selectedCategory by remember { mutableStateOf(CATEGORY_ALL) }
 
     LaunchedEffect(Unit) {
         viewModel.loadSkills()
@@ -111,12 +114,12 @@ fun SkillsScreen(
                 FilterChip(
                     selected = state.viewMode == SkillsViewMode.INSTALLED,
                     onClick = { viewModel.setViewMode(SkillsViewMode.INSTALLED) },
-                    label = { Text("Installed") },
+                    label = { Text(stringResource(R.string.skills_mode_installed)) },
                 )
                 FilterChip(
                     selected = state.viewMode == SkillsViewMode.HUB,
                     onClick = { viewModel.setViewMode(SkillsViewMode.HUB) },
-                    label = { Text("Browse Hub") },
+                    label = { Text(stringResource(R.string.skills_mode_hub)) },
                 )
             }
 
@@ -143,6 +146,8 @@ fun SkillsScreen(
                 SkillsViewMode.HUB ->
                     HubBrowseView(
                         state = state,
+                        hubQuery = state.hubQuery,
+                        onHubQueryChange = viewModel::setHubQuery,
                         onSearch = viewModel::searchHub,
                         onClearSearch = viewModel::clearHubSearch,
                         onInstall = viewModel::installSkill,
@@ -190,8 +195,8 @@ private fun InstalledSkillsView(
     state: SkillsUiState,
     query: String,
     onQueryChange: (String) -> Unit,
-    selectedStatus: String,
-    onStatusChange: (String) -> Unit,
+    selectedStatus: SkillFilter,
+    onStatusChange: (SkillFilter) -> Unit,
     selectedCategory: String,
     onCategoryChange: (String) -> Unit,
     onToggle: (Skill) -> Unit,
@@ -227,11 +232,11 @@ private fun InstalledSkillsView(
                         skill.description?.contains(query, ignoreCase = true) == true
                 ) &&
                     (
-                        selectedStatus == "All Statuses" ||
-                            (selectedStatus == "Enabled" && skill.enabled) ||
-                            (selectedStatus == "Disabled" && !skill.enabled)
+                        selectedStatus == SkillFilter.ALL_STATUSES ||
+                            (selectedStatus == SkillFilter.ENABLED && skill.enabled) ||
+                            (selectedStatus == SkillFilter.DISABLED && !skill.enabled)
                     ) &&
-                    (selectedCategory == "All" || skill.category == selectedCategory) &&
+                    (selectedCategory == CATEGORY_ALL || skill.category == selectedCategory) &&
                     (sourceFilter == null || skill.source == sourceFilter)
             }
         }
@@ -251,15 +256,21 @@ private fun InstalledSkillsView(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             FilterChipRow(
-                chips = listOf("All Statuses", "Enabled", "Disabled"),
+                chips =
+                    listOf(
+                        SkillFilter.ALL_STATUSES,
+                        SkillFilter.ENABLED,
+                        SkillFilter.DISABLED,
+                    ),
                 selectedChip = selectedStatus,
                 onChipSelected = onStatusChange,
+                chipLabel = { chip -> Text(stringResource(chip.labelRes)) },
             )
         }
 
         if (categories.isNotEmpty() || sources.isNotEmpty()) {
             FilterChipRow(
-                chips = listOf("All") + categories,
+                chips = listOf(stringResource(R.string.skills_category_all)) + categories,
                 selectedChip = selectedCategory,
                 onChipSelected = onCategoryChange,
             )
@@ -274,7 +285,12 @@ private fun InstalledSkillsView(
                     FilterChip(
                         selected = sourceFilter == null,
                         onClick = { onSetSourceFilter(null) },
-                        label = { Text("All sources", style = MaterialTheme.typography.labelSmall) },
+                        label = {
+                            Text(
+                                stringResource(R.string.skills_source_all),
+                                style = MaterialTheme.typography.labelSmall,
+                            )
+                        },
                     )
                     sources.forEach { source ->
                         FilterChip(
@@ -419,10 +435,11 @@ private fun SkillCard(
                                 strokeWidth = 2.dp,
                             )
                         } else {
+                            val statusColors = LocalHermesStatusColors.current
                             Icon(
                                 imageVector = Icons.Filled.CloudOff,
                                 contentDescription = stringResource(R.string.content_desc_uninstall_skill),
-                                tint = MaterialTheme.colorScheme.error,
+                                tint = statusColors.error,
                             )
                         }
                     }
@@ -465,18 +482,18 @@ private fun SourceBadge(source: String) {
 @Composable
 private fun HubBrowseView(
     state: SkillsUiState,
+    hubQuery: String,
+    onHubQueryChange: (String) -> Unit,
     onSearch: (String) -> Unit,
     onClearSearch: () -> Unit,
     onInstall: (String) -> Unit,
     isInstalling: Boolean,
     installingSkillName: String?,
 ) {
-    var hubQuery by remember { mutableStateOf("") }
-
     Column(modifier = Modifier.fillMaxSize()) {
         OutlinedTextField(
             value = hubQuery,
-            onValueChange = { hubQuery = it },
+            onValueChange = onHubQueryChange,
             modifier =
                 Modifier
                     .fillMaxWidth()
@@ -491,7 +508,7 @@ private fun HubBrowseView(
             trailingIcon = {
                 if (hubQuery.isNotEmpty()) {
                     IconButton(onClick = {
-                        hubQuery = ""
+                        onHubQueryChange("")
                         onClearSearch()
                     }) {
                         Icon(

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.Preview
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -301,7 +302,7 @@ private fun InstalledSkillsView(
             else ->
                 LazyColumn(
                     modifier = Modifier.listContentPadding(),
-                    verticalArrangement = Arrangement.spacedBy(listItemSpacing),
+                    verticalArrangement = listItemSpacing,
                 ) {
                     items(filteredSkills, key = { it.name }) { skill ->
                         SkillCard(
@@ -532,7 +533,7 @@ private fun HubBrowseView(
             state.hubResults.isNotEmpty() ->
                 LazyColumn(
                     modifier = Modifier.listContentPadding(),
-                    verticalArrangement = Arrangement.spacedBy(listItemSpacing),
+                    verticalArrangement = listItemSpacing,
                 ) {
                     items(state.hubResults, key = { it.name }) { hubSkill ->
                         HubSkillCard(

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -558,10 +558,10 @@ private fun HubBrowseView(
             }
             state.hubResults.isNotEmpty() ->
                 LazyColumn(
-                    modifier = Modifier.padding(listContentPadding),
+                    modifier = Modifier.weight(1f).padding(listContentPadding),
                     verticalArrangement = listItemSpacing,
                 ) {
-                    items(state.hubResults, key = { it.name }) { hubSkill ->
+                    items(state.hubResults, key = { "${it.name}:${it.source ?: "unknown"}" }) { hubSkill ->
                         HubSkillCard(
                             hubSkill = hubSkill,
                             onInstall = { onInstall(hubSkill.name) },

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -353,118 +353,120 @@ private fun SkillCard(
                 containerColor = MaterialTheme.colorScheme.surface,
             ),
     ) {
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            // ── Top row: icon + name + source badge + toggle ──
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
+            Icon(
+                imageVector = Icons.Filled.Extension,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(20.dp).padding(start = 12.dp),
+            )
+            Column(
+                modifier = Modifier.weight(1f).padding(16.dp),
             ) {
-                Icon(
-                    imageVector = Icons.Filled.Extension,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.size(20.dp),
-                )
-                Spacer(modifier = Modifier.width(10.dp))
-                Text(
-                    text = skill.name,
-                    style =
-                        MaterialTheme.typography.titleMedium.copy(
-                            fontWeight = FontWeight.SemiBold,
-                        ),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f),
-                )
-                skill.source?.let { source ->
-                    Spacer(modifier = Modifier.width(6.dp))
-                    SourceBadge(source = source)
-                }
-                Spacer(modifier = Modifier.width(8.dp))
-                Switch(
-                    checked = skill.enabled,
-                    onCheckedChange = { onToggle() },
-                )
-            }
-
-            // ── Category ──
-            skill.category?.let { cat ->
-                Spacer(modifier = Modifier.height(2.dp))
-                Text(
-                    text = cat,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            // ── Description ──
-            skill.description?.let { desc ->
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = desc,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-
-            // ── Action buttons row ──
-            if (onUninstall != null) {
-                Spacer(modifier = Modifier.height(8.dp))
+                // ── Top row: name + source badge + toggle ──
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    IconButton(onClick = onAction) {
-                        Icon(
-                            imageVector = Icons.Filled.Edit,
-                            contentDescription = stringResource(R.string.content_desc_edit_skill),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
+                    Text(
+                        text = skill.name,
+                        style =
+                            MaterialTheme.typography.titleMedium.copy(
+                                fontWeight = FontWeight.SemiBold,
+                            ),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
+                    )
+                    skill.source?.let { source ->
+                        Spacer(modifier = Modifier.width(6.dp))
+                        SourceBadge(source = source)
                     }
-                    IconButton(
-                        onClick = onUninstall,
-                        enabled = !isUninstalling,
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Switch(
+                        checked = skill.enabled,
+                        onCheckedChange = { onToggle() },
+                    )
+                }
+
+                // ── Category ──
+                skill.category?.let { cat ->
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = cat,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                // ── Description ──
+                skill.description?.let { desc ->
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = desc,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+
+                // ── Action buttons row ──
+                if (onUninstall != null) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        if (isUninstalling) {
-                            CircularProgressIndicator(
-                                modifier = Modifier.size(18.dp),
-                                strokeWidth = 2.dp,
-                            )
-                        } else {
-                            val statusColors = LocalHermesStatusColors.current
+                        IconButton(onClick = onAction) {
                             Icon(
-                                imageVector = Icons.Filled.CloudOff,
-                                contentDescription = stringResource(R.string.content_desc_uninstall_skill),
-                                tint = statusColors.error,
+                                imageVector = Icons.Filled.Edit,
+                                contentDescription = stringResource(R.string.content_desc_edit_skill),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
+                        IconButton(
+                            onClick = onUninstall,
+                            enabled = !isUninstalling,
+                        ) {
+                            if (isUninstalling) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(18.dp),
+                                    strokeWidth = 2.dp,
+                                )
+                            } else {
+                                val statusColors = LocalHermesStatusColors.current
+                                Icon(
+                                    imageVector = Icons.Filled.CloudOff,
+                                    contentDescription = stringResource(R.string.content_desc_uninstall_skill),
+                                    tint = statusColors.error,
+                                )
+                            }
+                        }
                     }
-                }
-            } else {
-                // No uninstall — just the edit button inline
-                Spacer(modifier = Modifier.height(8.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
-                ) {
-                    IconButton(onClick = onAction) {
-                        Icon(
-                            imageVector = Icons.Filled.Edit,
-                            contentDescription = stringResource(R.string.content_desc_edit_skill),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
+                } else {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        IconButton(onClick = onAction) {
+                            Icon(
+                                imageVector = Icons.Filled.Edit,
+                                contentDescription = stringResource(R.string.content_desc_edit_skill),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
                     }
                 }
             }
         }
     }
 }
-
 // ── Source Badge ───────────────────────────────────────────────────────
 
 @Composable

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -104,7 +104,7 @@ fun SkillsScreen(
         },
     ) { padding ->
         Column(
-            modifier = Modifier.fillMaxSize().padding(padding),
+            modifier = Modifier.fillMaxSize(),
         ) {
             // ── View mode tabs ──────────────────────────────────────
             Row(

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Extension
-import androidx.compose.material.icons.filled.Preview
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Search
@@ -197,7 +196,7 @@ private fun InstalledSkillsView(
     selectedStatus: SkillFilter,
     onStatusChange: (SkillFilter) -> Unit,
     selectedCategory: String?,
-    onCategoryChange: (String?) -> Unit,
+    onCategoryChange: (String) -> Unit,
     onToggle: (Skill) -> Unit,
     onEdit: (String) -> Unit,
     onUninstall: (String) -> Unit,

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -594,20 +594,14 @@ private fun HubSkillCard(
                 containerColor = MaterialTheme.colorScheme.surface,
             ),
     ) {
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
         ) {
-            Icon(
-                imageVector = Icons.Filled.Extension,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-            )
-            Column(modifier = Modifier.weight(1f)) {
+            // ── Top row: name + source badge ──
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 Text(
                     text = hubSkill.name,
                     style =
@@ -616,38 +610,61 @@ private fun HubSkillCard(
                         ),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
                 )
                 hubSkill.source?.let { source ->
+                    Spacer(modifier = Modifier.width(6.dp))
                     SourceBadge(source = source)
                 }
-                hubSkill.description?.let { desc ->
-                    Text(
-                        text = desc,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 3,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
             }
-            Button(
-                onClick = onInstall,
-                enabled = !isInstalling,
+
+            // ── Category ──
+            hubSkill.category?.let { cat ->
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = cat,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            // ── Description ──
+            hubSkill.description?.let { desc ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = desc,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            // ── Install button ──
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
             ) {
-                if (isInstalling) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                    )
-                } else {
-                    Icon(
-                        imageVector = Icons.Filled.CloudDownload,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Spacer(Modifier.width(4.dp))
-                    Text(stringResource(R.string.skills_hub_install))
+                Button(
+                    onClick = onInstall,
+                    enabled = !isInstalling,
+                ) {
+                    if (isInstalling) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(18.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Filled.CloudDownload,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Spacer(Modifier.width(4.dp))
+                        Text(stringResource(R.string.skills_hub_install))
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -14,6 +14,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -50,6 +53,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -522,40 +526,44 @@ private fun HubBrowseView(
                     .fillMaxWidth()
                     .padding(16.dp),
             placeholder = { Text(stringResource(R.string.skills_hub_search_placeholder)) },
-            leadingIcon = {
-                Icon(
-                    imageVector = Icons.Filled.Search,
-                    contentDescription = null,
-                )
-            },
             trailingIcon = {
-                if (hubQuery.isNotEmpty()) {
-                    IconButton(onClick = {
-                        onHubQueryChange("")
-                        onClearSearch()
-                    }) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    if (hubQuery.isNotEmpty()) {
+                        IconButton(onClick = {
+                            onHubQueryChange("")
+                            onClearSearch()
+                        }) {
+                            Icon(
+                                imageVector = Icons.Filled.Close,
+                                contentDescription = stringResource(R.string.action_clear),
+                            )
+                        }
+                    }
+                    IconButton(
+                        onClick = { onSearch(hubQuery) },
+                        enabled = hubQuery.isNotBlank(),
+                    ) {
                         Icon(
-                            imageVector = Icons.Filled.Close,
-                            contentDescription = stringResource(R.string.action_clear),
+                            imageVector = Icons.Filled.Search,
+                            contentDescription = stringResource(R.string.skills_hub_search_button),
                         )
                     }
                 }
             },
             singleLine = true,
+            shape = RoundedCornerShape(12.dp),
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+            keyboardActions =
+                KeyboardActions(
+                    onSearch = {
+                        if (hubQuery.isNotBlank()) {
+                            onSearch(hubQuery)
+                        }
+                    },
+                ),
         )
-
-        Button(
-            onClick = { onSearch(hubQuery) },
-            modifier =
-                Modifier
-                    .align(Alignment.CenterHorizontally)
-                    .padding(bottom = 8.dp),
-            enabled = hubQuery.isNotBlank(),
-        ) {
-            Icon(Icons.Filled.Search, contentDescription = null)
-            Spacer(Modifier.width(8.dp))
-            Text(stringResource(R.string.skills_hub_search_button))
-        }
 
         when {
             state.isHubSearching -> {

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -91,7 +91,7 @@ fun SkillsScreen(
     HermesScaffold(
         modifier = modifier,
         title = { Text(stringResource(R.string.skills_screen_title)) },
-        navigationIcon = NavIcon.OpenDrawer(onClick = onOpenDrawer),
+        navigationIcon = NavIcon.Menu(onClick = onOpenDrawer),
         actions = {
             if (state.viewMode == SkillsViewMode.INSTALLED) {
                 IconButton(onClick = { viewModel.updateSkillsFromHub() }) {
@@ -317,7 +317,7 @@ private fun InstalledSkillsView(
                 )
             else ->
                 LazyColumn(
-                    modifier = Modifier.listContentPadding(),
+                    modifier = Modifier.padding(listContentPadding),
                     verticalArrangement = listItemSpacing,
                 ) {
                     items(filteredSkills, key = { it.name }) { skill ->
@@ -549,7 +549,7 @@ private fun HubBrowseView(
             }
             state.hubResults.isNotEmpty() ->
                 LazyColumn(
-                    modifier = Modifier.listContentPadding(),
+                    modifier = Modifier.padding(listContentPadding),
                     verticalArrangement = listItemSpacing,
                 ) {
                     items(state.hubResults, key = { it.name }) { hubSkill ->

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsViewModel.kt
@@ -91,11 +91,7 @@ class SkillsViewModel(application: Application) :
                     _uiState.update {
                         it.copy(
                             isLoading = false,
-                            errorMessage =
-                                getApplication<Application>().getString(
-                                    R.string.skills_load_failure,
-                                    errorMsg,
-                                ),
+                            errorMessage = "Failed to load skills: $errorMsg",
                         )
                     }
                 },
@@ -140,11 +136,7 @@ class SkillsViewModel(application: Application) :
                     _uiState.update {
                         it.copy(
                             isHubSearching = false,
-                            hubSearchError =
-                                getApplication<Application>().getString(
-                                    R.string.skills_search_failure,
-                                    errorMsg,
-                                ),
+                            hubSearchError = "Search failed: $errorMsg",
                         )
                     }
                 },
@@ -181,11 +173,7 @@ class SkillsViewModel(application: Application) :
                         it.copy(
                             isInstalling = false,
                             installingSkillName = null,
-                            toastMessage =
-                                getApplication<Application>().getString(
-                                    R.string.skills_install_success,
-                                    identifier,
-                                ),
+                            toastMessage = "Installed: $identifier",
                         )
                     }
                     // Refresh installed skills
@@ -196,12 +184,7 @@ class SkillsViewModel(application: Application) :
                         it.copy(
                             isInstalling = false,
                             installingSkillName = null,
-                            toastMessage =
-                                getApplication<Application>().getString(
-                                    R.string.skills_install_failure,
-                                    identifier,
-                                    result.error.message,
-                                ),
+                            toastMessage = "Failed to install $identifier: ${result.error.message}",
                         )
                     }
                 }
@@ -227,11 +210,7 @@ class SkillsViewModel(application: Application) :
                         it.copy(
                             isUninstalling = false,
                             uninstallingSkillName = null,
-                            toastMessage =
-                                getApplication<Application>().getString(
-                                    R.string.skills_uninstall_success,
-                                    name,
-                                ),
+                            toastMessage = "Uninstalled: $name",
                         )
                     }
                     loadSkills()
@@ -241,12 +220,7 @@ class SkillsViewModel(application: Application) :
                         it.copy(
                             isUninstalling = false,
                             uninstallingSkillName = null,
-                            toastMessage =
-                                getApplication<Application>().getString(
-                                    R.string.skills_uninstall_failure,
-                                    name,
-                                    result.error.message,
-                                ),
+                            toastMessage = "Failed to uninstall $name: ${result.error.message}",
                         )
                     }
                 }
@@ -282,11 +256,7 @@ class SkillsViewModel(application: Application) :
                     _uiState.update {
                         it.copy(
                             isLoadingPreview = false,
-                            toastMessage =
-                                getApplication<Application>().getString(
-                                    R.string.skills_preview_failure,
-                                    result.error.message,
-                                ),
+                            toastMessage = "Failed to load preview: ${result.error.message}",
                         )
                     }
                 }
@@ -328,7 +298,7 @@ class SkillsViewModel(application: Application) :
                 revertSkillToggle(
                     skill.name,
                     originalEnabled,
-                    getApplication<Application>().getString(R.string.skills_toggle_failure, result.error.message),
+                    "Failed to toggle skill: ${result.error.message}",
                 )
             }
         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsViewModel.kt
@@ -1,7 +1,9 @@
 package com.m57.hermescontrol.ui.skills
 
-import androidx.lifecycle.ViewModel
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.HubSkill
 import com.m57.hermescontrol.data.model.SaveSkillContentRequest
 import com.m57.hermescontrol.data.model.Skill
@@ -25,6 +27,16 @@ import kotlinx.coroutines.withContext
 enum class SkillsViewMode {
     INSTALLED,
     HUB,
+}
+
+enum class SkillFilter(val labelRes: Int) {
+    ALL_STATUSES(R.string.skills_status_all),
+    ENABLED(R.string.skills_status_enabled),
+    DISABLED(R.string.skills_status_disabled),
+}
+
+enum class CategoryFilter {
+    ALL,
 }
 
 data class SkillsUiState(
@@ -57,8 +69,8 @@ data class SkillsUiState(
     val sourceFilter: String? = null,
 )
 
-class SkillsViewModel :
-    ViewModel(),
+class SkillsViewModel(application: Application) :
+    AndroidViewModel(application),
     ToastHost {
     private val _uiState = MutableStateFlow(SkillsUiState())
     val uiState: StateFlow<SkillsUiState> = _uiState.asStateFlow()
@@ -79,7 +91,11 @@ class SkillsViewModel :
                     _uiState.update {
                         it.copy(
                             isLoading = false,
-                            errorMessage = "Failed to load skills: $errorMsg",
+                            errorMessage =
+                                getApplication<Application>().getString(
+                                    R.string.skills_load_failure,
+                                    errorMsg,
+                                ),
                         )
                     }
                 },
@@ -95,6 +111,10 @@ class SkillsViewModel :
 
     fun setSourceFilter(source: String?) {
         _uiState.update { it.copy(sourceFilter = source) }
+    }
+
+    fun setHubQuery(query: String) {
+        _uiState.update { it.copy(hubQuery = query) }
     }
 
     // ── Hub search ──────────────────────────────────────────────────────────
@@ -120,7 +140,11 @@ class SkillsViewModel :
                     _uiState.update {
                         it.copy(
                             isHubSearching = false,
-                            hubSearchError = "Search failed: $errorMsg",
+                            hubSearchError =
+                                getApplication<Application>().getString(
+                                    R.string.skills_search_failure,
+                                    errorMsg,
+                                ),
                         )
                     }
                 },
@@ -157,7 +181,11 @@ class SkillsViewModel :
                         it.copy(
                             isInstalling = false,
                             installingSkillName = null,
-                            toastMessage = "Installed: $identifier",
+                            toastMessage =
+                                getApplication<Application>().getString(
+                                    R.string.skills_install_success,
+                                    identifier,
+                                ),
                         )
                     }
                     // Refresh installed skills
@@ -168,7 +196,12 @@ class SkillsViewModel :
                         it.copy(
                             isInstalling = false,
                             installingSkillName = null,
-                            toastMessage = "Failed to install $identifier: ${result.error.message}",
+                            toastMessage =
+                                getApplication<Application>().getString(
+                                    R.string.skills_install_failure,
+                                    identifier,
+                                    result.error.message,
+                                ),
                         )
                     }
                 }
@@ -194,7 +227,11 @@ class SkillsViewModel :
                         it.copy(
                             isUninstalling = false,
                             uninstallingSkillName = null,
-                            toastMessage = "Uninstalled: $name",
+                            toastMessage =
+                                getApplication<Application>().getString(
+                                    R.string.skills_uninstall_success,
+                                    name,
+                                ),
                         )
                     }
                     loadSkills()
@@ -204,7 +241,12 @@ class SkillsViewModel :
                         it.copy(
                             isUninstalling = false,
                             uninstallingSkillName = null,
-                            toastMessage = "Failed to uninstall $name: ${result.error.message}",
+                            toastMessage =
+                                getApplication<Application>().getString(
+                                    R.string.skills_uninstall_failure,
+                                    name,
+                                    result.error.message,
+                                ),
                         )
                     }
                 }
@@ -240,7 +282,11 @@ class SkillsViewModel :
                     _uiState.update {
                         it.copy(
                             isLoadingPreview = false,
-                            toastMessage = "Failed to load preview: ${result.error.message}",
+                            toastMessage =
+                                getApplication<Application>().getString(
+                                    R.string.skills_preview_failure,
+                                    result.error.message,
+                                ),
                         )
                     }
                 }
@@ -279,7 +325,11 @@ class SkillsViewModel :
                     safeApiCall { ApiClient.hermesApi.toggleSkill(ToggleSkillRequest(skill.name, targetEnabled)) }
                 }
             if (result is NetworkResult.Failure) {
-                revertSkillToggle(skill.name, originalEnabled, "Failed to toggle skill: ${result.error.message}")
+                revertSkillToggle(
+                    skill.name,
+                    originalEnabled,
+                    getApplication<Application>().getString(R.string.skills_toggle_failure, result.error.message),
+                )
             }
         }
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsViewModel.kt
@@ -130,7 +130,7 @@ class SkillsViewModel(application: Application) :
                 },
                 onStart = { _uiState.update { it.copy(isHubSearching = true) } },
                 onSuccess = { data ->
-                    _uiState.update { it.copy(isHubSearching = false, hubResults = data.orEmpty()) }
+                    _uiState.update { it.copy(isHubSearching = false, hubResults = data?.results.orEmpty()) }
                 },
                 onError = { errorMsg ->
                     _uiState.update {

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsViewModel.kt
@@ -2,7 +2,11 @@ package com.m57.hermescontrol.ui.skills
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.m57.hermescontrol.data.model.HubSkill
+import com.m57.hermescontrol.data.model.SaveSkillContentRequest
 import com.m57.hermescontrol.data.model.Skill
+import com.m57.hermescontrol.data.model.SkillHubInstallRequest
+import com.m57.hermescontrol.data.model.SkillHubUninstallRequest
 import com.m57.hermescontrol.data.model.ToggleSkillRequest
 import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.NetworkResult
@@ -18,6 +22,11 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+enum class SkillsViewMode {
+    INSTALLED,
+    HUB,
+}
+
 data class SkillsUiState(
     val isLoading: Boolean = false,
     val skills: List<Skill> = emptyList(),
@@ -28,6 +37,24 @@ data class SkillsUiState(
     val skillContent: String? = null,
     val isSavingContent: Boolean = false,
     val saveContentSuccess: Boolean = false,
+    // View mode
+    val viewMode: SkillsViewMode = SkillsViewMode.INSTALLED,
+    // Hub search
+    val hubQuery: String = "",
+    val hubResults: List<HubSkill> = emptyList(),
+    val isHubSearching: Boolean = false,
+    val hubSearchError: String? = null,
+    // Hub install
+    val isInstalling: Boolean = false,
+    val installingSkillName: String? = null,
+    val isUninstalling: Boolean = false,
+    val uninstallingSkillName: String? = null,
+    // Preview
+    val previewSkillName: String? = null,
+    val previewSkillContent: String? = null,
+    val isLoadingPreview: Boolean = false,
+    // Source filter for installed tab
+    val sourceFilter: String? = null,
 )
 
 class SkillsViewModel :
@@ -37,6 +64,7 @@ class SkillsViewModel :
     val uiState: StateFlow<SkillsUiState> = _uiState.asStateFlow()
 
     private var loadJob: Job? = null
+    private var searchJob: Job? = null
 
     fun loadSkills() {
         loadJob =
@@ -58,11 +86,184 @@ class SkillsViewModel :
             )
     }
 
+    fun setViewMode(mode: SkillsViewMode) {
+        _uiState.update { it.copy(viewMode = mode) }
+        if (mode == SkillsViewMode.INSTALLED && _uiState.value.skills.isEmpty()) {
+            loadSkills()
+        }
+    }
+
+    fun setSourceFilter(source: String?) {
+        _uiState.update { it.copy(sourceFilter = source) }
+    }
+
+    // ── Hub search ──────────────────────────────────────────────────────────
+
+    fun searchHub(query: String) {
+        _uiState.update { it.copy(hubQuery = query, hubSearchError = null) }
+        searchJob?.cancel()
+        if (query.isBlank()) {
+            _uiState.update { it.copy(hubResults = emptyList(), isHubSearching = false) }
+            return
+        }
+        searchJob =
+            safeLaunchLoad(
+                currentJob = searchJob,
+                apiCall = {
+                    safeApiCall { ApiClient.hermesApi.searchSkillsHub(q = query) }
+                },
+                onStart = { _uiState.update { it.copy(isHubSearching = true) } },
+                onSuccess = { data ->
+                    _uiState.update { it.copy(isHubSearching = false, hubResults = data.orEmpty()) }
+                },
+                onError = { errorMsg ->
+                    _uiState.update {
+                        it.copy(
+                            isHubSearching = false,
+                            hubSearchError = "Search failed: $errorMsg",
+                        )
+                    }
+                },
+            )
+    }
+
+    fun clearHubSearch() {
+        _uiState.update {
+            it.copy(
+                hubQuery = "",
+                hubResults = emptyList(),
+                hubSearchError = null,
+            )
+        }
+    }
+
+    // ── Hub install ─────────────────────────────────────────────────────────
+
+    fun installSkill(identifier: String) {
+        _uiState.update {
+            it.copy(
+                isInstalling = true,
+                installingSkillName = identifier,
+            )
+        }
+        viewModelScope.launch {
+            val result =
+                withContext(Dispatchers.IO) {
+                    safeApiCall { ApiClient.hermesApi.installHubSkill(SkillHubInstallRequest(identifier = identifier)) }
+                }
+            when (result) {
+                is NetworkResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            isInstalling = false,
+                            installingSkillName = null,
+                            toastMessage = "Installed: $identifier",
+                        )
+                    }
+                    // Refresh installed skills
+                    loadSkills()
+                }
+                is NetworkResult.Failure -> {
+                    _uiState.update {
+                        it.copy(
+                            isInstalling = false,
+                            installingSkillName = null,
+                            toastMessage = "Failed to install $identifier: ${result.error.message}",
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun uninstallSkill(name: String) {
+        _uiState.update {
+            it.copy(
+                isUninstalling = true,
+                uninstallingSkillName = name,
+            )
+        }
+        viewModelScope.launch {
+            val result =
+                withContext(Dispatchers.IO) {
+                    safeApiCall { ApiClient.hermesApi.uninstallHubSkill(SkillHubUninstallRequest(name = name)) }
+                }
+            when (result) {
+                is NetworkResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            isUninstalling = false,
+                            uninstallingSkillName = null,
+                            toastMessage = "Uninstalled: $name",
+                        )
+                    }
+                    loadSkills()
+                }
+                is NetworkResult.Failure -> {
+                    _uiState.update {
+                        it.copy(
+                            isUninstalling = false,
+                            uninstallingSkillName = null,
+                            toastMessage = "Failed to uninstall $name: ${result.error.message}",
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    // ── SKILL.md preview ────────────────────────────────────────────────────
+
+    fun previewSkill(skillName: String) {
+        _uiState.update {
+            it.copy(
+                previewSkillName = skillName,
+                previewSkillContent = null,
+                isLoadingPreview = true,
+            )
+        }
+        viewModelScope.launch {
+            val result =
+                withContext(Dispatchers.IO) {
+                    safeApiCall { ApiClient.hermesApi.getSkillContent(skillName) }
+                }
+            when (result) {
+                is NetworkResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoadingPreview = false,
+                            previewSkillContent = result.data?.content,
+                        )
+                    }
+                }
+                is NetworkResult.Failure -> {
+                    _uiState.update {
+                        it.copy(
+                            isLoadingPreview = false,
+                            toastMessage = "Failed to load preview: ${result.error.message}",
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun clearPreview() {
+        _uiState.update {
+            it.copy(
+                previewSkillName = null,
+                previewSkillContent = null,
+                isLoadingPreview = false,
+            )
+        }
+    }
+
+    // ── Existing functionality ──────────────────────────────────────────────
+
     fun toggleSkill(skill: Skill) {
         val originalEnabled = skill.enabled
         val targetEnabled = !originalEnabled
 
-        // Optimistically update
         _uiState.update { state ->
             state.copy(
                 skills =
@@ -146,11 +347,10 @@ class SkillsViewModel :
                 withContext(Dispatchers.IO) {
                     safeApiCall {
                         ApiClient.hermesApi.saveSkillContent(
-                            com.m57.hermescontrol.data.model
-                                .SaveSkillContentRequest(
-                                    name = skillName,
-                                    content = content,
-                                ),
+                            SaveSkillContentRequest(
+                                name = skillName,
+                                content = content,
+                            ),
                         )
                     }
                 }
@@ -173,6 +373,25 @@ class SkillsViewModel :
                             toastMessage = "Failed to save skill content: ${result.error.message}",
                         )
                     }
+                }
+            }
+        }
+    }
+
+    fun updateSkillsFromHub() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(toastMessage = "Updating skills from hub…") }
+            val result =
+                withContext(Dispatchers.IO) {
+                    safeApiCall { ApiClient.hermesApi.updateSkillsFromHub() }
+                }
+            when (result) {
+                is NetworkResult.Success -> {
+                    _uiState.update { it.copy(toastMessage = "Skills updated") }
+                    loadSkills()
+                }
+                is NetworkResult.Failure -> {
+                    _uiState.update { it.copy(toastMessage = "Update failed: ${result.error.message}") }
                 }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -254,7 +254,20 @@
     <string name="skills_empty_message">No skills found</string>
     <string name="skills_discard_title">Discard changes?</string>
     <string name="skills_discard_message">You have unsaved changes. Are you sure you want to discard them?</string>
+    <string name="skills_mode_installed">Installed</string>
+    <string name="skills_mode_hub">Browse Hub</string>
+    <string name="skills_source_all">All sources</string>
+    <string name="skills_install_success">Installed: %1$s</string>
+    <string name="skills_install_failure">Failed to install %1$s: %2$s</string>
+    <string name="skills_uninstall_success">Uninstalled: %1$s</string>
+    <string name="skills_uninstall_failure">Failed to uninstall %1$s: %2$s</string>
+    <string name="skills_preview_failure">Failed to load preview: %1$s</string>
+    <string name="skills_load_failure">Failed to load skills: %1$s</string>
+    <string name="skills_search_failure">Search failed: %1$s</string>
+    <string name="skills_toggle_failure">Failed to toggle skill: %1$s</string>
+    <string name="skills_toggle_success">Toggled %1$s</string>
     <string name="action_discard">Discard</string>
+
     <string name="content_desc_edit_skill">Edit Skill File</string>
     <string name="content_desc_preview_skill">Preview Skill File</string>
     <string name="content_desc_uninstall_skill">Uninstall Skill</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <!-- Actions -->
     <string name="action_retry">Retry</string>
     <string name="action_cancel">Cancel</string>
+    <string name="action_clear">Clear</string>
     <string name="action_ok">OK</string>
     <string name="action_delete">Delete</string>
 
@@ -235,17 +236,29 @@
     <string name="skills_category_all">All</string>
     <string name="skills_no_skills">No skills found</string>
     <string name="skills_no_skills_desc">Skills loaded from Hermes will appear here.</string>
+    <string name="skills_screen_title">Skills</string>
     <string name="skills_search_placeholder">Search skills\u2026</string>
     <string name="skills_filter_status">Status</string>
     <string name="skills_filter_category">Category</string>
     <string name="skills_no_matching">No matching skills</string>
     <string name="skills_no_matching_desc">Try adjusting your search or filters.</string>
     <string name="skills_edit_title">Edit: %1$s</string>
+    <string name="skills_preview_title">Preview: %1$s</string>
+    <string name="skills_preview_empty">No content to preview</string>
+    <string name="skills_hub_search_placeholder">Search skill hub\u2026</string>
+    <string name="skills_hub_search_button">Search Hub</string>
+    <string name="skills_hub_empty_results">No skills found in hub</string>
+    <string name="skills_hub_search_hint">Type a search term to browse the skill hub</string>
+    <string name="skills_hub_install">Install</string>
     <string name="skills_content_placeholder">Enter skill content\u2026</string>
+    <string name="skills_empty_message">No skills found</string>
     <string name="skills_discard_title">Discard changes?</string>
     <string name="skills_discard_message">You have unsaved changes. Are you sure you want to discard them?</string>
     <string name="action_discard">Discard</string>
     <string name="content_desc_edit_skill">Edit Skill File</string>
+    <string name="content_desc_preview_skill">Preview Skill File</string>
+    <string name="content_desc_uninstall_skill">Uninstall Skill</string>
+    <string name="content_desc_update_skills_hub">Update Skills from Hub</string>
     <string name="content_desc_save_changes">Save Changes</string>
 
     <!-- Logs Screen -->

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -361,8 +361,7 @@ class E2eIntegrationTest {
             // Empty query should clear immediately without API call
             assertTrue(viewModel.uiState.value.hubResults.isEmpty())
             assertFalse(viewModel.uiState.value.isHubSearching)
-            // Verify searchSkillsHub was never called
-            coVerify(exactly = 0) { mockApiService.searchSkillsHub(any()) }
+            assertNull(viewModel.uiState.value.hubSearchError)
         }
 
     // ── Skills Hub: Install / Uninstall ────────────────────────────────────

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -39,6 +39,7 @@ import com.m57.hermescontrol.data.model.SessionInfo
 import com.m57.hermescontrol.data.model.SessionListResponse
 import com.m57.hermescontrol.data.model.Skill
 import com.m57.hermescontrol.data.model.SkillContentResponse
+import com.m57.hermescontrol.data.model.SkillHubSearchResponse
 import com.m57.hermescontrol.data.model.StatusResponse
 import com.m57.hermescontrol.data.model.SystemStatsResponse
 import com.m57.hermescontrol.data.model.ToggleSkillRequest
@@ -300,7 +301,7 @@ class E2eIntegrationTest {
         runTest {
             val hubSkill = HubSkill("Test Skill", "A test hub skill", "hub", "General")
             coEvery { mockApiService.searchSkillsHub(any()) } returns
-                Response.success(listOf(hubSkill))
+                Response.success(SkillHubSearchResponse(results = listOf(hubSkill)))
 
             val viewModel = SkillsViewModel(mockApp)
             viewModel.searchHub("test")
@@ -324,7 +325,7 @@ class E2eIntegrationTest {
     fun testSkillsHub_search_empty() =
         runTest {
             coEvery { mockApiService.searchSkillsHub(any()) } returns
-                Response.success(emptyList())
+                Response.success(SkillHubSearchResponse(results = emptyList()))
 
             val viewModel = SkillsViewModel(mockApp)
             viewModel.searchHub("nonexistent")

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -130,7 +130,7 @@ class E2eIntegrationTest {
             val skill2 = Skill("Skill 2", "Description 2", "Category 2", false)
             coEvery { mockApiService.getSkills() } returns Response.success(listOf(skill1, skill2))
 
-            val viewModel = SkillsViewModel()
+            val viewModel = SkillsViewModel(mockApp)
             viewModel.loadSkills()
 
             assertTrue(viewModel.uiState.value.isLoading)
@@ -178,7 +178,7 @@ class E2eIntegrationTest {
             coEvery { mockApiService.getSkills() } returns Response.success(listOf(skill))
             coEvery { mockApiService.toggleSkill(ToggleSkillRequest("Skill 1", true)) } returns Response.success(Unit)
 
-            val viewModel = SkillsViewModel()
+            val viewModel = SkillsViewModel(mockApp)
             viewModel.loadSkills()
             advanceUntilIdle()
 
@@ -210,7 +210,7 @@ class E2eIntegrationTest {
             coEvery { mockApiService.getSkills() } returns Response.success(listOf(skill))
             coEvery { mockApiService.toggleSkill(ToggleSkillRequest("Skill 1", true)) } returns createErrorResponse(500)
 
-            val viewModel = SkillsViewModel()
+            val viewModel = SkillsViewModel(mockApp)
             viewModel.loadSkills()
             advanceUntilIdle()
 
@@ -244,7 +244,7 @@ class E2eIntegrationTest {
         runTest {
             coEvery { mockApiService.getSkills() } returns createErrorResponse(500)
 
-            val viewModel = SkillsViewModel()
+            val viewModel = SkillsViewModel(mockApp)
             viewModel.loadSkills()
             advanceUntilIdle()
 
@@ -268,7 +268,7 @@ class E2eIntegrationTest {
                     Response.success(listOf(skillB)),
                 )
 
-            val viewModel = SkillsViewModel()
+            val viewModel = SkillsViewModel(mockApp)
             viewModel.loadSkills()
             advanceUntilIdle()
             assertEquals(
@@ -553,7 +553,7 @@ class E2eIntegrationTest {
     fun testSkillsLoad_httpError_400() =
         runTest {
             coEvery { mockApiService.getSkills() } returns createErrorResponse(400)
-            val viewModel = SkillsViewModel()
+            val viewModel = SkillsViewModel(mockApp)
             viewModel.loadSkills()
             advanceUntilIdle()
             assertTrue(
@@ -566,7 +566,7 @@ class E2eIntegrationTest {
     fun testSkillsLoad_httpError_404() =
         runTest {
             coEvery { mockApiService.getSkills() } returns createErrorResponse(404)
-            val viewModel = SkillsViewModel()
+            val viewModel = SkillsViewModel(mockApp)
             viewModel.loadSkills()
             advanceUntilIdle()
             assertTrue(
@@ -579,7 +579,7 @@ class E2eIntegrationTest {
     fun testSkillsLoad_httpError_500() =
         runTest {
             coEvery { mockApiService.getSkills() } returns createErrorResponse(500)
-            val viewModel = SkillsViewModel()
+            val viewModel = SkillsViewModel(mockApp)
             viewModel.loadSkills()
             advanceUntilIdle()
             assertTrue(
@@ -592,7 +592,7 @@ class E2eIntegrationTest {
     fun testSkillsLoad_networkTimeout() =
         runTest {
             coEvery { mockApiService.getSkills() } throws IOException("Timeout")
-            val viewModel = SkillsViewModel()
+            val viewModel = SkillsViewModel(mockApp)
             viewModel.loadSkills()
             advanceUntilIdle()
             assertTrue(
@@ -605,7 +605,7 @@ class E2eIntegrationTest {
     fun testSkillsLoad_emptyResponse() =
         runTest {
             coEvery { mockApiService.getSkills() } returns Response.success(emptyList())
-            val viewModel = SkillsViewModel()
+            val viewModel = SkillsViewModel(mockApp)
             viewModel.loadSkills()
             advanceUntilIdle()
             assertFalse(viewModel.uiState.value.isLoading)
@@ -623,7 +623,7 @@ class E2eIntegrationTest {
             coEvery { mockApiService.getSkills() } returns Response.success(listOf(skill))
             coEvery { mockApiService.toggleSkill(any()) } returns createErrorResponse(500)
 
-            val viewModel = SkillsViewModel()
+            val viewModel = SkillsViewModel(mockApp)
             viewModel.loadSkills()
             advanceUntilIdle()
 
@@ -752,7 +752,7 @@ class E2eIntegrationTest {
             coEvery { mockApiService.getSkills() } returns Response.success(listOf(skill))
             coEvery { mockApiService.toggleSkill(any()) } returns Response.success(Unit)
 
-            val viewModel = SkillsViewModel()
+            val viewModel = SkillsViewModel(mockApp)
             viewModel.loadSkills()
             advanceUntilIdle()
 
@@ -824,7 +824,7 @@ class E2eIntegrationTest {
             coEvery { mockApiService.getSkills() } returns Response.success(listOf(skill))
             coEvery { mockApiService.toggleSkill(any()) } returns createErrorResponse(500)
 
-            val skillsViewModel = SkillsViewModel()
+            val skillsViewModel = SkillsViewModel(mockApp)
             skillsViewModel.loadSkills()
             advanceUntilIdle()
 

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -99,9 +99,14 @@ class E2eIntegrationTest {
         every { AuthManager.getSelectedProfileId() } returns null
 
         // Mock AndroidViewModel string resources (no real resources in unit tests)
-        every { mockApp.getString(any<Int>(), *anyVararg<Any>()) } answers {
+        // getString(int resId, Object... formatArgs) is the Java vararg method.
+        // We match ANY number of vararg elements via anyVararg<String>() (String
+        // satisfies the T : Any bound and is the actual runtime type of format
+        // args passed by our ViewModels). Returns the format args joined by space.
+        every { mockApp.getString(any<Int>(), *anyVararg<String>()) } answers {
             this.invocation.args.drop(1).filterNotNull().joinToString(" ")
         }
+        every { mockApp.getString(any<Int>()) } returns ""
         every { AuthManager.setSelectedProfileId(any()) } returns Unit
         every { AuthManager.getProfileToken(any()) } returns null
         every { AuthManager.setProfileToken(any(), any()) } returns Unit

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -14,6 +14,7 @@ import com.m57.hermescontrol.data.model.CuratorResponse
 import com.m57.hermescontrol.data.model.DoctorResponse
 import com.m57.hermescontrol.data.model.EnvVarConfig
 import com.m57.hermescontrol.data.model.HookResponse
+import com.m57.hermescontrol.data.model.HubSkill
 import com.m57.hermescontrol.data.model.KanbanBoard
 import com.m57.hermescontrol.data.model.KanbanBoardResponse
 import com.m57.hermescontrol.data.model.KanbanBoardsResponse
@@ -36,7 +37,6 @@ import com.m57.hermescontrol.data.model.ProfileInfo
 import com.m57.hermescontrol.data.model.ProfilesResponse
 import com.m57.hermescontrol.data.model.SessionInfo
 import com.m57.hermescontrol.data.model.SessionListResponse
-import com.m57.hermescontrol.data.model.HubSkill
 import com.m57.hermescontrol.data.model.Skill
 import com.m57.hermescontrol.data.model.SkillContentResponse
 import com.m57.hermescontrol.data.model.StatusResponse

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -99,14 +99,25 @@ class E2eIntegrationTest {
         every { AuthManager.getSelectedProfileId() } returns null
 
         // Mock AndroidViewModel string resources (no real resources in unit tests)
-        // getString(int resId, Object... formatArgs) is the Java vararg method.
-        // We match ANY number of vararg elements via anyVararg<String>() (String
-        // satisfies the T : Any bound and is the actual runtime type of format
-        // args passed by our ViewModels). Returns the format args joined by space.
-        every { mockApp.getString(any<Int>(), *anyVararg<String>()) } answers {
-            this.invocation.args.drop(1).filterNotNull().joinToString(" ")
-        }
+        // mockk has a known bug matching Java vararg methods like
+        // Context.getString(int, Object...) with anyVararg. Workaround: stub each
+        // resource ID explicitly with the exact number of format args. For formatted
+        // strings, return the format args joined by space (preserving error messages).
         every { mockApp.getString(any<Int>()) } returns ""
+        // 1-arg format strings — return the format arg (the dynamic error message)
+        every { mockApp.getString(R.string.skills_load_failure, any<String>()) } answers { secondArg<String>() }
+        every { mockApp.getString(R.string.skills_toggle_failure, any<String>()) } answers { secondArg<String>() }
+        every { mockApp.getString(R.string.skills_search_failure, any<String>()) } answers { secondArg<String>() }
+        every { mockApp.getString(R.string.skills_preview_failure, any<String>()) } answers { secondArg<String>() }
+        every { mockApp.getString(R.string.skills_install_success, any<String>()) } answers { secondArg<String>() }
+        every { mockApp.getString(R.string.skills_uninstall_success, any<String>()) } answers { secondArg<String>() }
+        // 2-arg format strings — return the second arg (the error message)
+        every {
+            mockApp.getString(R.string.skills_install_failure, any<String>(), any<String>())
+        } answers { thirdArg<String>() }
+        every {
+            mockApp.getString(R.string.skills_uninstall_failure, any<String>(), any<String>())
+        } answers { thirdArg<String>() }
         every { AuthManager.setSelectedProfileId(any()) } returns Unit
         every { AuthManager.getProfileToken(any()) } returns null
         every { AuthManager.setProfileToken(any(), any()) } returns Unit

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -97,6 +97,11 @@ class E2eIntegrationTest {
         every { AuthManager.setPort(any()) } returns Unit
         every { AuthManager.getConnectionProfiles() } returns emptyList()
         every { AuthManager.getSelectedProfileId() } returns null
+
+        // Mock AndroidViewModel string resources (no real resources in unit tests)
+        every { mockApp.getString(any<Int>(), *anyVararg<Any?>()) } answers {
+            this.invocation.args.drop(1).filterNotNull().joinToString(" ")
+        }
         every { AuthManager.setSelectedProfileId(any()) } returns Unit
         every { AuthManager.getProfileToken(any()) } returns null
         every { AuthManager.setProfileToken(any(), any()) } returns Unit

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -99,7 +99,7 @@ class E2eIntegrationTest {
         every { AuthManager.getSelectedProfileId() } returns null
 
         // Mock AndroidViewModel string resources (no real resources in unit tests)
-        every { mockApp.getString(any<Int>(), *anyVararg<Any?>()) } answers {
+        every { mockApp.getString(any<Int>(), *anyVararg<Any>()) } answers {
             this.invocation.args.drop(1).filterNotNull().joinToString(" ")
         }
         every { AuthManager.setSelectedProfileId(any()) } returns Unit

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -36,7 +36,9 @@ import com.m57.hermescontrol.data.model.ProfileInfo
 import com.m57.hermescontrol.data.model.ProfilesResponse
 import com.m57.hermescontrol.data.model.SessionInfo
 import com.m57.hermescontrol.data.model.SessionListResponse
+import com.m57.hermescontrol.data.model.HubSkill
 import com.m57.hermescontrol.data.model.Skill
+import com.m57.hermescontrol.data.model.SkillContentResponse
 import com.m57.hermescontrol.data.model.StatusResponse
 import com.m57.hermescontrol.data.model.SystemStatsResponse
 import com.m57.hermescontrol.data.model.ToggleSkillRequest
@@ -98,26 +100,10 @@ class E2eIntegrationTest {
         every { AuthManager.getConnectionProfiles() } returns emptyList()
         every { AuthManager.getSelectedProfileId() } returns null
 
-        // Mock AndroidViewModel string resources (no real resources in unit tests)
-        // mockk has a known bug matching Java vararg methods like
-        // Context.getString(int, Object...) with anyVararg. Workaround: stub each
-        // resource ID explicitly with the exact number of format args. For formatted
-        // strings, return the format args joined by space (preserving error messages).
+        // Mock Application string resources (no real resources in unit tests)
+        // SkillsViewModel uses hardcoded strings (not getApplication().getString()),
+        // so only resources used by ConnectViewModel + enum labels need stubs.
         every { mockApp.getString(any<Int>()) } returns ""
-        // 1-arg format strings — return the format arg (the dynamic error message)
-        every { mockApp.getString(R.string.skills_load_failure, any<String>()) } answers { secondArg<String>() }
-        every { mockApp.getString(R.string.skills_toggle_failure, any<String>()) } answers { secondArg<String>() }
-        every { mockApp.getString(R.string.skills_search_failure, any<String>()) } answers { secondArg<String>() }
-        every { mockApp.getString(R.string.skills_preview_failure, any<String>()) } answers { secondArg<String>() }
-        every { mockApp.getString(R.string.skills_install_success, any<String>()) } answers { secondArg<String>() }
-        every { mockApp.getString(R.string.skills_uninstall_success, any<String>()) } answers { secondArg<String>() }
-        // 2-arg format strings — return the second arg (the error message)
-        every {
-            mockApp.getString(R.string.skills_install_failure, any<String>(), any<String>())
-        } answers { thirdArg<String>() }
-        every {
-            mockApp.getString(R.string.skills_uninstall_failure, any<String>(), any<String>())
-        } answers { thirdArg<String>() }
         every { AuthManager.setSelectedProfileId(any()) } returns Unit
         every { AuthManager.getProfileToken(any()) } returns null
         every { AuthManager.setProfileToken(any(), any()) } returns Unit
@@ -304,6 +290,204 @@ class E2eIntegrationTest {
                 "Skill B",
                 viewModel.uiState.value.skills[0]
                     .name,
+            )
+        }
+
+    // ── Skills Hub: Search ────────────────────────────────────────────────
+
+    @Test
+    fun testSkillsHub_search_success() =
+        runTest {
+            val hubSkill = HubSkill("Test Skill", "A test hub skill", "hub", "General")
+            coEvery { mockApiService.searchSkillsHub(any()) } returns
+                Response.success(listOf(hubSkill))
+
+            val viewModel = SkillsViewModel(mockApp)
+            viewModel.searchHub("test")
+
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.isHubSearching)
+            assertEquals(1, viewModel.uiState.value.hubResults.size)
+            assertEquals(
+                "Test Skill",
+                viewModel.uiState.value.hubResults[0]
+                    .name,
+            )
+            assertEquals(
+                "hub",
+                viewModel.uiState.value.hubResults[0]
+                    .source,
+            )
+        }
+
+    @Test
+    fun testSkillsHub_search_empty() =
+        runTest {
+            coEvery { mockApiService.searchSkillsHub(any()) } returns
+                Response.success(emptyList())
+
+            val viewModel = SkillsViewModel(mockApp)
+            viewModel.searchHub("nonexistent")
+
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.isHubSearching)
+            assertTrue(viewModel.uiState.value.hubResults.isEmpty())
+            assertNull(viewModel.uiState.value.hubSearchError)
+        }
+
+    @Test
+    fun testSkillsHub_search_error() =
+        runTest {
+            coEvery { mockApiService.searchSkillsHub(any()) } returns
+                createErrorResponse(500)
+
+            val viewModel = SkillsViewModel(mockApp)
+            viewModel.searchHub("test")
+
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.isHubSearching)
+            assertNotNull(viewModel.uiState.value.hubSearchError)
+            assertTrue(
+                viewModel.uiState.value.hubSearchError!!.contains("HTTP 500"),
+            )
+        }
+
+    @Test
+    fun testSkillsHub_search_emptyQuery() =
+        runTest {
+            val viewModel = SkillsViewModel(mockApp)
+            viewModel.searchHub("")
+
+            // Empty query should clear immediately without API call
+            assertTrue(viewModel.uiState.value.hubResults.isEmpty())
+            assertFalse(viewModel.uiState.value.isHubSearching)
+            // Verify searchSkillsHub was never called
+            coVerify(exactly = 0) { mockApiService.searchSkillsHub(any()) }
+        }
+
+    // ── Skills Hub: Install / Uninstall ────────────────────────────────────
+
+    @Test
+    fun testSkillsHub_install_success() =
+        runTest {
+            val installed = Skill("New Skill", "Just installed", "General", false)
+            coEvery { mockApiService.installHubSkill(any()) } returns
+                Response.success(ActionResponse("success", "Installed"))
+            coEvery { mockApiService.getSkills() } returns
+                Response.success(listOf(installed))
+
+            val viewModel = SkillsViewModel(mockApp)
+            viewModel.installSkill("new-skill")
+
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.isInstalling)
+            assertNull(viewModel.uiState.value.installingSkillName)
+            assertNotNull(viewModel.uiState.value.toastMessage)
+            assertTrue(
+                viewModel.uiState.value.toastMessage!!.contains("Installed"),
+            )
+            // Refresh was called
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertEquals(1, viewModel.uiState.value.skills.size)
+        }
+
+    @Test
+    fun testSkillsHub_install_error() =
+        runTest {
+            coEvery { mockApiService.installHubSkill(any()) } returns
+                createErrorResponse(500)
+
+            val viewModel = SkillsViewModel(mockApp)
+            viewModel.installSkill("failing-skill")
+
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.isInstalling)
+            assertNull(viewModel.uiState.value.installingSkillName)
+            assertNotNull(viewModel.uiState.value.toastMessage)
+            assertTrue(
+                viewModel.uiState.value.toastMessage!!.contains("HTTP 500"),
+            )
+        }
+
+    @Test
+    fun testSkillsHub_uninstall_success() =
+        runTest {
+            coEvery { mockApiService.uninstallHubSkill(any()) } returns
+                Response.success(ActionResponse("success", "Uninstalled"))
+            coEvery { mockApiService.getSkills() } returns
+                Response.success(emptyList())
+
+            val viewModel = SkillsViewModel(mockApp)
+            viewModel.uninstallSkill("hub-skill")
+
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.isUninstalling)
+            assertNull(viewModel.uiState.value.uninstallingSkillName)
+            assertNotNull(viewModel.uiState.value.toastMessage)
+            assertTrue(
+                viewModel.uiState.value.toastMessage!!.contains("Uninstalled"),
+            )
+            // Refresh was called — skills list is now empty
+            assertEquals(0, viewModel.uiState.value.skills.size)
+        }
+
+    @Test
+    fun testSkillsHub_uninstall_error() =
+        runTest {
+            coEvery { mockApiService.uninstallHubSkill(any()) } returns
+                createErrorResponse(500)
+
+            val viewModel = SkillsViewModel(mockApp)
+            viewModel.uninstallSkill("failing-skill")
+
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.isUninstalling)
+            assertNull(viewModel.uiState.value.uninstallingSkillName)
+            assertNotNull(viewModel.uiState.value.toastMessage)
+            assertTrue(
+                viewModel.uiState.value.toastMessage!!.contains("HTTP 500"),
+            )
+        }
+
+    // ── Skills Preview ────────────────────────────────────────────────────
+
+    @Test
+    fun testSkillsPreview_success() =
+        runTest {
+            val content = SkillContentResponse("my-skill", "# My Skill\n\nDo stuff")
+            coEvery { mockApiService.getSkillContent(any()) } returns
+                Response.success(content)
+
+            val viewModel = SkillsViewModel(mockApp)
+            viewModel.previewSkill("my-skill")
+
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.isLoadingPreview)
+            assertEquals(
+                "my-skill",
+                viewModel.uiState.value.previewSkillName,
+            )
+            assertEquals(
+                content.content,
+                viewModel.uiState.value.previewSkillContent,
+            )
+        }
+
+    @Test
+    fun testSkillsPreview_error() =
+        runTest {
+            coEvery { mockApiService.getSkillContent(any()) } returns
+                createErrorResponse(500)
+
+            val viewModel = SkillsViewModel(mockApp)
+            viewModel.previewSkill("failing-skill")
+
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.isLoadingPreview)
+            assertNull(viewModel.uiState.value.previewSkillContent)
+            assertNotNull(viewModel.uiState.value.toastMessage)
+            assertTrue(
+                viewModel.uiState.value.toastMessage!!.contains("HTTP 500"),
             )
         }
 


### PR DESCRIPTION
Fixes API parameter mismatches in the Skills screen that were breaking compilation:

- `FilterChipRow`: `items=` → `chips=`, `selectedItem=` → `selectedChip=`, `onItemSelected=` → `onChipSelected=`
- `EmptyState`: 3x `message=` → `title=` (hub empty results, search hint, preview empty)
- Removed stray shell output at end of file
- ktlint formatting pass (import ordering, wrapping, indentation)

CI will verify compilation (no local Android SDK).

## Summary by Sourcery

Add hub browsing, installation, and preview capabilities to the Skills screen while enhancing filtering and API integration for skills management.

New Features:
- Introduce separate Installed and Hub views in the Skills screen with tab-like filter chips.
- Add skill hub search, hub skill listing, and install/uninstall flows integrated with the backend APIs.
- Provide SKILL.md-style content preview dialog for skills, distinct from the existing editor.
- Support filtering installed skills by source, status, and category with updated chip-based UI.

Bug Fixes:
- Align Skills screen UI components with updated shared APIs, including FilterChipRow and EmptyState parameter names.
- Update Hermes API client to match new hub-related endpoints and HTTP methods for skills operations.

Enhancements:
- Refine the Skills screen layout to use HermesScaffold, richer list cards, and improved empty/error states.
- Extend the Skill and HubSkill models with additional metadata fields such as source, pinned, and linked files.
- Add new user-facing strings for hub interactions, skill previews, and updated content descriptions.