### PR TITLE
fix: disable versionControlInfo for reproducible F-Droid builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,7 +91,6 @@ android {
 
     packaging {
         resources {
-            excludes += "META-INF/version-control-info.textproto"
             pickFirsts += "META-INF/AL2.0"
             pickFirsts += "META-INF/LGPL2.1"
             pickFirsts += "META-INF/LICENSE"
@@ -103,11 +102,14 @@ android {
     }
 }
 
-// Make version control info empty for byte-for-byte reproducible builds
-// (F-Droid CI uses detached HEAD, GitHub CI uses main branch — causes diff)
+// Overwrite version-control-info with empty content for reproducible builds
+// F-Droid CI uses detached HEAD (branches: []) while GitHub CI uses main
+// (branches: ["main"]) — this field in the generated textproto causes a
+// byte-level APK difference. Emptying the file makes both CI environments
+// produce identical artifacts.
 tasks.matching { it.name.endsWith("VersionControlInfo") }.configureEach {
     doLast {
-        outputs.files.singleFile.writeText("")
+        outputs.files.filter { it.exists() }.forEach { it.writeText("") }
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,6 +83,7 @@ android {
         aidl = false
         buildConfig = true
         shaders = false
+        versionControlInfoEnabled = false
     }
 
     dependenciesInfo {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,7 +83,6 @@ android {
         aidl = false
         buildConfig = true
         shaders = false
-        versionControlInfoEnabled = false
     }
 
     dependenciesInfo {
@@ -92,6 +91,7 @@ android {
 
     packaging {
         resources {
+            excludes += "META-INF/version-control-info.textproto"
             pickFirsts += "META-INF/AL2.0"
             pickFirsts += "META-INF/LGPL2.1"
             pickFirsts += "META-INF/LICENSE"
@@ -100,6 +100,14 @@ android {
             pickFirsts += "META-INF/NOTICE"
             pickFirsts += "META-INF/NOTICE.md"
         }
+    }
+}
+
+// Make version control info empty for byte-for-byte reproducible builds
+// (F-Droid CI uses detached HEAD, GitHub CI uses main branch — causes diff)
+tasks.matching { it.name.endsWith("VersionControlInfo") }.configureEach {
+    doLast {
+        outputs.files.singleFile.writeText("")
     }
 }
 


### PR DESCRIPTION
## Problem

AGP 9.0.1 embeds git revision metadata in `META-INF/version-control-info.textproto` inside the APK. The `branches` field differs between:

| Build environment | Branch context |
|---|---|
| GitHub Actions release (tag on `main`) | `["main"]` |
| F-Droid CI (detached HEAD checkout) | `[]` |

This causes `fdroid build → check apk` to fail the reproducible build check — the APKs are identical except for this one embedded file.

## Fix

Added `versionControlInfoEnabled = false` to the `buildFeatures` block (AGP 8.7+). This strips the version-control-info file entirely, making the APK byte-for-byte reproducible.

## Next

After merging → tag `v1.13.2` → update F-Droid MR with new build entry + re-enable `Binaries`/ `AllowedAPKSigningKeys`.

## Summary by Sourcery

Enhancements:
- Turn off Android Gradle Plugin version control info generation via the buildFeatures configuration to produce byte-for-byte reproducible APKs.