### PR TITLE
fix(#497): pass include_unconfigured=true to /api/model/options to restore full provider universe

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -432,6 +432,7 @@ interface HermesApiService {
     @GET("api/model/options")
     suspend fun getModelOptions(
         @Query("refresh") refresh: Boolean = false,
+        @Query("include_unconfigured") includeUnconfigured: Boolean = true,
     ): Response<ModelOptionsResponse>
 
     @GET("api/model/auxiliary")

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -1285,7 +1285,7 @@ class E2eIntegrationTest {
             val provider = ModelProvider("ollama", "Ollama", false, true, listOf("llama3"), 1, null, true, null, null)
             val profile = ProfileInfo("default", null, true, "llama3", "ollama", null, null, null, null)
 
-            coEvery { mockApiService.getModelOptions(any()) } returns
+            coEvery { mockApiService.getModelOptions(any(), any()) } returns
                 Response.success(ModelOptionsResponse(listOf(provider)))
             coEvery { mockApiService.getActiveProfile() } returns
                 Response.success(ActiveProfileResponse("default", null))
@@ -1340,7 +1340,7 @@ class E2eIntegrationTest {
             val provider = ModelProvider("ollama", "Ollama", false, true, listOf("llama3"), 1, null, true, null, null)
             val profile = ProfileInfo("default", null, true, "llama3", "ollama", null, null, null, null)
 
-            coEvery { mockApiService.getModelOptions(any()) } returns
+            coEvery { mockApiService.getModelOptions(any(), any()) } returns
                 Response.success(ModelOptionsResponse(listOf(provider)))
             coEvery { mockApiService.getActiveProfile() } returns
                 Response.success(ActiveProfileResponse("default", null))
@@ -1364,7 +1364,7 @@ class E2eIntegrationTest {
                 )
 
             val capturedRefresh = mutableListOf<Boolean>()
-            coEvery { mockApiService.getModelOptions(any()) } answers {
+            coEvery { mockApiService.getModelOptions(any(), any()) } answers {
                 capturedRefresh.add(firstArg())
                 Response.success(ModelOptionsResponse(listOf(provider)))
             }


### PR DESCRIPTION
## What

Adds `@Query("include_unconfigured") includeUnconfigured: Boolean = true` to `HermesApiService.getModelOptions()`.

## Why

Backend commit `37a4cf900` (NousResearch/hermes-agent) flipped the default of `GET /api/model/options`'s `include_unconfigured` from `true` → `false`. The mobile picker calls this endpoint with no explicit value, so it was silently downgraded to showing **only configured/authenticated providers** — the skeleton rows with setup-hint warnings for unconfigured providers (xAI, Kimi, Grok, etc.) stopped arriving.

Both call sites (`ModelViewModel` + `ProfilesViewModel`) invoke the API without passing the new param, so they automatically pick up the `true` default — no changes needed at call sites.

No response-model drift: the backend only *filters rows* when `explicit_only=true`; the row shape itself is unchanged.

## Changes

| File | Change |
|------|--------|
| `HermesApiService.kt:433-434` | Added `@Query("include_unconfigured") includeUnconfigured: Boolean = true` |
| `E2eIntegrationTest.kt` | Updated 3 mock signatures from `getModelOptions(any())` → `getModelOptions(any(), any())` to match new 2-arg signature |

## Verification
- ✅ `ktlint --format` clean on both modified files
- ✅ `./gradlew assembleDebug` — BUILD SUCCESSFUL
- ✅ `./gradlew testDebugUnitTest` — BUILD SUCCESSFUL (all unit tests pass)

Closes #497

## Summary by Sourcery

Ensure the model options API continues to return both configured and unconfigured providers by explicitly requesting them and align tests with the updated API signature.

Bug Fixes:
- Restore display of unconfigured providers in the model options by explicitly passing include_unconfigured=true to the backend API.

Tests:
- Update E2E integration tests to mock the new two-argument getModelOptions signature.