### PR TITLE
feat: move logout button from About tab to Connection tab

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
@@ -166,6 +166,20 @@ fun SettingsScreen(
                         )
 
                         Spacer(modifier = Modifier.height(16.dp))
+
+                        Button(
+                            onClick = {
+                                viewModel.logout()
+                                onLogout()
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                            colors =
+                                ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.error,
+                                ),
+                        ) {
+                            Text(stringResource(R.string.settings_logout))
+                        }
                     }
 
                     SettingsTab.BEHAVIOR -> {
@@ -252,20 +266,6 @@ fun SettingsScreen(
                             Spacer(modifier = Modifier.height(24.dp))
                             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
                             Spacer(modifier = Modifier.height(16.dp))
-
-                            Button(
-                                onClick = {
-                                    viewModel.logout()
-                                    onLogout()
-                                },
-                                modifier = Modifier.fillMaxWidth(),
-                                colors =
-                                    ButtonDefaults.buttonColors(
-                                        containerColor = MaterialTheme.colorScheme.error,
-                                    ),
-                            ) {
-                                Text(stringResource(R.string.settings_logout))
-                            }
                         }
                     }
                 }
@@ -1170,69 +1170,6 @@ private fun NavBarSection(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-        }
-    }
-}
-
-@Composable
-private fun AboutSection(onLogout: () -> Unit) {
-    SectionCard(title = stringResource(R.string.settings_sec_about)) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                text = stringResource(R.string.settings_about_app_name),
-                style =
-                    MaterialTheme.typography.titleMedium.copy(
-                        fontWeight = FontWeight.Bold,
-                    ),
-            )
-        }
-
-        Spacer(modifier = Modifier.height(8.dp))
-        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-        Spacer(modifier = Modifier.height(8.dp))
-
-        InfoRow(
-            label = stringResource(R.string.settings_about_version),
-            value = "v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
-        )
-        InfoRow(
-            label = stringResource(R.string.settings_about_build),
-            value =
-                if (BuildConfig.DEBUG) {
-                    stringResource(R.string.settings_about_debug)
-                } else {
-                    stringResource(R.string.settings_about_release)
-                },
-        )
-        if (BuildConfig.GIT_SHA.isNotBlank()) {
-            InfoRow(
-                label = stringResource(R.string.settings_about_commit),
-                value = BuildConfig.GIT_SHA,
-            )
-        }
-
-        Spacer(modifier = Modifier.height(12.dp))
-        Text(
-            text = "https://github.com/Hy4ri/hermes-mobile",
-            style =
-                MaterialTheme.typography.bodySmall.copy(
-                    color = MaterialTheme.colorScheme.primary,
-                ),
-        )
-
-        Spacer(modifier = Modifier.height(24.dp))
-        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-        Spacer(modifier = Modifier.height(16.dp))
-
-        Button(
-            onClick = onLogout,
-            modifier = Modifier.fillMaxWidth(),
-            colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.error,
-                ),
-        ) {
-            Text(stringResource(R.string.settings_logout))
         }
     }
 }


### PR DESCRIPTION
## Summary

Move the **Logout** action out of the About tab and into the **Connection** tab, so users can sign out directly where they manage their connection settings.

### Changes (SettingsScreen.kt)
- Removed the Logout button from the About tab content.
- Added the Logout button at the bottom of the Connection tab (full-width, error-colored, same styling).
- Deleted the unused, duplicate `AboutSection()` composable — it was never called and carried its own hidden Logout button. Removing it leaves a single source of truth for the action.

### Behavior unchanged
- Logout still calls `viewModel.logout()` then `onLogout()` (navigates back to the login/landing screen). Only the placement moved.

## Test plan
- [x] ktlint clean
- [x] assembleDebug compiles
- [ ] CI: ktlint / android-lint / unit-tests / build / release-compile
- [ ] Manual: open Settings → Connection tab → Logout is at the bottom; open About tab → no Logout button present; Logout returns to login.

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)

## Summary by Sourcery

Move the logout action from the About tab to the Connection tab in the settings screen to align sign-out with connection management.

Enhancements:
- Add a full-width, error-colored logout button to the bottom of the Connection tab.
- Remove the duplicate, unused AboutSection composable that contained a redundant logout button.