### PR TITLE
feat(#480): pass refresh=true on Models pull-to-refresh to re-probe custom providers

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -430,7 +430,9 @@ interface HermesApiService {
     ): Response<Unit>
 
     @GET("api/model/options")
-    suspend fun getModelOptions(): Response<ModelOptionsResponse>
+    suspend fun getModelOptions(
+        @Query("refresh") refresh: Boolean = false,
+    ): Response<ModelOptionsResponse>
 
     @GET("api/model/auxiliary")
     suspend fun getAuxiliaryModels(): Response<AuxiliaryModelsResponse>

--- a/app/src/main/java/com/m57/hermescontrol/ui/model/ModelScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/ModelScreen.kt
@@ -101,7 +101,7 @@ fun ModelScreen(
         title = { Text(stringResource(R.string.screen_models)) },
         navigationIcon = onOpenDrawer?.let { NavIcon.Menu(it) },
         isRefreshing = state.isLoading,
-        onRefresh = { viewModel.loadAll() },
+        onRefresh = { viewModel.loadAll(refresh = true) },
     ) { paddingValues ->
         when {
             state.isLoading && state.providers.isEmpty() -> {

--- a/app/src/main/java/com/m57/hermescontrol/ui/model/ModelViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/ModelViewModel.kt
@@ -76,12 +76,12 @@ class ModelViewModel :
         _uiState.update { it.copy(pinnedModels = AuthManager.getPinnedModels()) }
     }
 
-    fun loadAll() {
+    fun loadAll(refresh: Boolean = false) {
         _uiState.update { it.copy(isLoading = true, errorMessage = null) }
         viewModelScope.launch {
             val optionsDeferred =
                 async(Dispatchers.IO) {
-                    safeApiCall { ApiClient.hermesApi.getModelOptions() }
+                    safeApiCall { ApiClient.hermesApi.getModelOptions(refresh = refresh) }
                 }
             val activeProfileDeferred =
                 async(Dispatchers.IO) {

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -1284,7 +1284,7 @@ class E2eIntegrationTest {
             val provider = ModelProvider("ollama", "Ollama", false, true, listOf("llama3"), 1, null, true, null, null)
             val profile = ProfileInfo("default", null, true, "llama3", "ollama", null, null, null, null)
 
-            coEvery { mockApiService.getModelOptions() } returns
+            coEvery { mockApiService.getModelOptions(any()) } returns
                 Response.success(ModelOptionsResponse(listOf(provider)))
             coEvery { mockApiService.getActiveProfile() } returns
                 Response.success(ActiveProfileResponse("default", null))

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -1334,6 +1334,51 @@ class E2eIntegrationTest {
         }
 
     @Test
+    fun testModelOptions_refreshFlagPropagation() =
+        runTest {
+            val provider = ModelProvider("ollama", "Ollama", false, true, listOf("llama3"), 1, null, true, null, null)
+            val profile = ProfileInfo("default", null, true, "llama3", "ollama", null, null, null, null)
+
+            coEvery { mockApiService.getModelOptions(any()) } returns
+                Response.success(ModelOptionsResponse(listOf(provider)))
+            coEvery { mockApiService.getActiveProfile() } returns
+                Response.success(ActiveProfileResponse("default", null))
+            coEvery { mockApiService.getProfiles() } returns Response.success(ProfilesResponse(listOf(profile)))
+            coEvery { mockApiService.getAuxiliaryModels() } returns
+                Response.success(
+                    AuxiliaryModelsResponse(
+                        tasks = emptyList(),
+                        main = MainModelAssignment("openai", "gpt-4"),
+                    ),
+                )
+            coEvery { mockApiService.getMoaModels() } returns
+                Response.success<MoaConfigResponse>(
+                    MoaConfigResponse(
+                        presets = emptyMap(),
+                        default_preset = "",
+                        reference_models = emptyList(),
+                        aggregator = MoaModelSlot("openai", "gpt-4"),
+                        reference_temperature = 0.7,
+                        aggregator_temperature = 0.7,
+                        max_tokens = 4096,
+                    ),
+                )
+
+            // Default loadAll() must call getModelOptions with refresh = false
+            val viewModel = ModelViewModel()
+            viewModel.loadAll()
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { mockApiService.getModelOptions(false) }
+
+            // Pull-to-refresh path must call getModelOptions with refresh = true
+            viewModel.loadAll(refresh = true)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { mockApiService.getModelOptions(true) }
+        }
+
+    @Test
     fun testConnectViewModel_onPairingString_urlFormat() =
         runTest {
             mockkStatic(android.net.Uri::class)

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -1358,24 +1358,26 @@ class E2eIntegrationTest {
                         default_preset = "",
                         reference_models = emptyList(),
                         aggregator = MoaModelSlot("openai", "gpt-4"),
-                        reference_temperature = 0.7,
-                        aggregator_temperature = 0.7,
                         max_tokens = 4096,
                     ),
                 )
+
+            val capturedRefresh = mutableListOf<Boolean>()
+            coEvery { mockApiService.getModelOptions(any()) } answers {
+                capturedRefresh.add(firstArg())
+                Response.success(ModelOptionsResponse(listOf(provider)))
+            }
 
             // Default loadAll() must call getModelOptions with refresh = false
             val viewModel = ModelViewModel()
             viewModel.loadAll()
             advanceUntilIdle()
 
-            coVerify(exactly = 1) { mockApiService.getModelOptions(false) }
-
             // Pull-to-refresh path must call getModelOptions with refresh = true
             viewModel.loadAll(refresh = true)
             advanceUntilIdle()
 
-            coVerify(exactly = 1) { mockApiService.getModelOptions(true) }
+            assertEquals(listOf(false, true), capturedRefresh)
         }
 
     @Test


### PR DESCRIPTION
## Summary
Closes #480.

The backend merged model-picker changes (2026-07-06) where `GET /api/model/options` now takes `probe_current_custom_provider = not refresh`:
- Normal open (default): backend live-probes only the *current* active custom provider.
- Explicit `refresh=true`: backend re-probes *all* configured custom providers.

The mobile declared `getModelOptions()` with no query param and never exercised the `refresh=true` path, so newly-added/changed custom providers in `config.yaml` weren't rediscovered on pull-to-refresh.

### Changes
- `HermesApiService.kt`: `getModelOptions(@Query("refresh") refresh: Boolean = false)` — default keeps the fast normal-open path unchanged.
- `ModelViewModel.kt`: `loadAll(refresh: Boolean = false)`; initial load uses default `false`, pull-to-refresh passes `true`.
- `ModelScreen.kt`: `onRefresh = { viewModel.loadAll(refresh = true) }`.
- `E2eIntegrationTest.kt`: mock stub updated to `getModelOptions(any())` so it matches both call shapes.

WS `model.options` RPC is not used by the app, so no parity change is needed there.

## Test plan
- [x] ktlint-clean (lines < 120, trailing commas) — local ktlint blocked by broken JRE; CI gate covers it.
- [x] Existing E2E mock hardened to accept the new arg.
- [ ] CI: ktlint + android-lint + unit-tests + build + release-compile must go green.

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)

## Summary by Sourcery

Add support for passing a refresh flag when loading model options so pull-to-refresh re-probes custom providers.

New Features:
- Allow the client to request refreshed model options via a refresh query parameter on the model options API.

Enhancements:
- Wire the refresh flag through the model view model and model screen so pull-to-refresh uses the full re-probe behavior.
- Update E2E integration test mocks to accept the refreshed model options call signature.