### PR TITLE
fix: R8 minification fails on error_prone annotation missing from Tink

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -37,6 +37,11 @@
 # ── AndroidX Security Crypto ─────────────────────────────────────────────
 -dontwarn androidx.security.crypto.**
 
+# ── Tink / Error Prone ───────────────────────────────────────────────────
+# Tink references com.google.errorprone.annotations.Immutable which isn't
+# shipped as a runtime dependency. Suppress the R8 missing-class error.
+-dontwarn com.google.errorprone.annotations.Immutable
+
 # ── Compose ───────────────────────────────────────────────────────────────
 -dontwarn androidx.compose.**
 


### PR DESCRIPTION
## What

The **Release** workflow fails at the `minifyReleaseWithR8` step because R8 can't resolve `com.google.errorprone.annotations.Immutable` — a compile-time annotation referenced by Tink (`com.google.crypto.tink`) which is pulled in by `androidx.security.crypto`.

## Why

`androidx.security.crypto` → Tink → references `@Immutable` from `error_prone_annotations`, but that annotation lib isn't bundled as a runtime transitive dependency. When R8 tries to resolve all references during minification, it hits a missing class and hard-fails.

## Fix

Added `-dontwarn com.google.errorprone.annotations.Immutable` to `proguard-rules.pro` — tells R8 this is a compile-only annotation that doesn't need to be resolved at runtime.

\~1 line change, 5 lines with the comment for context.

## Summary by Sourcery

Build:
- Add ProGuard rule to ignore com.google.errorprone.annotations.Immutable to prevent R8 minification failures.