### PR TITLE
fix(chat): make search bar clickable (was overlayed by message list)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -1446,7 +1446,7 @@ private fun ChatMessageList(
 
         LazyColumn(
             state = listState,
-            modifier = Modifier.fillMaxSize().weight(1f),
+            modifier = Modifier.fillMaxWidth().weight(1f),
             contentPadding = PaddingValues(vertical = 8.dp),
         ) {
             itemsIndexed(

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -1402,107 +1402,113 @@ private fun ChatMessageList(
     onLastAnimatedMessageIdChange: (String?) -> Unit,
     viewModel: ChatViewModel,
 ) {
-    // Search bar
-    androidx.compose.animation.AnimatedVisibility(
-        visible = isSearchActive,
-        enter = androidx.compose.animation.expandVertically() + androidx.compose.animation.fadeIn(),
-        exit = androidx.compose.animation.shrinkVertically() + androidx.compose.animation.fadeOut(),
-    ) {
-        androidx.compose.material3.Surface(
-            modifier = Modifier.fillMaxWidth(),
-            color = MaterialTheme.colorScheme.surfaceContainerLow,
-            tonalElevation = 2.dp,
-            border =
-                BorderStroke(
-                    width = 1.dp,
-                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.12f),
-                ),
+    // Lay children out vertically so the search bar occupies real layout space
+    // ABOVE the message list. Without this container the call site is a Box,
+    // which overlays the LazyColumn on top of the search AnimatedVisibility and
+    // swallows every tap on the bar (bar visible but not clickable).
+    Column(modifier = Modifier.fillMaxSize()) {
+        // Search bar
+        androidx.compose.animation.AnimatedVisibility(
+            visible = isSearchActive,
+            enter = androidx.compose.animation.expandVertically() + androidx.compose.animation.fadeIn(),
+            exit = androidx.compose.animation.shrinkVertically() + androidx.compose.animation.fadeOut(),
         ) {
-            Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
-                SearchBarRow(
-                    searchQuery = searchQuery,
-                    onQueryChange = { viewModel.setSearchQuery(it) },
-                    searchMatchCount = searchMatchIndices.size,
-                    currentMatchIndex = currentSearchMatchIndex,
-                    onNavigateUp = { viewModel.navigateSearchMatch(-1) },
-                    onNavigateDown = { viewModel.navigateSearchMatch(1) },
-                    onClose = { viewModel.clearSearch() },
-                )
-            }
-        }
-    }
-
-    if (messages.isEmpty() && !isLoading) {
-        EmptyState(
-            title = stringResource(R.string.chat_empty_title),
-            subtitle = stringResource(R.string.chat_empty_subtitle),
-        )
-    }
-
-    LazyColumn(
-        state = listState,
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(vertical = 8.dp),
-    ) {
-        itemsIndexed(
-            items = messages,
-            key = { _, message -> message.id },
-        ) { index, message ->
-            val isCurrentMatch =
-                isSearchActive &&
-                    currentSearchMatchIndex >= 0 &&
-                    currentSearchMatchIndex < searchMatchIndices.size &&
-                    searchMatchIndices[currentSearchMatchIndex] == index
-
-            val isLastMessage = index == messages.lastIndex
-            val isAssistant = message.role == MessageRole.ASSISTANT
-
-            if (typingEffectEnabled && isLastMessage && isAssistant && message.isStreaming &&
-                lastAnimatedMessageId != message.id
+            androidx.compose.material3.Surface(
+                modifier = Modifier.fillMaxWidth(),
+                color = MaterialTheme.colorScheme.surfaceContainerLow,
+                tonalElevation = 2.dp,
+                border =
+                    BorderStroke(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.outline.copy(alpha = 0.12f),
+                    ),
             ) {
-                StreamingBubbleWithTypingEffect(
-                    streaming = message,
-                    typingDelayMs = typingEffectDelayMs,
-                    isDark = isDark,
-                    onAnimationComplete = {
-                        onLastAnimatedMessageIdChange(message.id)
-                    },
-                )
-            } else {
-                ChatBubble(
-                    message = message,
-                    isDarkTheme = isDark,
-                    searchQuery = if (isSearchActive) searchQuery else "",
-                    isCurrentMatch = isCurrentMatch,
-                    onRespondApproval = viewModel::respondToApproval,
-                )
-            }
-        }
-
-        // Streaming message
-        streamingMessage?.let { streaming ->
-            item(key = "streaming-${streaming.id}") {
-                if (typingEffectEnabled && streaming.isStreaming) {
-                    StreamingBubbleWithTypingEffect(
-                        streaming = streaming,
-                        typingDelayMs = typingEffectDelayMs,
-                        isDark = isDark,
-                    )
-                } else {
-                    ChatBubble(
-                        message = streaming,
-                        isDarkTheme = isDark,
-                        searchQuery = "",
-                        isCurrentMatch = false,
+                Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+                    SearchBarRow(
+                        searchQuery = searchQuery,
+                        onQueryChange = { viewModel.setSearchQuery(it) },
+                        searchMatchCount = searchMatchIndices.size,
+                        currentMatchIndex = currentSearchMatchIndex,
+                        onNavigateUp = { viewModel.navigateSearchMatch(-1) },
+                        onNavigateDown = { viewModel.navigateSearchMatch(1) },
+                        onClose = { viewModel.clearSearch() },
                     )
                 }
             }
         }
 
-        // Thinking indicator
-        if (isThinking) {
-            item(key = "thinking") {
-                ThinkingIndicator(thinkingText)
+        if (messages.isEmpty() && !isLoading) {
+            EmptyState(
+                title = stringResource(R.string.chat_empty_title),
+                subtitle = stringResource(R.string.chat_empty_subtitle),
+            )
+        }
+
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize().weight(1f),
+            contentPadding = PaddingValues(vertical = 8.dp),
+        ) {
+            itemsIndexed(
+                items = messages,
+                key = { _, message -> message.id },
+            ) { index, message ->
+                val isCurrentMatch =
+                    isSearchActive &&
+                        currentSearchMatchIndex >= 0 &&
+                        currentSearchMatchIndex < searchMatchIndices.size &&
+                        searchMatchIndices[currentSearchMatchIndex] == index
+
+                val isLastMessage = index == messages.lastIndex
+                val isAssistant = message.role == MessageRole.ASSISTANT
+
+                if (typingEffectEnabled && isLastMessage && isAssistant && message.isStreaming &&
+                    lastAnimatedMessageId != message.id
+                ) {
+                    StreamingBubbleWithTypingEffect(
+                        streaming = message,
+                        typingDelayMs = typingEffectDelayMs,
+                        isDark = isDark,
+                        onAnimationComplete = {
+                            onLastAnimatedMessageIdChange(message.id)
+                        },
+                    )
+                } else {
+                    ChatBubble(
+                        message = message,
+                        isDarkTheme = isDark,
+                        searchQuery = if (isSearchActive) searchQuery else "",
+                        isCurrentMatch = isCurrentMatch,
+                        onRespondApproval = viewModel::respondToApproval,
+                    )
+                }
+            }
+
+            // Streaming message
+            streamingMessage?.let { streaming ->
+                item(key = "streaming-${streaming.id}") {
+                    if (typingEffectEnabled && streaming.isStreaming) {
+                        StreamingBubbleWithTypingEffect(
+                            streaming = streaming,
+                            typingDelayMs = typingEffectDelayMs,
+                            isDark = isDark,
+                        )
+                    } else {
+                        ChatBubble(
+                            message = streaming,
+                            isDarkTheme = isDark,
+                            searchQuery = "",
+                            isCurrentMatch = false,
+                        )
+                    }
+                }
+            }
+
+            // Thinking indicator
+            if (isThinking) {
+                item(key = "thinking") {
+                    ThinkingIndicator(thinkingText)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
Fixes #490 — the chat search bar opened (toggle worked) but nothing inside was clickable: the text input, match nav arrows, and close button all ignored taps.

## Root cause
In `ChatMessageList`, the search `AnimatedVisibility` bar and the message `LazyColumn` were emitted as siblings with **no container**. The call site is a `Box`, which overlays children by default — so the `LazyColumn` (fillMaxSize) rendered **on top of** the search bar and intercepted every pointer event. The bar was visually visible but dead to input.

## Fix
Wrap `ChatMessageList`'s children in a `Column` so the search bar occupies real layout space **above** the list. The `LazyColumn` now uses `weight(1f)` and scrolls independently.

## Verification
- `compileDebugKotlin` ✅
- `ktlintCheck` ✅ (auto-formatted the re-indented block)

Behavior-preserving for non-search UI; only the search bar's hit-testing is fixed.

Closes #490

## Summary by Sourcery

Fix chat message list layout so the search bar occupies space above the message list instead of being overlaid and non-clickable.

Bug Fixes:
- Ensure the chat search bar input, navigation controls, and close button are tappable by placing the search bar above the scrollable message list.
- Correct streaming message rendering to avoid reusing non-streaming message state when applying typing effects.

Enhancements:
- Adjust the message list to use weighted height within a vertical layout for more predictable scrolling alongside the search bar.