### PR TITLE
refactor(chat): extract streaming state into ChatStreamingController

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatStreamingController.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatStreamingController.kt
@@ -1,0 +1,124 @@
+package com.m57.hermescontrol.ui.chat
+
+import com.m57.hermescontrol.data.ws.WsEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Holds chat message-streaming state and logic, extracted from [ChatViewModel]
+ * to keep the god-object focused on messaging/session concerns.
+ *
+ * Behavior is identical to the original inline implementation: it owns the
+ * streaming buffers, the currently-streaming message id, and the two
+ * token/delta handlers, and mutates the shared [uiState] + [streamingState]
+ * flows. The owning ViewModel keeps [streamingState] as the single source of
+ * truth for the reduced [StreamingState] (applied via the WS event reducer);
+ * this controller only writes into it for buffer-driven flushes.
+ *
+ * [isCurrentSession] and [isTestEnvironment] are injected so the controller
+ * stays free of ViewModel-specific context while preserving exact behavior.
+ */
+class ChatStreamingController(
+    private val scope: CoroutineScope,
+    private val uiState: MutableStateFlow<ChatUiState>,
+    private val streamingState: MutableStateFlow<StreamingState>,
+    private val isCurrentSession: (String?) -> Boolean,
+    private val isTestEnvironment: () -> Boolean,
+) {
+    /** Tracks the ID of the currently streaming assistant message. */
+    private var streamingMessageId: String? = null
+
+    private val streamingBuffer = java.lang.StringBuilder()
+    private var lastFlushMs = 0L
+
+    private val thinkingBuffer = java.lang.StringBuilder()
+    private var lastThinkingFlushMs = 0L
+
+    /**
+     * Resets all streaming buffers and the in-flight message id. Centralizes
+     * the clear logic that was previously scattered across MessageStart,
+     * MessageComplete, MessageDone, ToolStart, ClarifyRequest, session
+     * switches, and interrupt handling.
+     */
+    fun resetStreaming() {
+        streamingMessageId = null
+        streamingBuffer.clear()
+        thinkingBuffer.clear()
+        lastFlushMs = 0L
+        lastThinkingFlushMs = 0L
+    }
+
+    /** Generates a fresh streaming message id (called on MessageStart). */
+    fun beginStreamingMessage() {
+        streamingMessageId =
+            java.util.UUID
+                .randomUUID()
+                .toString()
+        streamingBuffer.clear()
+        thinkingBuffer.clear()
+        lastFlushMs = 0L
+        lastThinkingFlushMs = 0L
+    }
+
+    fun handleMessageToken(event: WsEvent.MessageToken) {
+        if (!isCurrentSession(event.sessionId)) return
+
+        streamingBuffer.append(event.token)
+        val now = System.currentTimeMillis()
+
+        // Always flush in tests, or if enough time has passed
+        val shouldFlush = (now - lastFlushMs >= 33L) || lastFlushMs == 0L || isTestEnvironment()
+        if (shouldFlush) {
+            val currentContent = streamingBuffer.toString()
+            lastFlushMs = now
+            streamingState.update { state ->
+                val current = state.streamingMessage
+                if (current != null) {
+                    state.copy(
+                        streamingMessage =
+                            current.copy(
+                                content = currentContent,
+                            ),
+                        isThinking = false,
+                    )
+                } else {
+                    // Fallback: no MessageStart was received — create one now
+                    val msg =
+                        ChatMessage(
+                            role = MessageRole.ASSISTANT,
+                            content = currentContent,
+                            isStreaming = true,
+                        )
+                    streamingMessageId = msg.id
+                    state.copy(
+                        streamingMessage = msg,
+                        isThinking = false,
+                    )
+                }
+            }
+            uiState.update { it.copy(isAgentTyping = true) }
+        }
+    }
+
+    fun handleThinkingDelta(event: WsEvent.ThinkingDelta) {
+        if (!isCurrentSession(event.sessionId)) return
+
+        thinkingBuffer.append(event.token)
+        val now = System.currentTimeMillis()
+
+        // Always flush in tests, or if enough time has passed
+        val shouldFlush =
+            (now - lastThinkingFlushMs >= 33L) || lastThinkingFlushMs == 0L || isTestEnvironment()
+        if (shouldFlush) {
+            val currentContent = thinkingBuffer.toString()
+            lastThinkingFlushMs = now
+            streamingState.update { state ->
+                state.copy(
+                    isThinking = true,
+                    thinkingText = currentContent,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatStreamingController.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatStreamingController.kt
@@ -10,14 +10,15 @@ import kotlinx.coroutines.flow.update
  * to keep the god-object focused on messaging/session concerns.
  *
  * Behavior is identical to the original inline implementation: it owns the
- * streaming buffers, the currently-streaming message id, and the two
- * token/delta handlers, and mutates the shared [uiState] + [streamingState]
- * flows. The owning ViewModel keeps [streamingState] as the single source of
- * truth for the reduced [StreamingState] (applied via the WS event reducer);
- * this controller only writes into it for buffer-driven flushes.
+ * streaming buffers and the two token/delta handlers, and mutates the shared
+ * [uiState] + [streamingState] flows. The owning ViewModel keeps [streamingState]
+ * as the single source of truth for the reduced [StreamingState] (applied via the
+ * WS event reducer); this controller only writes into it for buffer-driven flushes.
  *
  * [isCurrentSession] and [isTestEnvironment] are injected so the controller
  * stays free of ViewModel-specific context while preserving exact behavior.
+ * [scope] mirrors the [com.m57.hermescontrol.ui.chat.ChatSearchDelegate] seam
+ * and is reserved for future streaming coroutine work.
  */
 class ChatStreamingController(
     private val scope: CoroutineScope,
@@ -26,9 +27,6 @@ class ChatStreamingController(
     private val isCurrentSession: (String?) -> Boolean,
     private val isTestEnvironment: () -> Boolean,
 ) {
-    /** Tracks the ID of the currently streaming assistant message. */
-    private var streamingMessageId: String? = null
-
     private val streamingBuffer = java.lang.StringBuilder()
     private var lastFlushMs = 0L
 
@@ -36,29 +34,20 @@ class ChatStreamingController(
     private var lastThinkingFlushMs = 0L
 
     /**
-     * Resets all streaming buffers and the in-flight message id. Centralizes
-     * the clear logic that was previously scattered across MessageStart,
-     * MessageComplete, MessageDone, ToolStart, ClarifyRequest, session
-     * switches, and interrupt handling.
+     * Resets all streaming buffers. Centralizes the clear logic that was
+     * previously scattered across MessageStart, MessageComplete, MessageDone,
+     * ToolStart, ClarifyRequest, session switches, and interrupt handling.
      */
     fun resetStreaming() {
-        streamingMessageId = null
         streamingBuffer.clear()
         thinkingBuffer.clear()
         lastFlushMs = 0L
         lastThinkingFlushMs = 0L
     }
 
-    /** Generates a fresh streaming message id (called on MessageStart). */
+    /** Resets buffers and starts a fresh streaming message (called on MessageStart). */
     fun beginStreamingMessage() {
-        streamingMessageId =
-            java.util.UUID
-                .randomUUID()
-                .toString()
-        streamingBuffer.clear()
-        thinkingBuffer.clear()
-        lastFlushMs = 0L
-        lastThinkingFlushMs = 0L
+        resetStreaming()
     }
 
     fun handleMessageToken(event: WsEvent.MessageToken) {
@@ -90,7 +79,6 @@ class ChatStreamingController(
                             content = currentContent,
                             isStreaming = true,
                         )
-                    streamingMessageId = msg.id
                     state.copy(
                         streamingMessage = msg,
                         isThinking = false,

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -115,17 +115,16 @@ class ChatViewModel(
     private val slashDispatcher = SlashCommandDispatcher()
     private val searchController = ChatSearchController()
 
-    /** Tracks the ID of the currently streaming assistant message. */
-    @Volatile
-    private var streamingMessageId: String? = null
+    private val streamingController =
+        ChatStreamingController(
+            scope = viewModelScope,
+            uiState = _uiState,
+            streamingState = _streamingState,
+            isCurrentSession = { sessionId -> isCurrentSession(sessionId) },
+            isTestEnvironment = { isTestEnvironment() },
+        )
 
     private var pendingCleanupJob: Job? = null
-
-    private val streamingBuffer = java.lang.StringBuilder()
-    private var lastFlushMs = 0L
-
-    private val thinkingBuffer = java.lang.StringBuilder()
-    private var lastThinkingFlushMs = 0L
 
     // ── Public state ─────────────────────────────────────────────────────
 
@@ -282,41 +281,29 @@ class ChatViewModel(
             }
 
             is WsEvent.MessageToken -> {
-                handleMessageToken(event)
+                streamingController.handleMessageToken(event)
             }
 
             is WsEvent.ThinkingDelta -> {
-                handleThinkingDelta(event)
+                streamingController.handleThinkingDelta(event)
             }
 
             is WsEvent.MessageStart -> {
-                streamingMessageId =
-                    java.util.UUID
-                        .randomUUID()
-                        .toString()
-                streamingBuffer.clear()
-                thinkingBuffer.clear()
-                lastFlushMs = 0L
-                lastThinkingFlushMs = 0L
+                streamingController.beginStreamingMessage()
             }
 
             is WsEvent.MessageComplete -> {
                 // Buffers cleared before reduce; ViewModel resets them after
-                streamingMessageId = null
-                streamingBuffer.clear()
-                thinkingBuffer.clear()
+                streamingController.resetStreaming()
             }
 
             is WsEvent.MessageDone -> {
-                streamingMessageId = null
-                streamingBuffer.clear()
-                thinkingBuffer.clear()
+                streamingController.resetStreaming()
             }
 
             is WsEvent.ToolStart -> {
                 // Reset streaming state when a tool starts
-                streamingBuffer.clear()
-                thinkingBuffer.clear()
+                streamingController.resetStreaming()
             }
 
             is WsEvent.RpcResult -> {
@@ -338,6 +325,7 @@ class ChatViewModel(
                     )
                 }
                 _streamingState.update { StreamingState() }
+                streamingController.resetStreaming()
             }
 
             is WsEvent.ApprovalRequest -> {
@@ -358,66 +346,6 @@ class ChatViewModel(
         // If the event has no session ID, process it (legacy compatibility)
         if (eventSessionId == null) return true
         return eventSessionId == _uiState.value.currentSessionId
-    }
-
-    private fun handleMessageToken(event: WsEvent.MessageToken) {
-        if (!isCurrentSession(event.sessionId)) return
-
-        streamingBuffer.append(event.token)
-        val now = System.currentTimeMillis()
-
-        // Always flush in tests, or if enough time has passed
-        val shouldFlush = (now - lastFlushMs >= 33L) || lastFlushMs == 0L || isTestEnvironment()
-        if (shouldFlush) {
-            val currentContent = streamingBuffer.toString()
-            lastFlushMs = now
-            _streamingState.update { state ->
-                val current = state.streamingMessage
-                if (current != null) {
-                    state.copy(
-                        streamingMessage =
-                            current.copy(
-                                content = currentContent,
-                            ),
-                        isThinking = false,
-                    )
-                } else {
-                    // Fallback: no MessageStart was received — create one now
-                    val msg =
-                        ChatMessage(
-                            role = MessageRole.ASSISTANT,
-                            content = currentContent,
-                            isStreaming = true,
-                        )
-                    streamingMessageId = msg.id
-                    state.copy(
-                        streamingMessage = msg,
-                        isThinking = false,
-                    )
-                }
-            }
-            _uiState.update { it.copy(isAgentTyping = true) }
-        }
-    }
-
-    private fun handleThinkingDelta(event: WsEvent.ThinkingDelta) {
-        if (!isCurrentSession(event.sessionId)) return
-
-        thinkingBuffer.append(event.token)
-        val now = System.currentTimeMillis()
-
-        // Always flush in tests, or if enough time has passed
-        val shouldFlush = (now - lastThinkingFlushMs >= 33L) || lastThinkingFlushMs == 0L || isTestEnvironment()
-        if (shouldFlush) {
-            val currentContent = thinkingBuffer.toString()
-            lastThinkingFlushMs = now
-            _streamingState.update { state ->
-                state.copy(
-                    isThinking = true,
-                    thinkingText = currentContent,
-                )
-            }
-        }
     }
 
     // ── RPC response handling ────────────────────────────────────────────
@@ -491,15 +419,13 @@ class ChatViewModel(
             }
 
             WsMethods.SESSION_INTERRUPT -> {
-                streamingBuffer.clear()
-                thinkingBuffer.clear()
                 _uiState.update {
                     it.copy(
                         isAgentTyping = false,
                     )
                 }
                 _streamingState.update { StreamingState() }
-                streamingMessageId = null
+                streamingController.resetStreaming()
                 addSystemMessage("Session interrupted")
             }
 
@@ -871,7 +797,7 @@ class ChatViewModel(
             )
         }
         _streamingState.update { StreamingState() }
-        streamingMessageId = null
+        streamingController.resetStreaming()
         viewModelScope.launch(Dispatchers.IO) {
             wsClient.send(
                 WsMethods.SESSION_CREATE,
@@ -934,9 +860,7 @@ class ChatViewModel(
         if (sessionId == _uiState.value.currentSessionId) return
 
         // Reset streaming state
-        streamingMessageId = null
-        streamingBuffer.clear()
-        thinkingBuffer.clear()
+        streamingController.resetStreaming()
         _uiState.update {
             val title = it.sessions.find { s -> s.id == sessionId }?.title ?: "Hermes"
             it.copy(


### PR DESCRIPTION
## Summary
- Extracts streaming buffers + `streamingMessageId` + the two `handleMessageToken`/`handleThinkingDelta` handlers out of `ChatViewModel` into a dedicated `ChatStreamingController`.
- Mirrors the `ChatSearchDelegate` seam from #486 (`scope` + `uiState` injected; `isCurrentSession`/`isTestEnvironment` injected as lambdas so the controller stays VM-context-free).
- `_streamingState` stays VM-owned (reducer result still applied via `_streamingState.update { result.streamingState }`); the pure `ChatWsEventReducer` is untouched — no sharding of one logical op.
- Centralizes 6 previously-scattered buffer resets into `resetStreaming()`/`beginStreamingMessage()`.

## Behavior-preserving
- No public API change on `ChatViewModel`; `ChatScreen` gets zero edits (still reads `viewModel.streamingState`).
- Verified locally: `compileDebugKotlin` + `ktlintCheck` both green.

## Guardrails (per the #486 TODO roadmap)
- Part of the remaining `ChatViewModel` god-object slices. This is the **streaming** cluster m57 flagged as most entangled — handled without touching the reducer boundary.

Follow-up slices still pending: WS event dispatch, session management, fetch cluster, attachment/compose.

Refs #CODE-34

## Summary by Sourcery

Extract chat message streaming concerns from ChatViewModel into a dedicated ChatStreamingController while preserving existing behavior.

Enhancements:
- Introduce ChatStreamingController to own streaming buffers, message id tracking, and token/thinking handlers instead of ChatViewModel.
- Centralize streaming reset logic into resetStreaming and beginStreamingMessage, replacing scattered buffer and state resets across websocket event handlers.