### PR TITLE
fix(ws): chat opening no longer races singleton into stuck RECONNECTING

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
@@ -165,6 +165,25 @@ object HermesWsClient {
             Log.d(TAG, "Already connected — skipping")
             return
         }
+        // Guard against re-entrant connect() while a connection is already in
+        // flight. The singleton may be CONNECTING (mid handshake) or RECONNECTING
+        // (a scheduled reconnect is pending). Opening a second socket on the same
+        // `webSocket` field races the in-flight one and can leave the status
+        // stuck on RECONNECTING (e.g. the chat tab calls connect() on every open
+        // while the app-level reconnect is already running). Only start a fresh
+        // socket from a terminal state.
+        if (_connectionStatus.value == ConnectionStatus.CONNECTING ||
+            _connectionStatus.value == ConnectionStatus.RECONNECTING
+        ) {
+            Log.d(TAG, "Connection already in flight (${_connectionStatus.value}) — skipping")
+            return
+        }
+        // AUTH_EXPIRED cannot be resolved by reconnecting alone — caller must
+        // re-authenticate. Leave the status as-is so the UI can surface sign-in.
+        if (_connectionStatus.value == ConnectionStatus.AUTH_EXPIRED) {
+            Log.d(TAG, "Connection is AUTH_EXPIRED — skipping reconnect; re-auth required")
+            return
+        }
         intentionalClose.set(false)
         currentBackoff = INITIAL_BACKOFF_MS
         _connectionStatus.value = ConnectionStatus.CONNECTING

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -195,6 +195,20 @@ class ChatViewModel(
     private fun connectWebSocket(setLoading: Boolean = false) {
         val token = AuthManager.getToken() ?: return
 
+        // Don't disturb an already-working (or already-recovering) connection.
+        // HermesWsClient is a global singleton shared by every tab; the chat tab
+        // is recreated on every open, so calling connect() here must be a no-op
+        // unless the singleton is in a terminal state. Re-entering connect() while
+        // it is CONNECTING/RECONNECTING races the in-flight socket and can leave
+        // the status stuck on RECONNECTING (see HermesWsClient.connect).
+        val status = wsClient.connectionStatus.value
+        if (status == ConnectionStatus.CONNECTING ||
+            status == ConnectionStatus.RECONNECTING ||
+            status == ConnectionStatus.AUTH_EXPIRED
+        ) {
+            return
+        }
+
         if (setLoading) {
             _uiState.update { it.copy(isLoading = true) }
         }


### PR DESCRIPTION
## Summary
Fixes the reported symptom: _"all tabs connected and working except chat — it shows 'Reconnecting to Hermes'"_.

**Root cause:** `HermesWsClient` is a global singleton connected once at login; every tab reads its single `connectionStatus`. `ChatViewModel` is `viewModel()`-scoped to the chat tab, so it is **recreated on every chat-tab open**, and its `init` calls `connectWebSocket()` → `wsClient.connect()`.

`connect()` only guarded the `CONNECTED` case. When the socket had dropped (singleton in `RECONNECTING` with its own scheduled reconnect in flight) and the user opened chat, `connect()` reset `currentBackoff`, set `CONNECTING`, and opened a **second socket** on the same `webSocket` field. The orphaned socket's later `onClosed` set `connected=false` + re-armed `RECONNECTING` *after* the new socket connected, and `currentBackoff` kept resetting on each chat open → the status got stuck on `RECONNECTING`. Other tabs never call `connect()`, so they rode the singleton once it recovered — exactly the reported asymmetry.

**Fix (behavior-preserving):**
- `HermesWsClient.connect()` now no-ops while `CONNECTING`/`RECONNECTING` (in-flight socket already pending) and while `AUTH_EXPIRED` (needs re-auth, not a loop).
- `ChatViewModel.connectWebSocket()` mirrors the same terminal-state guard, so the chat tab never disturbs an already-working or already-recovering connection.

Happy path (`CONNECTED`), genuine terminal states (`DISCONNECTED`/`NO_NETWORK`), and the auto-reconnect backoff/network-return/queue logic are all unchanged.

## Verification
- `compileDebugKotlin` ✅ · full `ktlintCheck` ✅ (local Android SDK /opt/android-sdk)

## Relation to #491
PR #493 surfaces all non-connected states in the reconnect banner (UI visibility). This PR fixes the underlying *stuck* state that produced the symptom. Together they close #491.

🤖 Generated with [Hermes](https://github.com/Hy4ri/hermes-agent)

## Summary by Sourcery

Prevent chat-tab websocket connects from racing the global HermesWsClient into a stuck RECONNECTING state by guarding re-entrant connects against in-flight and auth-expired statuses.

Bug Fixes:
- Ensure HermesWsClient.connect() no-ops while a connection is already in CONNECTING or RECONNECTING states or when authentication is expired, avoiding duplicate sockets and stuck reconnecting status.
- Make ChatViewModel.connectWebSocket() respect non-terminal connection states so reopening the chat tab does not interfere with an existing or recovering websocket connection.