### PR TITLE
fix(chat): surface all disconnected states in reconnect banner (#491)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -109,6 +109,7 @@ import androidx.core.content.FileProvider
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
+import com.m57.hermescontrol.AuthLoginScreen
 import com.m57.hermescontrol.NavigationController
 import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.Attachment
@@ -360,6 +361,7 @@ fun ChatScreen(
             ChatTopBanner(
                 connectionStatus = state.connectionStatus,
                 onReconnect = viewModel::reconnect,
+                onAuthExpired = { NavigationController.navigateTo(AuthLoginScreen) },
             )
 
             Box(
@@ -1337,11 +1339,13 @@ private fun ChatLifecycleEffects(
 private fun ChatTopBanner(
     connectionStatus: ConnectionStatus,
     onReconnect: () -> Unit,
+    onAuthExpired: () -> Unit,
 ) {
+    val isShown =
+        connectionStatus != ConnectionStatus.CONNECTED &&
+            connectionStatus != ConnectionStatus.CONNECTING
     androidx.compose.animation.AnimatedVisibility(
-        visible =
-            connectionStatus == ConnectionStatus.RECONNECTING ||
-                connectionStatus == ConnectionStatus.DISCONNECTED,
+        visible = isShown,
         enter = androidx.compose.animation.expandVertically() + androidx.compose.animation.fadeIn(),
         exit = androidx.compose.animation.shrinkVertically() + androidx.compose.animation.fadeOut(),
     ) {
@@ -1358,25 +1362,52 @@ private fun ChatTopBanner(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
-                Text(
-                    text =
-                        if (connectionStatus == ConnectionStatus.RECONNECTING) {
-                            stringResource(R.string.chat_status_reconnecting)
-                        } else {
-                            stringResource(R.string.chat_status_disconnected)
-                        },
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                if (connectionStatus == ConnectionStatus.DISCONNECTED) {
-                    TextButton(
-                        onClick = onReconnect,
-                        colors =
-                            androidx.compose.material3.ButtonDefaults.textButtonColors(
-                                contentColor = MaterialTheme.colorScheme.onErrorContainer,
-                            ),
-                    ) {
-                        Text(stringResource(R.string.chat_action_reconnect))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (connectionStatus == ConnectionStatus.RECONNECTING) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp).padding(end = 8.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                        )
                     }
+                    Text(
+                        text =
+                            when (connectionStatus) {
+                                ConnectionStatus.RECONNECTING -> stringResource(R.string.chat_status_reconnecting)
+                                ConnectionStatus.DISCONNECTED -> stringResource(R.string.chat_status_disconnected)
+                                ConnectionStatus.NO_NETWORK -> stringResource(R.string.chat_status_no_network)
+                                ConnectionStatus.AUTH_EXPIRED -> stringResource(R.string.chat_status_auth_expired)
+                                else -> ""
+                            },
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                when (connectionStatus) {
+                    ConnectionStatus.DISCONNECTED,
+                    ConnectionStatus.NO_NETWORK,
+                    -> {
+                        TextButton(
+                            onClick = onReconnect,
+                            colors =
+                                androidx.compose.material3.ButtonDefaults.textButtonColors(
+                                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                                ),
+                        ) {
+                            Text(stringResource(R.string.chat_action_reconnect))
+                        }
+                    }
+                    ConnectionStatus.AUTH_EXPIRED -> {
+                        TextButton(
+                            onClick = onAuthExpired,
+                            colors =
+                                androidx.compose.material3.ButtonDefaults.textButtonColors(
+                                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                                ),
+                        ) {
+                            Text(stringResource(R.string.chat_action_sign_in))
+                        }
+                    }
+                    else -> { /* RECONNECTING: auto, no button */ }
                 }
             }
         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -116,6 +116,7 @@ import com.m57.hermescontrol.data.model.Attachment
 import com.m57.hermescontrol.data.ws.CommandCatalog
 import com.m57.hermescontrol.data.ws.ConnectionStatus
 import com.m57.hermescontrol.notification.NotificationHelper
+import com.m57.hermescontrol.theme.LocalHermesStatusColors
 import com.m57.hermescontrol.theme.StatusRed
 import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.HermesScaffold
@@ -1351,8 +1352,8 @@ private fun ChatTopBanner(
     ) {
         androidx.compose.material3.Surface(
             modifier = Modifier.fillMaxWidth(),
-            color = MaterialTheme.colorScheme.errorContainer,
-            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+            color = LocalHermesStatusColors.current.errorContainer,
+            contentColor = LocalHermesStatusColors.current.error,
         ) {
             Row(
                 modifier =
@@ -1367,7 +1368,7 @@ private fun ChatTopBanner(
                         CircularProgressIndicator(
                             modifier = Modifier.size(16.dp).padding(end = 8.dp),
                             strokeWidth = 2.dp,
-                            color = MaterialTheme.colorScheme.onErrorContainer,
+                            color = LocalHermesStatusColors.current.error,
                         )
                     }
                     Text(
@@ -1390,7 +1391,7 @@ private fun ChatTopBanner(
                             onClick = onReconnect,
                             colors =
                                 androidx.compose.material3.ButtonDefaults.textButtonColors(
-                                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                                    contentColor = LocalHermesStatusColors.current.error,
                                 ),
                         ) {
                             Text(stringResource(R.string.chat_action_reconnect))
@@ -1401,7 +1402,7 @@ private fun ChatTopBanner(
                             onClick = onAuthExpired,
                             colors =
                                 androidx.compose.material3.ButtonDefaults.textButtonColors(
-                                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                                    contentColor = LocalHermesStatusColors.current.error,
                                 ),
                         ) {
                             Text(stringResource(R.string.chat_action_sign_in))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,11 +82,14 @@
     <string name="chat_action_search">Search</string>
     <string name="chat_action_close_search">Close search</string>
     <string name="chat_action_reconnect">Reconnect</string>
+    <string name="chat_action_sign_in">Sign in again</string>
     <string name="chat_empty_title">Ready to chat</string>
     <string name="chat_empty_subtitle">Send a message to start a conversation</string>
     <string name="chat_status_connecting">Connecting to Hermes\u2026</string>
     <string name="chat_status_reconnecting">Reconnecting to Hermes\u2026</string>
     <string name="chat_status_disconnected">Disconnected from Hermes</string>
+    <string name="chat_status_no_network">No network connection</string>
+    <string name="chat_status_auth_expired">Session expired \u2014 please sign in again</string>
     <string name="chat_thinking">Thinking\u2026</string>
     <string name="chat_thinking_param">Thinking: %1$s\u2026</string>
     <string name="chat_input_placeholder_not_connected">Not connected\u2026</string>


### PR DESCRIPTION
## Summary
Closes #491 — make reconnecting to the gateway easier and more user-friendly.

## Discovery
Most of the reconnect UX was already built in `HermesWsClient`:
- Auto-reconnect with exponential backoff (1s → 30s)
- Immediate reconnect when `NetworkMonitor` reports network restored
- In-flight message queue that flushes on reconnect
- Clean `ConnectionStatus` states (DISCONNECTED / RECONNECTING / NO_NETWORK / AUTH_EXPIRED)

The **real gap** was the UI: `ChatTopBanner` only appeared for `RECONNECTING`/`DISCONNECTED`. So when the socket dropped with no network (`NO_NETWORK`) or the session cookie expired (`AUTH_EXPIRED`), the user saw **nothing** — a silent chat with no feedback and no recovery path. That is exactly the 'not user-friendly' complaint.

## Fix
`ChatTopBanner` now surfaces **every** non-connected, non-connecting state:
| State | Banner | Action |
|------|--------|--------|
| RECONNECTING | spinner + 'Reconnecting to Hermes…' | auto (no button) |
| DISCONNECTED | 'Disconnected from Hermes' | Reconnect |
| NO_NETWORK | 'No network connection' | Reconnect (force retry) |
| AUTH_EXPIRED | 'Session expired — please sign in again' | Sign in again → AuthLoginScreen |

Added strings: `chat_status_no_network`, `chat_status_auth_expired`, `chat_action_sign_in`.

## Verification
- `compileDebugKotlin` ✅
- `ktlintCheck` ✅ (auto-formatted import order)

The auto-reconnect engine is untouched — purely a visibility/actionability fix.

Closes #491

## Summary by Sourcery

Surface all non-connected chat connection states in the top banner and provide appropriate user actions for each state.

New Features:
- Show a reconnect banner for NO_NETWORK and AUTH_EXPIRED connection states in addition to existing reconnecting and disconnected states.
- Add a sign-in action that navigates to the login screen when the chat session has expired.

Enhancements:
- Display a spinner in the chat banner while reconnecting and adjust banner visibility to cover all non-connected, non-connecting states.