### PR TITLE
Fix/issue 470 stuck reconnecting

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
@@ -119,7 +119,9 @@ object AuthManager {
             // session-cookie prefs are passed as a Deferred so existing gated
             // sessions can be migrated on first load WITHOUT blocking startup.
             // The Deferred is created above, before this call.
-            CookieManager.initialize(context, prefsDeferred)
+            val initialProfileId =
+                store.getLatestState().selectedProfileId?.takeIf { it.isNotBlank() } ?: DEFAULT_PROFILE_ID
+            CookieManager.initialize(context, prefsDeferred, initialProfileId)
 
             scope.launch {
                 store.stateFlow.collect { state ->
@@ -299,6 +301,12 @@ object AuthManager {
     ) {
         requirePrefs().edit().putString("token_$profileId", token).apply()
         if (getSelectedProfileId() == profileId) {
+            // B7 (Jul 08 2026, kanban t_470): sync in-memory cachedToken
+            // to prevent stale tokens during ticket refresh
+            synchronized(this) {
+                cachedToken = token
+                tokenInitialized = true
+            }
             _tokenFlow.value = token
         }
     }

--- a/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
@@ -130,12 +130,8 @@ object AuthManager {
                     _useDynamicColorsFlow.value = state.useDynamicColors
                     _themePresetFlow.value = state.themePreset
                     _bottomNavDisplayModeFlow.value = state.bottomNavDisplayMode
-
-                    // B7 (Jul 08 2026, kanban t_470): sync CookieManager active store scope with the selected profile ID
-                    val profileId = state.selectedProfileId?.takeIf { it.isNotBlank() } ?: DEFAULT_PROFILE_ID
-                    if (CookieManager.isInitialized() && CookieManager.cookieJar.currentServer() != profileId) {
-                        CookieManager.useStore(profileId)
-                    }
+                    // B7 (Jul 08 2026, kanban t_470): keep cookie scope aligned with active profile.
+                    syncCookieStoreForProfile(state.selectedProfileId)
                 }
             }
         }
@@ -322,11 +318,18 @@ object AuthManager {
             tokenInitialized = false
         }
         _tokenFlow.value = getToken()
+        // B7 (Jul 08 2026, kanban t_470): keep cookie scope aligned with active profile.
+        syncCookieStoreForProfile(id)
+    }
 
-        // B7 (Jul 08 2026, kanban t_470): sync CookieManager active store scope with the selected profile ID
-        val profileId = id?.takeIf { it.isNotBlank() } ?: DEFAULT_PROFILE_ID
-        if (CookieManager.isInitialized()) {
-            CookieManager.useStore(profileId)
+    private fun normalizedProfileId(profileId: String?): String =
+        profileId?.takeIf { it.isNotBlank() } ?: DEFAULT_PROFILE_ID
+
+    private fun syncCookieStoreForProfile(profileId: String?) {
+        if (!CookieManager.isInitialized()) return
+        val normalizedId = normalizedProfileId(profileId)
+        if (CookieManager.cookieJar.currentServer() != normalizedId) {
+            CookieManager.useStore(normalizedId)
         }
     }
 

--- a/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
@@ -128,6 +128,12 @@ object AuthManager {
                     _useDynamicColorsFlow.value = state.useDynamicColors
                     _themePresetFlow.value = state.themePreset
                     _bottomNavDisplayModeFlow.value = state.bottomNavDisplayMode
+
+                    // B7 (Jul 08 2026, kanban t_470): sync CookieManager active store scope with the selected profile ID
+                    val profileId = state.selectedProfileId?.takeIf { it.isNotBlank() } ?: DEFAULT_PROFILE_ID
+                    if (CookieManager.isInitialized() && CookieManager.cookieJar.currentServer() != profileId) {
+                        CookieManager.useStore(profileId)
+                    }
                 }
             }
         }
@@ -266,13 +272,15 @@ object AuthManager {
         if (p.getBoolean(KEY_LEGACY_DEFAULT_MIGRATED, false)) return
         val legacyToken = p.getString(KEY_LEGACY_TOKEN, null)
         ensureDefaultProfile()
-        p.edit().apply {
-            if (!legacyToken.isNullOrBlank()) {
-                putString("token_$DEFAULT_PROFILE_ID", legacyToken)
-            }
-            remove(KEY_LEGACY_TOKEN)
-            putBoolean(KEY_LEGACY_DEFAULT_MIGRATED, true)
-        }.apply()
+        p
+            .edit()
+            .apply {
+                if (!legacyToken.isNullOrBlank()) {
+                    putString("token_$DEFAULT_PROFILE_ID", legacyToken)
+                }
+                remove(KEY_LEGACY_TOKEN)
+                putBoolean(KEY_LEGACY_DEFAULT_MIGRATED, true)
+            }.apply()
     }
 
     // ── Pinned Models ────────────────────────────────────────────────────
@@ -306,6 +314,12 @@ object AuthManager {
             tokenInitialized = false
         }
         _tokenFlow.value = getToken()
+
+        // B7 (Jul 08 2026, kanban t_470): sync CookieManager active store scope with the selected profile ID
+        val profileId = id?.takeIf { it.isNotBlank() } ?: DEFAULT_PROFILE_ID
+        if (CookieManager.isInitialized()) {
+            CookieManager.useStore(profileId)
+        }
     }
 
     // ── Token ────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/CookieManager.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/CookieManager.kt
@@ -39,15 +39,16 @@ object CookieManager {
     fun initialize(
         context: Context,
         legacyPrefsDeferred: Deferred<SharedPreferences>? = null,
+        initialServerId: String = PersistentCookieJar.DEFAULT_SERVER_ID,
     ) {
         if (jar != null) return
         synchronized(this) {
             if (jar != null) return
             val store = EncryptedCookieStore(context.applicationContext, legacyPrefsDeferred)
             jar = PersistentCookieJar(store, scope)
-            // Eagerly load the default scope off the caller thread so the
+            // Eagerly load the initial scope off the caller thread so the
             // first REST call is instant without blocking app startup.
-            scope.launch { jar!!.useStore(PersistentCookieJar.DEFAULT_SERVER_ID) }
+            scope.launch { jar!!.useStore(initialServerId) }
         }
     }
 

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
@@ -165,6 +165,25 @@ object HermesWsClient {
             Log.d(TAG, "Already connected — skipping")
             return
         }
+        // Guard against re-entrant connect() while a connection is already in
+        // flight. The singleton may be CONNECTING (mid handshake) or RECONNECTING
+        // (a scheduled reconnect is pending). Opening a second socket on the same
+        // `webSocket` field races the in-flight one and can leave the status
+        // stuck on RECONNECTING (e.g. the chat tab calls connect() on every open
+        // while the app-level reconnect is already running). Only start a fresh
+        // socket from a terminal state.
+        if (_connectionStatus.value == ConnectionStatus.CONNECTING ||
+            _connectionStatus.value == ConnectionStatus.RECONNECTING
+        ) {
+            Log.d(TAG, "Connection already in flight (${_connectionStatus.value}) — skipping")
+            return
+        }
+        // AUTH_EXPIRED cannot be resolved by reconnecting alone — caller must
+        // re-authenticate. Leave the status as-is so the UI can surface sign-in.
+        if (_connectionStatus.value == ConnectionStatus.AUTH_EXPIRED) {
+            Log.d(TAG, "Connection is AUTH_EXPIRED — skipping reconnect; re-auth required")
+            return
+        }
         intentionalClose.set(false)
         currentBackoff = INITIAL_BACKOFF_MS
         _connectionStatus.value = ConnectionStatus.CONNECTING

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -1428,7 +1428,9 @@ private fun ChatTopBanner(
                         }
                     }
 
-                    ConnectionStatus.AUTH_EXPIRED -> {
+                    ConnectionStatus.RECONNECTING,
+                    ConnectionStatus.AUTH_EXPIRED,
+                    -> {
                         TextButton(
                             onClick = onReloginClick,
                             colors =
@@ -1440,7 +1442,7 @@ private fun ChatTopBanner(
                         }
                     }
 
-                    else -> { /* RECONNECTING: auto, no button */ }
+                    else -> {}
                 }
             }
         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -1665,6 +1665,7 @@ private fun ReloginDialog(
     onDismiss: () -> Unit,
     onRelogin: (String, String, (Boolean, String?) -> Unit) -> Unit,
 ) {
+    val context = LocalContext.current
     val statusColors = LocalHermesStatusColors.current
     var username by rememberSaveable { mutableStateOf("") }
     var password by rememberSaveable { mutableStateOf("") }
@@ -1718,7 +1719,7 @@ private fun ReloginDialog(
                 enabled = !isLoading,
                 onClick = {
                     if (username.isBlank() || password.isBlank()) {
-                        errorMessage = stringResource(R.string.chat_relogin_error_empty)
+                        errorMessage = context.getString(R.string.chat_relogin_error_empty)
                         return@TextButton
                     }
                     isLoading = true

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -146,6 +146,7 @@ fun ChatScreen(
     var inputText by rememberSaveable { mutableStateOf("") }
     var isListening by rememberSaveable { mutableStateOf(false) }
     var lastAnimatedMessageId by rememberSaveable { mutableStateOf<String?>(null) }
+    var showReloginDialog by rememberSaveable { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
     val isDark = isSystemInDarkTheme()
     val context = LocalContext.current
@@ -360,6 +361,7 @@ fun ChatScreen(
             ChatTopBanner(
                 connectionStatus = state.connectionStatus,
                 onReconnect = viewModel::reconnect,
+                onReloginClick = { showReloginDialog = true },
             )
 
             Box(
@@ -475,6 +477,15 @@ fun ChatScreen(
                 onImageTap = { filePickerLauncher.launch("image/*") },
                 onFileTap = { filePickerLauncher.launch("*/*") },
                 onRemoveAttachment = viewModel::removeAttachment,
+            )
+        }
+
+        if (showReloginDialog) {
+            ReloginDialog(
+                onDismiss = { showReloginDialog = false },
+                onRelogin = { username, password, onResult ->
+                    viewModel.relogin(username, password, onResult)
+                },
             )
         }
     }
@@ -1337,6 +1348,7 @@ private fun ChatLifecycleEffects(
 private fun ChatTopBanner(
     connectionStatus: ConnectionStatus,
     onReconnect: () -> Unit,
+    onReloginClick: () -> Unit,
 ) {
     androidx.compose.animation.AnimatedVisibility(
         visible =
@@ -1366,16 +1378,31 @@ private fun ChatTopBanner(
                             stringResource(R.string.chat_status_disconnected)
                         },
                     style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f),
                 )
-                if (connectionStatus == ConnectionStatus.DISCONNECTED) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
                     TextButton(
-                        onClick = onReconnect,
+                        onClick = onReloginClick,
                         colors =
                             androidx.compose.material3.ButtonDefaults.textButtonColors(
                                 contentColor = MaterialTheme.colorScheme.onErrorContainer,
                             ),
                     ) {
-                        Text(stringResource(R.string.chat_action_reconnect))
+                        Text(stringResource(R.string.chat_action_relogin))
+                    }
+                    if (connectionStatus == ConnectionStatus.DISCONNECTED) {
+                        TextButton(
+                            onClick = onReconnect,
+                            colors =
+                                androidx.compose.material3.ButtonDefaults.textButtonColors(
+                                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                                ),
+                        ) {
+                            Text(stringResource(R.string.chat_action_reconnect))
+                        }
                     }
                 }
             }
@@ -1594,4 +1621,98 @@ private fun BoxScope.ChatScrollToBottomFab(
             )
         }
     }
+}
+
+@Composable
+private fun ReloginDialog(
+    onDismiss: () -> Unit,
+    onRelogin: (String, String, (Boolean, String?) -> Unit) -> Unit,
+) {
+    var username by rememberSaveable { mutableStateOf("") }
+    var password by rememberSaveable { mutableStateOf("") }
+    var isLoading by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    AlertDialog(
+        onDismissRequest = { if (!isLoading) onDismiss() },
+        title = { Text(stringResource(R.string.chat_relogin_title)) },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                OutlinedTextField(
+                    value = username,
+                    onValueChange = {
+                        username = it
+                        errorMessage = null
+                    },
+                    label = { Text(stringResource(R.string.chat_relogin_username)) },
+                    singleLine = true,
+                    enabled = !isLoading,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = {
+                        password = it
+                        errorMessage = null
+                    },
+                    label = { Text(stringResource(R.string.chat_relogin_password)) },
+                    singleLine = true,
+                    enabled = !isLoading,
+                    visualTransformation =
+                        androidx.compose.ui.text.input
+                            .PasswordVisualTransformation(),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                if (errorMessage != null) {
+                    Text(
+                        text = errorMessage!!,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = !isLoading,
+                onClick = {
+                    if (username.isBlank() || password.isBlank()) {
+                        errorMessage = "Username and password cannot be empty"
+                        return@TextButton
+                    }
+                    isLoading = true
+                    errorMessage = null
+                    onRelogin(username, password) { success, error ->
+                        isLoading = false
+                        if (success) {
+                            onDismiss()
+                        } else {
+                            errorMessage = error ?: "Unknown error"
+                        }
+                    }
+                },
+            ) {
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                } else {
+                    Text(stringResource(R.string.chat_relogin_submit))
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(
+                enabled = !isLoading,
+                onClick = onDismiss,
+            ) {
+                Text(stringResource(R.string.chat_relogin_cancel))
+            }
+        },
+    )
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -1644,6 +1644,7 @@ private fun ReloginDialog(
     onDismiss: () -> Unit,
     onRelogin: (String, String, (Boolean, String?) -> Unit) -> Unit,
 ) {
+    val statusColors = LocalHermesStatusColors.current
     var username by rememberSaveable { mutableStateOf("") }
     var password by rememberSaveable { mutableStateOf("") }
     var isLoading by remember { mutableStateOf(false) }
@@ -1685,7 +1686,7 @@ private fun ReloginDialog(
                 if (errorMessage != null) {
                     Text(
                         text = errorMessage!!,
-                        color = MaterialTheme.colorScheme.error,
+                        color = statusColors.error,
                         style = MaterialTheme.typography.bodySmall,
                     )
                 }
@@ -1696,7 +1697,7 @@ private fun ReloginDialog(
                 enabled = !isLoading,
                 onClick = {
                     if (username.isBlank() || password.isBlank()) {
-                        errorMessage = "Username and password cannot be empty"
+                        errorMessage = stringResource(R.string.chat_relogin_error_empty)
                         return@TextButton
                     }
                     isLoading = true
@@ -1715,7 +1716,7 @@ private fun ReloginDialog(
                     CircularProgressIndicator(
                         modifier = Modifier.size(16.dp),
                         strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.primary,
+                        color = statusColors.info,
                     )
                 } else {
                     Text(stringResource(R.string.chat_relogin_submit))

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -1393,9 +1393,30 @@ private fun ChatTopBanner(
                     )
                 }
                 when (connectionStatus) {
-                    ConnectionStatus.DISCONNECTED,
-                    ConnectionStatus.NO_NETWORK,
-                    -> {
+                    ConnectionStatus.DISCONNECTED -> {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            TextButton(
+                                onClick = onReloginClick,
+                                colors =
+                                    androidx.compose.material3.ButtonDefaults.textButtonColors(
+                                        contentColor = LocalHermesStatusColors.current.error,
+                                    ),
+                            ) {
+                                Text(stringResource(R.string.chat_action_relogin))
+                            }
+                            TextButton(
+                                onClick = onReconnect,
+                                colors =
+                                    androidx.compose.material3.ButtonDefaults.textButtonColors(
+                                        contentColor = LocalHermesStatusColors.current.error,
+                                    ),
+                            ) {
+                                Text(stringResource(R.string.chat_action_reconnect))
+                            }
+                        }
+                    }
+
+                    ConnectionStatus.NO_NETWORK -> {
                         TextButton(
                             onClick = onReconnect,
                             colors =

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -195,6 +195,20 @@ class ChatViewModel(
     private fun connectWebSocket(setLoading: Boolean = false) {
         val token = AuthManager.getToken() ?: return
 
+        // Don't disturb an already-working (or already-recovering) connection.
+        // HermesWsClient is a global singleton shared by every tab; the chat tab
+        // is recreated on every open, so calling connect() here must be a no-op
+        // unless the singleton is in a terminal state. Re-entering connect() while
+        // it is CONNECTING/RECONNECTING races the in-flight socket and can leave
+        // the status stuck on RECONNECTING (see HermesWsClient.connect).
+        val status = wsClient.connectionStatus.value
+        if (status == ConnectionStatus.CONNECTING ||
+            status == ConnectionStatus.RECONNECTING ||
+            status == ConnectionStatus.AUTH_EXPIRED
+        ) {
+            return
+        }
+
         if (setLoading) {
             _uiState.update { it.copy(isLoading = true) }
         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -34,8 +34,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.decodeFromJsonElement
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
 import java.util.concurrent.ConcurrentHashMap
 
 private const val TAG = "ChatViewModel"
@@ -1104,7 +1106,14 @@ class ChatViewModel(
             val host = AuthManager.getHost()
             val port = AuthManager.getPort()
             val baseUrl = "http://$host:$port"
-            val jsonBody = """{"provider":"basic","username":"$username","password":"$password","next":""}"""
+            val jsonMediaType = "application/json; charset=utf-8".toMediaType()
+            val jsonBody =
+                JSONObject()
+                    .put("provider", "basic")
+                    .put("username", username)
+                    .put("password", password)
+                    .put("next", "")
+                    .toString()
 
             try {
                 val loginClient =
@@ -1119,21 +1128,21 @@ class ChatViewModel(
                         .Builder()
                         .url("$baseUrl/auth/password-login")
                         .header("Content-Type", "application/json")
-                        .post(jsonBody.toRequestBody())
+                        .post(jsonBody.toRequestBody(jsonMediaType))
                         .build()
-                val loginResp = loginClient.newCall(loginReq).execute()
-
-                if (!loginResp.isSuccessful) {
-                    val msg =
-                        when (loginResp.code) {
-                            401 -> "Invalid username or password (401)"
-                            403 -> "Forbidden (403)"
-                            else -> "HTTP error code: ${loginResp.code}"
+                loginClient.newCall(loginReq).execute().use { loginResp ->
+                    if (!loginResp.isSuccessful) {
+                        val msg =
+                            when (loginResp.code) {
+                                401 -> "Invalid username or password (401)"
+                                403 -> "Forbidden (403)"
+                                else -> "HTTP error code: ${loginResp.code}"
+                            }
+                        withContext(Dispatchers.Main) {
+                            onResult(false, msg)
                         }
-                    withContext(Dispatchers.Main) {
-                        onResult(false, msg)
+                        return@launch
                     }
-                    return@launch
                 }
 
                 val ticketClient =
@@ -1147,36 +1156,39 @@ class ChatViewModel(
                     Request
                         .Builder()
                         .url("$baseUrl/api/auth/ws-ticket")
-                        .post("{}".toRequestBody())
+                        .post("{}".toRequestBody(jsonMediaType))
                         .build()
-                val ticketResp = ticketClient.newCall(ticketReq).execute()
-
-                if (!ticketResp.isSuccessful) {
-                    withContext(Dispatchers.Main) {
-                        onResult(false, "Failed to mint WS ticket: HTTP ${ticketResp.code}")
+                ticketClient.newCall(ticketReq).execute().use { ticketResp ->
+                    if (!ticketResp.isSuccessful) {
+                        withContext(Dispatchers.Main) {
+                            onResult(false, "Failed to mint WS ticket: HTTP ${ticketResp.code}")
+                        }
+                        return@launch
                     }
-                    return@launch
-                }
 
-                val body = ticketResp.body?.string() ?: ""
-                val ticketMatch = Regex("""\"ticket\":\"([^\"]+)\"""").find(body)
-                val ticket = ticketMatch?.groupValues?.getOrNull(1)
+                    val body = ticketResp.body?.string().orEmpty()
+                    val ticket = JSONObject(body).optString("ticket").takeIf { it.isNotBlank() }
 
-                if (ticket.isNullOrBlank()) {
-                    withContext(Dispatchers.Main) {
-                        onResult(false, "Invalid ticket returned from server")
+                    if (ticket.isNullOrBlank()) {
+                        withContext(Dispatchers.Main) {
+                            onResult(false, "Invalid ticket returned from server")
+                        }
+                        return@launch
                     }
-                    return@launch
+
+                    AuthManager.setWsAuthParam("ticket")
+                    AuthManager.setToken(ticket)
+
+                    withContext(Dispatchers.Main) {
+                        onResult(true, null)
+                        reconnect()
+                    }
                 }
-
-                AuthManager.setWsAuthParam("ticket")
-                AuthManager.setToken(ticket)
-
+            } catch (e: java.io.IOException) {
                 withContext(Dispatchers.Main) {
-                    onResult(true, null)
-                    reconnect()
+                    onResult(false, "Connection failed: ${e.message}")
                 }
-            } catch (e: Exception) {
+            } catch (e: org.json.JSONException) {
                 withContext(Dispatchers.Main) {
                     onResult(false, "Connection failed: ${e.message}")
                 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -34,6 +34,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.decodeFromJsonElement
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import java.util.concurrent.ConcurrentHashMap
 
 private const val TAG = "ChatViewModel"
@@ -1090,6 +1092,95 @@ class ChatViewModel(
         viewModelScope.launch {
             delay(500)
             connectWebSocket(setLoading = true)
+        }
+    }
+
+    fun relogin(
+        username: String,
+        password: String,
+        onResult: (Boolean, String?) -> Unit,
+    ) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val host = AuthManager.getHost()
+            val port = AuthManager.getPort()
+            val baseUrl = "http://$host:$port"
+            val jsonBody = """{"provider":"basic","username":"$username","password":"$password","next":""}"""
+
+            try {
+                val loginClient =
+                    com.m57.hermescontrol.data.remote.OkHttpProvider.probe
+                        .newBuilder()
+                        .connectTimeout(10, java.util.concurrent.TimeUnit.SECONDS)
+                        .readTimeout(10, java.util.concurrent.TimeUnit.SECONDS)
+                        .build()
+
+                val loginReq =
+                    Request
+                        .Builder()
+                        .url("$baseUrl/auth/password-login")
+                        .header("Content-Type", "application/json")
+                        .post(jsonBody.toRequestBody())
+                        .build()
+                val loginResp = loginClient.newCall(loginReq).execute()
+
+                if (!loginResp.isSuccessful) {
+                    val msg =
+                        when (loginResp.code) {
+                            401 -> "Invalid username or password (401)"
+                            403 -> "Forbidden (403)"
+                            else -> "HTTP error code: ${loginResp.code}"
+                        }
+                    withContext(Dispatchers.Main) {
+                        onResult(false, msg)
+                    }
+                    return@launch
+                }
+
+                val ticketClient =
+                    com.m57.hermescontrol.data.remote.OkHttpProvider.base
+                        .newBuilder()
+                        .connectTimeout(10, java.util.concurrent.TimeUnit.SECONDS)
+                        .readTimeout(10, java.util.concurrent.TimeUnit.SECONDS)
+                        .build()
+
+                val ticketReq =
+                    Request
+                        .Builder()
+                        .url("$baseUrl/api/auth/ws-ticket")
+                        .post("{}".toRequestBody())
+                        .build()
+                val ticketResp = ticketClient.newCall(ticketReq).execute()
+
+                if (!ticketResp.isSuccessful) {
+                    withContext(Dispatchers.Main) {
+                        onResult(false, "Failed to mint WS ticket: HTTP ${ticketResp.code}")
+                    }
+                    return@launch
+                }
+
+                val body = ticketResp.body?.string() ?: ""
+                val ticketMatch = Regex("""\"ticket\":\"([^\"]+)\"""").find(body)
+                val ticket = ticketMatch?.groupValues?.getOrNull(1)
+
+                if (ticket.isNullOrBlank()) {
+                    withContext(Dispatchers.Main) {
+                        onResult(false, "Invalid ticket returned from server")
+                    }
+                    return@launch
+                }
+
+                AuthManager.setWsAuthParam("ticket")
+                AuthManager.setToken(ticket)
+
+                withContext(Dispatchers.Main) {
+                    onResult(true, null)
+                    reconnect()
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    onResult(false, "Connection failed: ${e.message}")
+                }
+            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,13 @@
     <string name="chat_action_search">Search</string>
     <string name="chat_action_close_search">Close search</string>
     <string name="chat_action_reconnect">Reconnect</string>
+    <string name="chat_action_relogin">Re-login</string>
+    <string name="chat_relogin_title">Re-login to Hermes</string>
+    <string name="chat_relogin_username">Username</string>
+    <string name="chat_relogin_password">Password</string>
+    <string name="chat_relogin_submit">Login</string>
+    <string name="chat_relogin_cancel">Cancel</string>
+    <string name="chat_relogin_error_empty">Username and password cannot be empty</string>
     <string name="chat_empty_title">Ready to chat</string>
     <string name="chat_empty_subtitle">Send a message to start a conversation</string>
     <string name="chat_status_connecting">Connecting to Hermes\u2026</string>


### PR DESCRIPTION
## Summary

<!-- One-sentence summary of what this PR does. -->

Fixes #<!-- issue number -->

## Type of change

<!-- Check the type that applies. Delete the rest. -->

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 🎨 UX improvement
- [ ] ♻️ Refactor
- [ ] 🔧 CI / build config
- [ ] 📝 Documentation
- [ ] 🔒 Security

## Screenshots / screen recordings

<!-- Required for UI changes. Drag & drop images or link to recordings. -->

_Before:_

_After:_

## What changed

<!--
  Describe the changes in detail — what was wrong, what was done to fix it,
  key decisions made, trade-offs considered. For UI changes, explain the
  reasoning behind layout, color, or interaction decisions.
-->

## How to test

<!--
  Steps to verify the change works correctly. Example:

  1. Open the app
  2. Navigate to …
  3. Tap …
  4. Verify that …
-->

## Checklist

- [ ] Code follows the project's style (ktlint passes)
- [ ] No new compiler warnings introduced
- [ ] If adding a new screen, checked that existing screens don't already cover the functionality (see `NavigationKeys.kt`/`ls ui/`)
- [ ] Routes all navigation through `NavigationController.navigateTo()` — no raw `backStack.add()` from UI callbacks
- [ ] Uses `HermesScaffold` instead of raw `Scaffold` for new/rewritten screens
- [ ] Room schema directory updated if entities changed
- [ ] Tested the change on a real device or CI APK
- [ ] CI is green (all checks pass: ktlint, Android Lint, unit tests, build)

## Related issues

<!--
  Link any related issues, PRs, or discussions.
  e.g., Closes #N, Refs #M, Related to #P
-->

## Notes for reviewers

<!--
  Any gotchas, follow-up work, or things to watch out for.
-->

## Summary by Sourcery

Prevent chat WebSocket connections from getting stuck in a reconnecting state and support re-authentication when the auth session expires.

Bug Fixes:
- Avoid starting new WebSocket connections while an existing connection is in progress or in a reconnecting/auth-expired state to prevent the client from becoming stuck.
- Keep the authentication token and cookie store in sync with the selected profile to avoid stale credentials during reconnect and ticket refresh.

Enhancements:
- Add a relogin flow from the chat screen banner that lets users re-enter credentials and mint a new WebSocket ticket when authentication has expired.
- Display both re-login and reconnect actions in the chat connection status banner when disconnected for clearer recovery options.
- Initialize and switch the cookie manager's active store based on the selected profile so each profile uses the correct cookie scope.