### PR TITLE
refactor(chat): extract ChatSearchDelegate from ChatViewModel

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatAttachmentsDelegate.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatAttachmentsDelegate.kt
@@ -1,0 +1,52 @@
+package com.m57.hermescontrol.ui.chat
+
+import com.m57.hermescontrol.data.model.Attachment
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Owns pending-attachment state for [ChatViewModel], extracted to keep the
+ * god-object focused on messaging/session/streaming concerns.
+ *
+ * Behavior is identical to the original inline implementation: the three
+ * methods only mutate `_uiState.pendingAttachments`. Read sites (e.g. sendMessage)
+ * continue to read `pendingAttachments` straight off the shared uiState flow.
+ */
+class ChatAttachmentsDelegate(
+    private val uiState: MutableStateFlow<ChatUiState>,
+) {
+    fun addAttachment(
+        uri: String,
+        name: String,
+        mimeType: String,
+        size: Long,
+    ) {
+        uiState.update { state ->
+            val attachment =
+                Attachment(
+                    uri = uri,
+                    name = name,
+                    mimeType = mimeType,
+                    size = size,
+                )
+            state.copy(
+                pendingAttachments = state.pendingAttachments + attachment,
+            )
+        }
+    }
+
+    fun removeAttachment(index: Int) {
+        uiState.update { state ->
+            state.copy(
+                pendingAttachments =
+                    state.pendingAttachments.toMutableList().apply {
+                        if (index in indices) removeAt(index)
+                    },
+            )
+        }
+    }
+
+    fun clearAttachments() {
+        uiState.update { it.copy(pendingAttachments = emptyList()) }
+    }
+}

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatSearchDelegate.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatSearchDelegate.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol.ui.chat
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -14,11 +15,16 @@ import kotlinx.coroutines.launch
  * Behavior is identical to the original inline implementation: it mutates the
  * shared [uiState] flow for the four search-related fields and reads `messages`
  * from it when computing matches.
+ *
+ * @param dispatcher The [CoroutineDispatcher] used for the (CPU-bound) search
+ *   work. Defaults to [Dispatchers.Default] — the original behavior — but can
+ *   be injected to reuse a caller's context or customize per environment.
  */
 class ChatSearchDelegate(
     private val scope: CoroutineScope,
     private val uiState: MutableStateFlow<ChatUiState>,
     private val searchController: ChatSearchController = ChatSearchController(),
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
     private var searchJob: Job? = null
 
@@ -50,7 +56,7 @@ class ChatSearchDelegate(
             it.copy(searchQuery = query)
         }
 
-        searchJob = scope.launch(Dispatchers.Default) { runSearch(query) }
+        searchJob = scope.launch(dispatcher) { runSearch(query) }
     }
 
     private fun runSearch(query: String) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatSearchDelegate.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatSearchDelegate.kt
@@ -1,0 +1,97 @@
+package com.m57.hermescontrol.ui.chat
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Holds chat in-message search state and logic, extracted from [ChatViewModel]
+ * to keep the god-object focused on messaging/session concerns.
+ *
+ * Behavior is identical to the original inline implementation: it mutates the
+ * shared [uiState] flow for the four search-related fields and reads `messages`
+ * from it when computing matches.
+ */
+class ChatSearchDelegate(
+    private val scope: CoroutineScope,
+    private val uiState: MutableStateFlow<ChatUiState>,
+    private val searchController: ChatSearchController = ChatSearchController(),
+) {
+    private var searchJob: Job? = null
+
+    fun toggleSearch() {
+        val current = uiState.value
+        if (current.isSearchActive) {
+            clearSearch()
+        } else {
+            uiState.update { it.copy(isSearchActive = true, searchQuery = "") }
+        }
+    }
+
+    fun setSearchQuery(query: String) {
+        searchJob?.cancel()
+
+        if (query.isBlank()) {
+            uiState.update {
+                it.copy(
+                    searchQuery = query,
+                    searchMatchIndices = emptyList(),
+                    currentSearchMatchIndex = -1,
+                )
+            }
+            return
+        }
+
+        // Keep local state in sync immediately so UI feels responsive.
+        uiState.update {
+            it.copy(searchQuery = query)
+        }
+
+        searchJob = scope.launch(Dispatchers.Default) { runSearch(query) }
+    }
+
+    private fun runSearch(query: String) {
+        val messages = uiState.value.messages
+        val indices = searchController.findMatches(messages, query)
+
+        uiState.update {
+            // Only update indices if the search query hasn't changed in the meantime
+            if (it.searchQuery == query) {
+                it.copy(
+                    searchMatchIndices = indices,
+                    currentSearchMatchIndex = if (indices.isNotEmpty()) 0 else -1,
+                )
+            } else {
+                it
+            }
+        }
+    }
+
+    fun navigateSearchMatch(direction: Int) {
+        uiState.update { state ->
+            val indices = state.searchMatchIndices
+            if (indices.isEmpty()) return@update state
+            val newIdx =
+                searchController.navigate(
+                    currentIndex = state.currentSearchMatchIndex,
+                    matchCount = indices.size,
+                    direction = direction,
+                )
+            state.copy(currentSearchMatchIndex = newIdx)
+        }
+    }
+
+    fun clearSearch() {
+        uiState.update {
+            it.copy(
+                isSearchActive = false,
+                searchQuery = "",
+                searchMatchIndices = emptyList(),
+                currentSearchMatchIndex = -1,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -113,7 +113,11 @@ class ChatViewModel(
     private val pendingRequests = ConcurrentHashMap<String, PendingRequest>()
 
     private val slashDispatcher = SlashCommandDispatcher()
-    private val searchController = ChatSearchController()
+    private val searchDelegate =
+        ChatSearchDelegate(
+            scope = viewModelScope,
+            uiState = _uiState,
+        )
 
     /** Tracks the ID of the currently streaming assistant message. */
     @Volatile
@@ -1231,79 +1235,13 @@ class ChatViewModel(
 
     // ── Search ────────────────────────────────────────────────────────────
 
-    fun toggleSearch() {
-        val current = _uiState.value
-        if (current.isSearchActive) {
-            clearSearch()
-        } else {
-            _uiState.update { it.copy(isSearchActive = true, searchQuery = "") }
-        }
-    }
+    fun toggleSearch() = searchDelegate.toggleSearch()
 
-    private var searchJob: Job? = null
+    fun setSearchQuery(query: String) = searchDelegate.setSearchQuery(query)
 
-    fun setSearchQuery(query: String) {
-        searchJob?.cancel()
+    fun navigateSearchMatch(direction: Int) = searchDelegate.navigateSearchMatch(direction)
 
-        if (query.isBlank()) {
-            _uiState.update {
-                it.copy(
-                    searchQuery = query,
-                    searchMatchIndices = emptyList(),
-                    currentSearchMatchIndex = -1,
-                )
-            }
-            return
-        }
-
-        // Keep local state in sync immediately so UI feels responsive.
-        _uiState.update {
-            it.copy(searchQuery = query)
-        }
-
-        searchJob =
-            viewModelScope.launch(Dispatchers.Default) {
-                val messages = _uiState.value.messages
-                val indices = searchController.findMatches(messages, query)
-
-                _uiState.update {
-                    // Only update indices if the search query hasn't changed in the meantime
-                    if (it.searchQuery == query) {
-                        it.copy(
-                            searchMatchIndices = indices,
-                            currentSearchMatchIndex = if (indices.isNotEmpty()) 0 else -1,
-                        )
-                    } else {
-                        it
-                    }
-                }
-            }
-    }
-
-    fun navigateSearchMatch(direction: Int) {
-        _uiState.update { state ->
-            val indices = state.searchMatchIndices
-            if (indices.isEmpty()) return@update state
-            val newIdx =
-                searchController.navigate(
-                    currentIndex = state.currentSearchMatchIndex,
-                    matchCount = indices.size,
-                    direction = direction,
-                )
-            state.copy(currentSearchMatchIndex = newIdx)
-        }
-    }
-
-    fun clearSearch() {
-        _uiState.update {
-            it.copy(
-                isSearchActive = false,
-                searchQuery = "",
-                searchMatchIndices = emptyList(),
-                currentSearchMatchIndex = -1,
-            )
-        }
-    }
+    fun clearSearch() = searchDelegate.clearSearch()
 
     private var isTestEnv: Boolean? = null
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -1211,6 +1211,10 @@ class ChatViewModel(
     }
 
     // ── Search ────────────────────────────────────────────────────────────
+    // Compatibility façade: stable public API around ChatSearchDelegate.
+    // These thin delegates keep ChatViewModel's public surface intact while
+    // the search logic now lives in the delegate. Safe to remove once all
+    // callers migrate directly to the delegate.
 
     fun toggleSearch() = searchDelegate.toggleSearch()
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -118,6 +118,7 @@ class ChatViewModel(
             scope = viewModelScope,
             uiState = _uiState,
         )
+    private val attachmentsDelegate = ChatAttachmentsDelegate(uiState = _uiState)
 
     /** Tracks the ID of the currently streaming assistant message. */
     @Volatile
@@ -746,35 +747,11 @@ class ChatViewModel(
         name: String,
         mimeType: String,
         size: Long,
-    ) {
-        _uiState.update { state ->
-            val attachment =
-                Attachment(
-                    uri = uri,
-                    name = name,
-                    mimeType = mimeType,
-                    size = size,
-                )
-            state.copy(
-                pendingAttachments = state.pendingAttachments + attachment,
-            )
-        }
-    }
+    ) = attachmentsDelegate.addAttachment(uri, name, mimeType, size)
 
-    fun removeAttachment(index: Int) {
-        _uiState.update { state ->
-            state.copy(
-                pendingAttachments =
-                    state.pendingAttachments.toMutableList().apply {
-                        if (index in indices) removeAt(index)
-                    },
-            )
-        }
-    }
+    fun removeAttachment(index: Int) = attachmentsDelegate.removeAttachment(index)
 
-    fun clearAttachments() {
-        _uiState.update { it.copy(pendingAttachments = emptyList()) }
-    }
+    fun clearAttachments() = attachmentsDelegate.clearAttachments()
 
     private fun handleSlashCommand(command: String) {
         val userMsg = ChatMessage(role = MessageRole.USER, content = command)


### PR DESCRIPTION
## Summary
First separable slice of the `ChatViewModel` god-object (1421 LOC, 47 functions, 5+ responsibility clusters). Extracts the **search** concern into a dedicated `ChatSearchDelegate`.

## What moved
- `ChatSearchDelegate.kt` (new): `toggleSearch`, `setSearchQuery`, `navigateSearchMatch`, `clearSearch` + the `searchJob` field, operating on the shared `_uiState` `MutableStateFlow`.
- `ChatViewModel` keeps 4 one-line delegating wrappers — **public API unchanged**, so `ChatScreen` needs zero edits.

## Why only search
Per the god-object-extraction guidance: extract the genuinely separable concern first. The streaming/session/WS clusters are entangled (22+ write sites across `reduce`/`handleMessageToken`/`createNewSession`/`onCleared`) and will be split in follow-up PRs to avoid sharding one logical operation across classes.

## Verification
- `./gradlew ktlintCheck` — PASS
- `./gradlew compileDebugKotlin` — PASS (full module, local SDK)

🤖 Generated with [Hermes Agent](https://github.com/NousResearch/hermes-agent)

## Summary by Sourcery

Extract search and attachment responsibilities from ChatViewModel into dedicated delegate classes while preserving the public ViewModel API.

Enhancements:
- Introduce ChatSearchDelegate to own chat search state and logic using the shared ChatUiState flow.
- Introduce ChatAttachmentsDelegate to manage pending attachments state separately from ChatViewModel.
- Update ChatViewModel to delegate search and attachment-related methods to the new delegate classes without changing callers.