### PR TITLE
Remove Settings profile dropdown; cards tappable to switch

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
@@ -166,7 +166,7 @@ fun SettingsScreen(
                             onTest = viewModel::testConnection,
                         )
 
-                        Spacer(modifier = Modifier.height(8.dp))
+                        Spacer(modifier = Modifier.height(4.dp))
 
                         Button(
                             onClick = {

--- a/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -349,7 +350,7 @@ private fun ConnectionSection(
                         Modifier
                             .fillMaxWidth()
                             .padding(vertical = 2.dp)
-                            .clickable { viewModel.selectProfile(profile.id) },
+                            .clickable(role = Role.Button) { viewModel.selectProfile(profile.id) },
                     colors =
                         CardDefaults.cardColors(
                             containerColor =

--- a/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
@@ -166,7 +166,7 @@ fun SettingsScreen(
                             onTest = viewModel::testConnection,
                         )
 
-                        Spacer(modifier = Modifier.height(16.dp))
+                        Spacer(modifier = Modifier.height(8.dp))
 
                         Button(
                             onClick = {

--- a/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -332,54 +333,7 @@ private fun ConnectionSection(
     onPasswordVisibilityToggle: () -> Unit,
 ) {
     SectionCard(title = stringResource(R.string.settings_sec_connection)) {
-        // ── Profile selector ─────────────────────────────────────────
         if (state.profiles.isNotEmpty()) {
-            var profilesExpanded by remember { mutableStateOf(false) }
-            Text(
-                text = stringResource(R.string.settings_item_profile),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Box(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-                OutlinedButton(
-                    onClick = { profilesExpanded = true },
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    val activeProfile =
-                        state.profiles.firstOrNull { it.id == state.selectedProfileId }
-                    Text(
-                        text =
-                            activeProfile?.name ?: stringResource(
-                                R.string.settings_profile_default,
-                            ),
-                    )
-                }
-                DropdownMenu(
-                    expanded = profilesExpanded,
-                    onDismissRequest = { profilesExpanded = false },
-                    modifier = Modifier.fillMaxWidth(0.85f),
-                ) {
-                    DropdownMenuItem(
-                        text = { Text(stringResource(R.string.settings_profile_none)) },
-                        onClick = {
-                            viewModel.selectProfile(null)
-                            profilesExpanded = false
-                        },
-                    )
-                    state.profiles.forEach { profile ->
-                        DropdownMenuItem(
-                            text = { Text(profile.name) },
-                            onClick = {
-                                viewModel.selectProfile(profile.id)
-                                profilesExpanded = false
-                            },
-                        )
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(4.dp))
-
             // ── Saved profiles list ──────────────────────────────────
             Text(
                 text = stringResource(R.string.settings_saved_profiles, state.profiles.size),
@@ -391,7 +345,11 @@ private fun ConnectionSection(
             state.profiles.forEach { profile ->
                 val isActive = profile.id == state.selectedProfileId
                 Card(
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 2.dp)
+                            .clickable { viewModel.selectProfile(profile.id) },
                     colors =
                         CardDefaults.cardColors(
                             containerColor =

--- a/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsScreen.kt
@@ -166,7 +166,7 @@ fun SettingsScreen(
                             onTest = viewModel::testConnection,
                         )
 
-                        Spacer(modifier = Modifier.height(4.dp))
+                        Spacer(modifier = Modifier.height(2.dp))
 
                         Button(
                             onClick = {


### PR DESCRIPTION
## What
- Removes the profile `DropdownMenu` picker from `SettingsScreen` (Connection tab) — it's redundant now that the saved-profiles list is the single source of truth.
- Makes each saved-profile `Card` tappable (`clickable { viewModel.selectProfile(profile.id) }`) reusing the existing `isActive` highlight, so switching the active profile from Settings still works after the dropdown is gone.

## Why
The dropdown and the saved-profiles list both lived in Settings; the list cards only had Edit/Delete. Blindly deleting the dropdown would have left no way to switch the active profile from Settings. This keeps switching alive and de-clutters the UI.

## Verification
- `./ktlint` clean
- `./gradlew compileDebugKotlin` BUILD SUCCESSFUL

## Note
The `if (state.profiles.isNotEmpty())` guard on the section is kept — it just hides the list cleanly when there are zero profiles. No functional change there.

Follows up on the profile-UI cleanup discussed for #482. Not merged — awaiting review/OK.

## Summary by Sourcery

Streamline profile selection in the Settings connection section by removing the dropdown selector and making saved profile cards directly selectable.

Enhancements:
- Remove the redundant profile dropdown selector from the Settings connection section, relying solely on the saved profiles list for selection.
- Make each saved profile card tappable to switch the active profile while preserving the existing active-state highlight.