### PR TITLE
feat(#500): tap-to-reveal detail dialog for truncated item descriptions

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/common/DetailDialog.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/common/DetailDialog.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.m57.hermescontrol.theme.LocalHermesStatusColors
@@ -71,7 +70,7 @@ fun DetailDialog(
                 ),
         ) {
             HermesScaffold(
-                title = { Text(title, maxLines = 2, overflow = TextOverflow.Ellipsis) },
+                title = { Text(title, style = MaterialTheme.typography.titleLarge) },
                 navigationIcon = NavIcon.Back(onDismiss),
                 isRefreshing = false,
             ) { padding ->

--- a/app/src/main/java/com/m57/hermescontrol/ui/common/DetailDialog.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/common/DetailDialog.kt
@@ -39,7 +39,7 @@ import com.m57.hermescontrol.R
 @Composable
 fun DetailDialog(
     title: String,
-    rows: List<Pair<String?, String?>>,
+    rows: List<Pair<String, String?>>,
     onDismiss: () -> Unit,
     actions: @Composable (() -> Unit)? = null,
 ) {
@@ -82,7 +82,7 @@ fun DetailDialog(
                                 HorizontalDivider()
                             }
                             Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                                label?.let {
+                                label.let {
                                     Text(
                                         text = it,
                                         style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/java/com/m57/hermescontrol/ui/common/DetailDialog.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/common/DetailDialog.kt
@@ -2,8 +2,6 @@ package com.m57.hermescontrol.ui.common
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -14,99 +12,111 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import com.m57.hermescontrol.R
+import com.m57.hermescontrol.theme.LocalHermesStatusColors
 
 /**
- * Shared tap-to-reveal detail dialog used across list screens (skills, plugins,
- * MCP servers, toolsets, webhooks) to show untruncated metadata for an item
- * whose card description is truncated. See issue #500.
+ * Semantic tone for a detail row's value text.
+ * NONEl uses the default on-surface variant; the rest pull from
+ * [LocalHermesStatusColors] so status feedback stays brand-correct
+ * regardless of the wallpaper-derived Material palette.
+ */
+enum class DetailRowTone {
+    NONE,
+    SUCCESS,
+    WARNING,
+    ERROR,
+    INFO,
+    NEUTRAL,
+}
+
+/**
+ * A single label/value row shown in [DetailDialog].
  *
- * @param title        Dialog title (usually the item name).
- * @param rows         Label → value pairs. Rows with a null or blank value are
- *                     skipped so callers can pass every field unconditionally.
- * @param onDismiss    Called when the dialog is dismissed.
- * @param actions     Optional trailing content (action buttons). Rendered inside
- *                     the scroll area below the rows so it never scrolls away from
- *                     the content but stays grouped with the detail.
+ * @param label Non-null resource string (already resolved by the mapper).
+ * @param value Display value; null/blank rows are skipped at render time.
+ * @param tone Semantic tone for the value text (defaults to [DetailRowTone.NONE]).
+ */
+data class DetailRow(
+    val label: String,
+    val value: String?,
+    val tone: DetailRowTone = DetailRowTone.NONE,
+)
+
+/**
+ * Reusable tap-to-reveal detail dialog: a title plus a scrollable list of
+ * label/value rows. Null/blank rows are skipped automatically. An optional
+ * [actions] slot renders after the rows (inside the scroll area) so primary
+ * actions stay visible without the user dismissing the dialog.
  */
 @Composable
 fun DetailDialog(
     title: String,
-    rows: List<Pair<String, String?>>,
+    rows: List<DetailRow>,
     onDismiss: () -> Unit,
     actions: @Composable (() -> Unit)? = null,
 ) {
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false),
-    ) {
+    val statusColors = LocalHermesStatusColors.current
+
+    Dialog(onDismissRequest = onDismiss) {
         Card(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(16.dp),
+            modifier = Modifier.fillMaxWidth(),
             colors =
                 CardDefaults.cardColors(
                     containerColor = MaterialTheme.colorScheme.surface,
                 ),
         ) {
             HermesScaffold(
-                title = { Text(title) },
-                navigationIcon = NavIcon.Back(onBack = onDismiss),
-            ) {
+                title = { Text(title, maxLines = 2, overflow = TextOverflow.Ellipsis) },
+                navigationIcon = NavIcon.Back(onDismiss),
+                isRefreshing = false,
+            ) { padding ->
+                val visibleRows = rows.filter { !it.value.isNullOrBlank() }
                 Column(
                     modifier =
                         Modifier
-                            .fillMaxSize()
-                            .padding(16.dp)
-                            .verticalScroll(rememberScrollState()),
+                            .padding(padding)
+                            .fillMaxWidth()
+                            .verticalScroll(rememberScrollState())
+                            .padding(16.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
-                    val visibleRows = rows.filter { !it.second.isNullOrBlank() }
-                    if (visibleRows.isEmpty()) {
-                        Text(
-                            text = stringResource(R.string.detail_dialog_no_info),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    } else {
-                        visibleRows.forEachIndexed { index, (label, value) ->
-                            if (index > 0) {
-                                HorizontalDivider()
-                            }
-                            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                                label.let {
-                                    Text(
-                                        text = it,
-                                        style = MaterialTheme.typography.labelSmall,
-                                        fontWeight = FontWeight.Bold,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-                                }
-                                Text(
-                                    text = value ?: "",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                )
-                            }
+                    visibleRows.forEachIndexed { index, (label, value, tone) ->
+                        if (index > 0) {
+                            HorizontalDivider()
+                        }
+                        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                            Text(
+                                text = label,
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Text(
+                                text = value ?: "",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color =
+                                    when (tone) {
+                                        DetailRowTone.SUCCESS -> statusColors.success
+                                        DetailRowTone.WARNING -> statusColors.warning
+                                        DetailRowTone.ERROR -> statusColors.error
+                                        DetailRowTone.INFO -> statusColors.info
+                                        DetailRowTone.NEUTRAL -> statusColors.neutral
+                                        DetailRowTone.NONE -> MaterialTheme.colorScheme.onSurfaceVariant
+                                    },
+                            )
                         }
                     }
 
-                    actions?.let {
-                        HorizontalDivider()
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.End,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            it()
+                    if (actions != null) {
+                        if (visibleRows.isNotEmpty()) {
+                            HorizontalDivider()
                         }
+                        actions()
                     }
                 }
             }

--- a/app/src/main/java/com/m57/hermescontrol/ui/common/DetailDialog.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/common/DetailDialog.kt
@@ -1,0 +1,115 @@
+package com.m57.hermescontrol.ui.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.m57.hermescontrol.R
+
+/**
+ * Shared tap-to-reveal detail dialog used across list screens (skills, plugins,
+ * MCP servers, toolsets, webhooks) to show untruncated metadata for an item
+ * whose card description is truncated. See issue #500.
+ *
+ * @param title        Dialog title (usually the item name).
+ * @param rows         Label → value pairs. Rows with a null or blank value are
+ *                     skipped so callers can pass every field unconditionally.
+ * @param onDismiss    Called when the dialog is dismissed.
+ * @param actions     Optional trailing content (action buttons). Rendered inside
+ *                     the scroll area below the rows so it never scrolls away from
+ *                     the content but stays grouped with the detail.
+ */
+@Composable
+fun DetailDialog(
+    title: String,
+    rows: List<Pair<String?, String?>>,
+    onDismiss: () -> Unit,
+    actions: @Composable (() -> Unit)? = null,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Card(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+            colors =
+                CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                ),
+        ) {
+            HermesScaffold(
+                title = { Text(title) },
+                navigationIcon = NavIcon.Back(onBack = onDismiss),
+            ) {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(16.dp)
+                            .verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    val visibleRows = rows.filter { !it.second.isNullOrBlank() }
+                    if (visibleRows.isEmpty()) {
+                        Text(
+                            text = stringResource(R.string.detail_dialog_no_info),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    } else {
+                        visibleRows.forEachIndexed { index, (label, value) ->
+                            if (index > 0) {
+                                HorizontalDivider()
+                            }
+                            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                                label?.let {
+                                    Text(
+                                        text = it,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        fontWeight = FontWeight.Bold,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                                Text(
+                                    text = value ?: "",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                            }
+                        }
+                    }
+
+                    actions?.let {
+                        HorizontalDivider()
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.End,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            it()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/m57/hermescontrol/ui/common/DetailRows.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/common/DetailRows.kt
@@ -1,0 +1,122 @@
+package com.m57.hermescontrol.ui.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.m57.hermescontrol.R
+import com.m57.hermescontrol.data.model.HubSkill
+import com.m57.hermescontrol.data.model.McpServer
+import com.m57.hermescontrol.data.model.PluginInfo
+import com.m57.hermescontrol.data.model.Skill
+import com.m57.hermescontrol.data.model.Toolset
+import com.m57.hermescontrol.data.model.WebhookSubscription
+
+/**
+ * Mappers that turn a domain model into the rows shown by [DetailDialog].
+ * Keeping these here (instead of inline in each screen) avoids the
+ * showDetail + DetailDialog wiring being copied across six screens.
+ */
+
+@Composable
+fun Skill.toDetailRows(): List<DetailRow> =
+    listOf(
+        DetailRow(stringResource(R.string.detail_dialog_category), category),
+        DetailRow(stringResource(R.string.detail_dialog_source), source),
+        DetailRow(stringResource(R.string.detail_dialog_description), description),
+    )
+
+@Composable
+fun HubSkill.toDetailRows(): List<DetailRow> =
+    listOf(
+        DetailRow(stringResource(R.string.detail_dialog_category), category),
+        DetailRow(stringResource(R.string.detail_dialog_source), source),
+        DetailRow(stringResource(R.string.detail_dialog_description), description),
+        DetailRow(stringResource(R.string.detail_dialog_tags), tags.orEmpty().joinToString(", ")),
+        DetailRow(stringResource(R.string.detail_dialog_trust_level), trustLevel),
+    )
+
+@Composable
+fun McpServer.toDetailRows(): List<DetailRow> {
+    val commandSummary =
+        buildString {
+            if (command?.isNotBlank() == true) append(command)
+            if (!args.isNullOrEmpty()) append(" " + args.joinToString(" "))
+        }.trim().ifBlank { null }
+
+    return listOf(
+        DetailRow(stringResource(R.string.detail_dialog_transport), transport),
+        DetailRow(stringResource(R.string.detail_dialog_status), status, toneForStatus(status)),
+        DetailRow(stringResource(R.string.detail_dialog_url), url),
+        DetailRow(stringResource(R.string.detail_dialog_command), commandSummary),
+        DetailRow(
+            stringResource(R.string.detail_dialog_env_vars),
+            env?.entries?.joinToString("\n") { "${it.key}=${it.value}" },
+        ),
+        DetailRow(stringResource(R.string.detail_dialog_error), error),
+    )
+}
+
+@Composable
+fun PluginInfo.toDetailRows(): List<DetailRow> =
+    listOf(
+        DetailRow(stringResource(R.string.detail_dialog_version), version),
+        DetailRow(stringResource(R.string.detail_dialog_source), source),
+        DetailRow(
+            stringResource(R.string.detail_dialog_status),
+            runtimeStatus,
+            toneForStatus(runtimeStatus),
+        ),
+        DetailRow(stringResource(R.string.detail_dialog_description), description),
+    )
+
+@Composable
+fun Toolset.toDetailRows(): List<DetailRow> =
+    listOf(
+        DetailRow(stringResource(R.string.detail_dialog_label), label),
+        DetailRow(stringResource(R.string.detail_dialog_description), description),
+        DetailRow(stringResource(R.string.detail_dialog_tools), tools.orEmpty().joinToString(", ")),
+        DetailRow(
+            stringResource(R.string.detail_dialog_status),
+            if (enabled) {
+                stringResource(R.string.detail_dialog_status_enabled)
+            } else {
+                stringResource(R.string.detail_dialog_status_disabled)
+            },
+            if (enabled) DetailRowTone.SUCCESS else DetailRowTone.NEUTRAL,
+        ),
+    )
+
+@Composable
+fun WebhookSubscription.toDetailRows(): List<DetailRow> =
+    listOf(
+        DetailRow(
+            stringResource(R.string.detail_dialog_status),
+            if (enabled == true) {
+                stringResource(R.string.detail_dialog_status_enabled)
+            } else {
+                stringResource(R.string.detail_dialog_status_disabled)
+            },
+            if (enabled == true) DetailRowTone.SUCCESS else DetailRowTone.NEUTRAL,
+        ),
+        DetailRow(stringResource(R.string.detail_dialog_deliver), deliver),
+        DetailRow(stringResource(R.string.detail_dialog_description), description),
+        DetailRow(stringResource(R.string.detail_dialog_events), events.orEmpty().joinToString(", ")),
+        DetailRow(stringResource(R.string.detail_dialog_prompt), prompt),
+        DetailRow(stringResource(R.string.detail_dialog_skills), skills.orEmpty().joinToString(", ")),
+        DetailRow(stringResource(R.string.detail_dialog_url), url),
+        DetailRow(stringResource(R.string.detail_dialog_created_at), created_at),
+    )
+
+/**
+ * Map a free-form status string to a semantic tone. Recognises the app's
+ * common status vocabulary (enabled/active/running/ok → success, etc.).
+ */
+private fun toneForStatus(status: String?): DetailRowTone {
+    if (status.isNullOrBlank()) return DetailRowTone.NONE
+    return when (status.lowercase()) {
+        "enabled", "active", "running", "ok", "online", "connected" -> DetailRowTone.SUCCESS
+        "disabled", "inactive", "offline", "disconnected" -> DetailRowTone.NEUTRAL
+        "error", "failed", "unreachable" -> DetailRowTone.ERROR
+        "warning", "degraded" -> DetailRowTone.WARNING
+        else -> DetailRowTone.NONE
+    }
+}

--- a/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
@@ -1,6 +1,7 @@
 package com.m57.hermescontrol.ui.mcp
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -57,6 +58,7 @@ import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.McpCatalogEntry
 import com.m57.hermescontrol.data.model.McpServer
 import com.m57.hermescontrol.theme.LocalSpacing
+import com.m57.hermescontrol.ui.common.DetailDialog
 import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.HermesScaffold
@@ -79,6 +81,7 @@ fun McpServersScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val spacing = LocalSpacing.current
     var query by remember { mutableStateOf("") }
+    var showDetail by remember { mutableStateOf<McpServer?>(null) }
 
     val filteredServers =
         remember(query, state.servers) {
@@ -162,7 +165,13 @@ fun McpServersScreen(
                     }
 
                     items(filteredServers, key = { "server:${it.name}" }) { server ->
-                        ServerCard(server = server, state = state, viewModel = viewModel, spacing = spacing)
+                        ServerCard(
+                            server = server,
+                            state = state,
+                            viewModel = viewModel,
+                            spacing = spacing,
+                            onClick = { showDetail = server },
+                        )
                     }
 
                     // ── 4. Catalog ──────────────────────────────────────
@@ -177,6 +186,30 @@ fun McpServersScreen(
                 }
             }
         }
+    }
+
+    showDetail?.let { server ->
+        DetailDialog(
+            title = server.name,
+            rows =
+                listOf(
+                    stringResource(R.string.detail_dialog_transport) to (server.transport ?: ""),
+                    stringResource(R.string.detail_dialog_status) to (server.status ?: ""),
+                    stringResource(R.string.detail_dialog_url) to (server.url ?: ""),
+                    stringResource(R.string.detail_dialog_command) to
+                        (
+                            if (server.command != null) {
+                                "${server.command} ${server.args.orEmpty().joinToString(" ")}"
+                            } else {
+                                ""
+                            }
+                        ),
+                    stringResource(R.string.detail_dialog_env_vars) to
+                        (server.env?.entries?.joinToString("\n") { "${it.key}=${it.value}" } ?: ""),
+                    stringResource(R.string.detail_dialog_error) to (server.error ?: ""),
+                ),
+            onDismiss = { showDetail = null },
+        )
     }
 }
 
@@ -279,11 +312,12 @@ private fun ServerCard(
     state: McpServersUiState,
     viewModel: McpServersViewModel,
     spacing: com.m57.hermescontrol.theme.Spacing,
+    onClick: () -> Unit,
 ) {
     var showEnv by remember { mutableStateOf(false) }
 
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
         colors =
             CardDefaults.cardColors(
                 containerColor =

--- a/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
@@ -71,6 +71,7 @@ import com.m57.hermescontrol.ui.common.StatusBadgeType
 import com.m57.hermescontrol.ui.common.ToastEffect
 import com.m57.hermescontrol.ui.common.listContentPadding
 import com.m57.hermescontrol.ui.common.listItemSpacing
+import com.m57.hermescontrol.ui.common.toDetailRows
 
 @Composable
 fun McpServersScreen(
@@ -191,23 +192,7 @@ fun McpServersScreen(
     showDetail?.let { server ->
         DetailDialog(
             title = server.name,
-            rows =
-                listOf(
-                    stringResource(R.string.detail_dialog_transport) to (server.transport ?: ""),
-                    stringResource(R.string.detail_dialog_status) to (server.status ?: ""),
-                    stringResource(R.string.detail_dialog_url) to (server.url ?: ""),
-                    stringResource(R.string.detail_dialog_command) to
-                        (
-                            if (server.command != null) {
-                                "${server.command} ${server.args.orEmpty().joinToString(" ")}"
-                            } else {
-                                ""
-                            }
-                        ),
-                    stringResource(R.string.detail_dialog_env_vars) to
-                        (server.env?.entries?.joinToString("\n") { "${it.key}=${it.value}" } ?: ""),
-                    stringResource(R.string.detail_dialog_error) to (server.error ?: ""),
-                ),
+            rows = server.toDetailRows(),
             onDismiss = { showDetail = null },
         )
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/plugins/PluginsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/plugins/PluginsScreen.kt
@@ -207,6 +207,20 @@ fun PluginsScreen(
             }
         }
     }
+
+    showDetail?.let { plugin ->
+        DetailDialog(
+            title = plugin.name,
+            rows =
+                listOf(
+                    stringResource(R.string.detail_dialog_version) to (plugin.version ?: ""),
+                    stringResource(R.string.detail_dialog_source) to (plugin.source ?: ""),
+                    stringResource(R.string.detail_dialog_status) to (plugin.runtimeStatus ?: ""),
+                    stringResource(R.string.detail_dialog_description) to (plugin.description ?: ""),
+                ),
+            onDismiss = { showDetail = null },
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -620,19 +634,5 @@ private fun OrphanPluginCard(
                 }
             }
         }
-    }
-
-    showDetail?.let { plugin ->
-        DetailDialog(
-            title = plugin.name,
-            rows =
-                listOf(
-                    stringResource(R.string.detail_dialog_version) to (plugin.version ?: ""),
-                    stringResource(R.string.detail_dialog_source) to (plugin.source ?: ""),
-                    stringResource(R.string.detail_dialog_status) to (plugin.runtimeStatus ?: ""),
-                    stringResource(R.string.detail_dialog_description) to (plugin.description ?: ""),
-                ),
-            onDismiss = { showDetail = null },
-        )
     }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/plugins/PluginsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/plugins/PluginsScreen.kt
@@ -62,6 +62,7 @@ import com.m57.hermescontrol.ui.common.SearchBar
 import com.m57.hermescontrol.ui.common.ToastEffect
 import com.m57.hermescontrol.ui.common.listContentPadding
 import com.m57.hermescontrol.ui.common.listItemSpacing
+import com.m57.hermescontrol.ui.common.toDetailRows
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -211,13 +212,7 @@ fun PluginsScreen(
     showDetail?.let { plugin ->
         DetailDialog(
             title = plugin.name,
-            rows =
-                listOf(
-                    stringResource(R.string.detail_dialog_version) to (plugin.version ?: ""),
-                    stringResource(R.string.detail_dialog_source) to (plugin.source ?: ""),
-                    stringResource(R.string.detail_dialog_status) to (plugin.runtimeStatus ?: ""),
-                    stringResource(R.string.detail_dialog_description) to (plugin.description ?: ""),
-                ),
+            rows = plugin.toDetailRows(),
             onDismiss = { showDetail = null },
         )
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/plugins/PluginsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/plugins/PluginsScreen.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol.ui.plugins
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -51,6 +52,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.PluginInfo
 import com.m57.hermescontrol.theme.LocalHermesStatusColors
+import com.m57.hermescontrol.ui.common.DetailDialog
 import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.HermesScaffold
@@ -71,6 +73,7 @@ fun PluginsScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     var query by remember { mutableStateOf("") }
+    var showDetail by remember { mutableStateOf<PluginInfo?>(null) }
 
     val filteredPlugins =
         remember(query, state.plugins) {
@@ -176,7 +179,12 @@ fun PluginsScreen(
 
                         // Plugin list
                         items(filteredPlugins, key = { it.name }) { plugin ->
-                            PluginCard(plugin = plugin, state = state, viewModel = viewModel)
+                            PluginCard(
+                                plugin = plugin,
+                                state = state,
+                                viewModel = viewModel,
+                                onClick = { showDetail = plugin },
+                            )
                         }
 
                         // Orphan dashboard plugins section
@@ -191,7 +199,7 @@ fun PluginsScreen(
                                 )
                             }
                             items(state.orphanPlugins, key = { "orphan-${it.name}" }) { plugin ->
-                                OrphanPluginCard(plugin = plugin)
+                                OrphanPluginCard(plugin = plugin, onClick = { showDetail = plugin })
                             }
                         }
                     }
@@ -422,11 +430,12 @@ private fun PluginCard(
     plugin: PluginInfo,
     state: PluginsUiState,
     viewModel: PluginsViewModel,
+    onClick: () -> Unit,
 ) {
     val busy = state.rowBusy == plugin.name
     val statusColors = LocalHermesStatusColors.current
 
-    Card(modifier = Modifier.fillMaxWidth()) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
         Column(modifier = Modifier.padding(16.dp)) {
             // Header row: name + toggle
             Row(
@@ -588,8 +597,11 @@ private fun PluginCard(
 }
 
 @Composable
-private fun OrphanPluginCard(plugin: PluginInfo) {
-    Card(modifier = Modifier.fillMaxWidth()) {
+private fun OrphanPluginCard(
+    plugin: PluginInfo,
+    onClick: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)) {
         Row(
             modifier = Modifier.padding(12.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -608,5 +620,19 @@ private fun OrphanPluginCard(plugin: PluginInfo) {
                 }
             }
         }
+    }
+
+    showDetail?.let { plugin ->
+        DetailDialog(
+            title = plugin.name,
+            rows =
+                listOf(
+                    stringResource(R.string.detail_dialog_version) to (plugin.version ?: ""),
+                    stringResource(R.string.detail_dialog_source) to (plugin.source ?: ""),
+                    stringResource(R.string.detail_dialog_status) to (plugin.runtimeStatus ?: ""),
+                    stringResource(R.string.detail_dialog_description) to (plugin.description ?: ""),
+                ),
+            onDismiss = { showDetail = null },
+        )
     }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -76,6 +76,7 @@ import com.m57.hermescontrol.ui.common.SearchBar
 import com.m57.hermescontrol.ui.common.ToastEffect
 import com.m57.hermescontrol.ui.common.listContentPadding
 import com.m57.hermescontrol.ui.common.listItemSpacing
+import com.m57.hermescontrol.ui.common.toDetailRows
 
 internal const val CATEGORY_ALL = "All"
 
@@ -362,12 +363,7 @@ private fun InstalledSkillsView(
     showDetail?.let { skill ->
         DetailDialog(
             title = skill.name,
-            rows =
-                listOf(
-                    stringResource(R.string.detail_dialog_category) to (skill.category ?: ""),
-                    stringResource(R.string.detail_dialog_source) to (skill.source ?: ""),
-                    stringResource(R.string.detail_dialog_description) to (skill.description ?: ""),
-                ),
+            rows = skill.toDetailRows(),
             onDismiss = { showDetail = null },
         )
     }
@@ -536,6 +532,8 @@ private fun HubBrowseView(
     isInstalling: Boolean,
     installingSkillName: String?,
 ) {
+    var hubShowDetail by remember { mutableStateOf<HubSkill?>(null) }
+
     Column(modifier = Modifier.fillMaxSize()) {
         OutlinedTextField(
             value = hubQuery,
@@ -616,6 +614,7 @@ private fun HubBrowseView(
                             hubSkill = hubSkill,
                             onInstall = { onInstall(hubSkill.name) },
                             isInstalling = isInstalling && installingSkillName == hubSkill.name,
+                            onClick = { hubShowDetail = hubSkill },
                         )
                     }
                 }
@@ -629,6 +628,14 @@ private fun HubBrowseView(
             }
         }
     }
+
+    hubShowDetail?.let { hubSkill ->
+        DetailDialog(
+            title = hubSkill.name,
+            rows = hubSkill.toDetailRows(),
+            onDismiss = { hubShowDetail = null },
+        )
+    }
 }
 
 // ── Hub Skill Card ─────────────────────────────────────────────────────
@@ -638,9 +645,10 @@ private fun HubSkillCard(
     hubSkill: HubSkill,
     onInstall: () -> Unit,
     isInstalling: Boolean,
+    onClick: () -> Unit,
 ) {
     Card(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).clickable(onClick = onClick),
         colors =
             CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surface,

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol.ui.skills
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -64,6 +65,7 @@ import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.HubSkill
 import com.m57.hermescontrol.data.model.Skill
 import com.m57.hermescontrol.theme.LocalHermesStatusColors
+import com.m57.hermescontrol.ui.common.DetailDialog
 import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.FilterChipRow
@@ -214,6 +216,8 @@ private fun InstalledSkillsView(
     uninstallingSkillName: String?,
     onRefresh: () -> Unit,
 ) {
+    var showDetail by remember { mutableStateOf<Skill?>(null) }
+
     val categories =
         remember(state.skills) {
             state.skills
@@ -347,11 +351,25 @@ private fun InstalledSkillsView(
                                     null
                                 },
                             isUninstalling = isUninstalling && uninstallingSkillName == skill.name,
+                            onClick = { showDetail = skill },
                         )
                     }
                 }
             }
         }
+    }
+
+    showDetail?.let { skill ->
+        DetailDialog(
+            title = skill.name,
+            rows =
+                listOf(
+                    stringResource(R.string.detail_dialog_category) to (skill.category ?: ""),
+                    stringResource(R.string.detail_dialog_source) to (skill.source ?: ""),
+                    stringResource(R.string.detail_dialog_description) to (skill.description ?: ""),
+                ),
+            onDismiss = { showDetail = null },
+        )
     }
 }
 
@@ -364,9 +382,10 @@ private fun SkillCard(
     onAction: () -> Unit,
     onUninstall: (() -> Unit)?,
     isUninstalling: Boolean,
+    onClick: () -> Unit,
 ) {
     Card(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).clickable(onClick = onClick),
         colors =
             CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surface,

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -66,6 +66,7 @@ import com.m57.hermescontrol.data.model.HubSkill
 import com.m57.hermescontrol.data.model.Skill
 import com.m57.hermescontrol.theme.LocalHermesStatusColors
 import com.m57.hermescontrol.ui.common.DetailDialog
+import com.m57.hermescontrol.ui.common.DetailRow
 import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.FilterChipRow
@@ -159,6 +160,7 @@ fun SkillsScreen(
                         onSearch = viewModel::searchHub,
                         onClearSearch = viewModel::clearHubSearch,
                         onInstall = viewModel::installSkill,
+                        onPreviewHubSkill = viewModel::previewHubSkill,
                         isInstalling = state.isInstalling,
                         installingSkillName = state.installingSkillName,
                     )
@@ -529,6 +531,7 @@ private fun HubBrowseView(
     onSearch: (String) -> Unit,
     onClearSearch: () -> Unit,
     onInstall: (String) -> Unit,
+    onPreviewHubSkill: (String) -> Unit,
     isInstalling: Boolean,
     installingSkillName: String?,
 ) {
@@ -614,7 +617,10 @@ private fun HubBrowseView(
                             hubSkill = hubSkill,
                             onInstall = { onInstall(hubSkill.name) },
                             isInstalling = isInstalling && installingSkillName == hubSkill.name,
-                            onClick = { hubShowDetail = hubSkill },
+                            onClick = {
+                                hubShowDetail = hubSkill
+                                hubSkill.identifier?.let { onPreviewHubSkill(it) }
+                            },
                         )
                     }
                 }
@@ -630,9 +636,29 @@ private fun HubBrowseView(
     }
 
     hubShowDetail?.let { hubSkill ->
+        val previewReady = state.hubPreviewIdentifier == hubSkill.identifier
+        val fullContent =
+            if (previewReady) {
+                state.hubPreviewContent ?: hubSkill.description
+            } else {
+                hubSkill.description
+            }
         DetailDialog(
             title = hubSkill.name,
-            rows = hubSkill.toDetailRows(),
+            rows =
+                listOf(
+                    DetailRow(stringResource(R.string.detail_dialog_category), hubSkill.category),
+                    DetailRow(stringResource(R.string.detail_dialog_source), hubSkill.source),
+                    DetailRow(stringResource(R.string.detail_dialog_description), fullContent),
+                    DetailRow(stringResource(R.string.detail_dialog_tags), hubSkill.tags.orEmpty().joinToString(", ")),
+                    DetailRow(stringResource(R.string.detail_dialog_trust_level), hubSkill.trustLevel),
+                ),
+            actions =
+                if (previewReady && state.isHubPreviewing) {
+                    { CircularProgressIndicator(modifier = Modifier.padding(top = 8.dp)) }
+                } else {
+                    null
+                },
             onDismiss = { hubShowDetail = null },
         )
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsViewModel.kt
@@ -56,6 +56,11 @@ data class SkillsUiState(
     val hubResults: List<HubSkill> = emptyList(),
     val isHubSearching: Boolean = false,
     val hubSearchError: String? = null,
+    // Hub detail preview (full description/content via preview endpoint)
+    val hubPreviewIdentifier: String? = null,
+    val hubPreviewContent: String? = null,
+    val isHubPreviewing: Boolean = false,
+    val hubPreviewError: String? = null,
     // Hub install
     val isInstalling: Boolean = false,
     val installingSkillName: String? = null,
@@ -149,6 +154,60 @@ class SkillsViewModel(application: Application) :
                 hubQuery = "",
                 hubResults = emptyList(),
                 hubSearchError = null,
+            )
+        }
+    }
+
+    // ── Hub detail preview ──────────────────────────────────────────────────
+
+    /**
+     * Fetches the full skill content via the preview endpoint so the detail
+     * dialog can show the complete description (search results only carry a
+     * truncated snippet).
+     */
+    fun previewHubSkill(identifier: String) {
+        if (identifier.isBlank()) return
+        _uiState.update {
+            it.copy(
+                hubPreviewIdentifier = identifier,
+                isHubPreviewing = true,
+                hubPreviewError = null,
+                hubPreviewContent = null,
+            )
+        }
+        viewModelScope.launch {
+            val result =
+                withContext(Dispatchers.IO) {
+                    safeApiCall { ApiClient.hermesApi.previewHubSkill(identifier = identifier) }
+                }
+            when (result) {
+                is NetworkResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            isHubPreviewing = false,
+                            hubPreviewContent = result.data.content,
+                        )
+                    }
+                }
+                is NetworkResult.Failure -> {
+                    _uiState.update {
+                        it.copy(
+                            isHubPreviewing = false,
+                            hubPreviewError = result.error.message,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun clearHubPreview() {
+        _uiState.update {
+            it.copy(
+                hubPreviewIdentifier = null,
+                hubPreviewContent = null,
+                isHubPreviewing = false,
+                hubPreviewError = null,
             )
         }
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
@@ -32,6 +32,8 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol.ui.skills.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -41,6 +42,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.HubSkill
+import com.m57.hermescontrol.ui.common.DetailDialog
 import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.LoadingState
@@ -59,6 +61,8 @@ internal fun HubBrowseView(
     isInstalling: Boolean,
     installingSkillName: String?,
 ) {
+    var showDetail by remember { mutableStateOf<HubSkill?>(null) }
+
     Column(modifier = Modifier.fillMaxSize()) {
         OutlinedTextField(
             value = hubQuery,
@@ -139,6 +143,7 @@ internal fun HubBrowseView(
                             hubSkill = hubSkill,
                             onInstall = { onInstall(hubSkill.name) },
                             isInstalling = isInstalling && installingSkillName == hubSkill.name,
+                            onClick = { showDetail = hubSkill },
                         )
                     }
                 }
@@ -152,6 +157,20 @@ internal fun HubBrowseView(
             }
         }
     }
+
+    showDetail?.let { hubSkill ->
+        DetailDialog(
+            title = hubSkill.name,
+            rows =
+                listOf(
+                    stringResource(R.string.detail_dialog_category) to (hubSkill.category ?: ""),
+                    stringResource(R.string.detail_dialog_source) to (hubSkill.source ?: ""),
+                    stringResource(R.string.detail_dialog_description) to (hubSkill.description ?: ""),
+                    stringResource(R.string.detail_dialog_tags) to (hubSkill.tags.orEmpty().joinToString(", ")),
+                ),
+            onDismiss = { showDetail = null },
+        )
+    }
 }
 
 @Composable
@@ -159,9 +178,10 @@ private fun HubSkillCard(
     hubSkill: HubSkill,
     onInstall: () -> Unit,
     isInstalling: Boolean,
+    onClick: () -> Unit,
 ) {
     Card(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).clickable(onClick = onClick),
         colors =
             CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surface,

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
@@ -45,12 +45,12 @@ import androidx.compose.ui.unit.dp
 import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.HubSkill
 import com.m57.hermescontrol.ui.common.DetailDialog
+import com.m57.hermescontrol.ui.common.DetailRow
 import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.LoadingState
 import com.m57.hermescontrol.ui.common.listContentPadding
 import com.m57.hermescontrol.ui.common.listItemSpacing
-import com.m57.hermescontrol.ui.common.toDetailRows
 import com.m57.hermescontrol.ui.skills.SkillsUiState
 
 @Composable
@@ -61,6 +61,7 @@ internal fun HubBrowseView(
     onSearch: (String) -> Unit,
     onClearSearch: () -> Unit,
     onInstall: (String) -> Unit,
+    onPreviewHubSkill: (String) -> Unit,
     isInstalling: Boolean,
     installingSkillName: String?,
 ) {
@@ -146,7 +147,10 @@ internal fun HubBrowseView(
                             hubSkill = hubSkill,
                             onInstall = { onInstall(hubSkill.name) },
                             isInstalling = isInstalling && installingSkillName == hubSkill.name,
-                            onClick = { showDetail = hubSkill },
+                            onClick = {
+                                showDetail = hubSkill
+                                hubSkill.identifier?.let { onPreviewHubSkill(it) }
+                            },
                         )
                     }
                 }
@@ -162,9 +166,29 @@ internal fun HubBrowseView(
     }
 
     showDetail?.let { hubSkill ->
+        val previewReady = state.hubPreviewIdentifier == hubSkill.identifier
+        val fullContent =
+            if (previewReady) {
+                state.hubPreviewContent ?: hubSkill.description
+            } else {
+                hubSkill.description
+            }
         DetailDialog(
             title = hubSkill.name,
-            rows = hubSkill.toDetailRows(),
+            rows =
+                listOf(
+                    DetailRow(stringResource(R.string.detail_dialog_category), hubSkill.category),
+                    DetailRow(stringResource(R.string.detail_dialog_source), hubSkill.source),
+                    DetailRow(stringResource(R.string.detail_dialog_description), fullContent),
+                    DetailRow(stringResource(R.string.detail_dialog_tags), hubSkill.tags.orEmpty().joinToString(", ")),
+                    DetailRow(stringResource(R.string.detail_dialog_trust_level), hubSkill.trustLevel),
+                ),
+            actions =
+                if (previewReady && state.isHubPreviewing) {
+                    { CircularProgressIndicator(modifier = Modifier.padding(top = 8.dp)) }
+                } else {
+                    null
+                },
             onDismiss = { showDetail = null },
         )
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
@@ -50,6 +50,7 @@ import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.LoadingState
 import com.m57.hermescontrol.ui.common.listContentPadding
 import com.m57.hermescontrol.ui.common.listItemSpacing
+import com.m57.hermescontrol.ui.common.toDetailRows
 import com.m57.hermescontrol.ui.skills.SkillsUiState
 
 @Composable
@@ -163,13 +164,7 @@ internal fun HubBrowseView(
     showDetail?.let { hubSkill ->
         DetailDialog(
             title = hubSkill.name,
-            rows =
-                listOf(
-                    stringResource(R.string.detail_dialog_category) to (hubSkill.category ?: ""),
-                    stringResource(R.string.detail_dialog_source) to (hubSkill.source ?: ""),
-                    stringResource(R.string.detail_dialog_description) to (hubSkill.description ?: ""),
-                    stringResource(R.string.detail_dialog_tags) to (hubSkill.tags.orEmpty().joinToString(", ")),
-                ),
+            rows = hubSkill.toDetailRows(),
             onDismiss = { showDetail = null },
         )
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol.ui.skills.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -44,6 +45,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.Skill
 import com.m57.hermescontrol.theme.LocalHermesStatusColors
+import com.m57.hermescontrol.ui.common.DetailDialog
 import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.FilterChipRow
@@ -75,6 +77,8 @@ internal fun InstalledSkillsView(
     uninstallingSkillName: String?,
     onRefresh: () -> Unit,
 ) {
+    var showDetail by remember { mutableStateOf<Skill?>(null) }
+
     val categories =
         remember(state.skills) {
             state.skills
@@ -208,11 +212,27 @@ internal fun InstalledSkillsView(
                                     null
                                 },
                             isUninstalling = isUninstalling && uninstallingSkillName == skill.name,
+                            onClick = {
+                                showDetail = skill
+                            },
                         )
                     }
                 }
             }
         }
+    }
+
+    showDetail?.let { skill ->
+        DetailDialog(
+            title = skill.name,
+            rows =
+                listOf(
+                    stringResource(R.string.detail_dialog_category) to (skill.category ?: ""),
+                    stringResource(R.string.detail_dialog_source) to (skill.source ?: ""),
+                    stringResource(R.string.detail_dialog_description) to (skill.description ?: ""),
+                ),
+            onDismiss = { showDetail = null },
+        )
     }
 }
 
@@ -223,9 +243,10 @@ private fun SkillCard(
     onAction: () -> Unit,
     onUninstall: (() -> Unit)?,
     isUninstalling: Boolean,
+    onClick: () -> Unit,
 ) {
     Card(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).clickable(onClick = onClick),
         colors =
             CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surface,

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
@@ -56,6 +56,7 @@ import com.m57.hermescontrol.ui.common.NavIcon
 import com.m57.hermescontrol.ui.common.SearchBar
 import com.m57.hermescontrol.ui.common.listContentPadding
 import com.m57.hermescontrol.ui.common.listItemSpacing
+import com.m57.hermescontrol.ui.common.toDetailRows
 import com.m57.hermescontrol.ui.skills.CATEGORY_ALL
 import com.m57.hermescontrol.ui.skills.SkillFilter
 import com.m57.hermescontrol.ui.skills.SkillsUiState
@@ -226,12 +227,7 @@ internal fun InstalledSkillsView(
     showDetail?.let { skill ->
         DetailDialog(
             title = skill.name,
-            rows =
-                listOf(
-                    stringResource(R.string.detail_dialog_category) to (skill.category ?: ""),
-                    stringResource(R.string.detail_dialog_source) to (skill.source ?: ""),
-                    stringResource(R.string.detail_dialog_description) to (skill.description ?: ""),
-                ),
+            rows = skill.toDetailRows(),
             onDismiss = { showDetail = null },
         )
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/toolsets/ToolsetsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/toolsets/ToolsetsScreen.kt
@@ -50,6 +50,7 @@ import com.m57.hermescontrol.ui.common.SearchBar
 import com.m57.hermescontrol.ui.common.ToastEffect
 import com.m57.hermescontrol.ui.common.listContentPadding
 import com.m57.hermescontrol.ui.common.listItemSpacing
+import com.m57.hermescontrol.ui.common.toDetailRows
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -216,20 +217,7 @@ fun ToolsetsScreen(
         showDetail?.let { toolset ->
             DetailDialog(
                 title = toolset.label ?: toolset.name,
-                rows =
-                    listOf(
-                        stringResource(R.string.detail_dialog_label) to (toolset.label ?: ""),
-                        stringResource(R.string.detail_dialog_description) to (toolset.description ?: ""),
-                        stringResource(R.string.detail_dialog_tools) to (toolset.tools.orEmpty().joinToString(", ")),
-                        stringResource(R.string.detail_dialog_status) to
-                            (
-                                if (toolset.enabled) {
-                                    stringResource(R.string.detail_dialog_status_enabled)
-                                } else {
-                                    stringResource(R.string.detail_dialog_status_disabled)
-                                }
-                            ),
-                    ),
+                rows = toolset.toDetailRows(),
                 onDismiss = { showDetail = null },
             )
         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/toolsets/ToolsetsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/toolsets/ToolsetsScreen.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol.ui.toolsets
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -38,6 +39,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.m57.hermescontrol.R
+import com.m57.hermescontrol.data.model.Toolset
+import com.m57.hermescontrol.ui.common.DetailDialog
 import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.HermesScaffold
@@ -58,6 +61,7 @@ fun ToolsetsScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     var query by remember { mutableStateOf("") }
+    var showDetail by remember { mutableStateOf<Toolset?>(null) }
 
     val filteredToolsets =
         remember(query, state.toolsets) {
@@ -136,7 +140,7 @@ fun ToolsetsScreen(
                             }
                             items(filteredToolsets, key = { it.name }) { toolset ->
                                 Card(
-                                    modifier = Modifier.fillMaxWidth(),
+                                    modifier = Modifier.fillMaxWidth().clickable(onClick = { showDetail = toolset }),
                                     colors =
                                         CardDefaults.cardColors(
                                             containerColor =
@@ -207,6 +211,27 @@ fun ToolsetsScreen(
                     }
                 }
             }
+        }
+
+        showDetail?.let { toolset ->
+            DetailDialog(
+                title = toolset.label ?: toolset.name,
+                rows =
+                    listOf(
+                        stringResource(R.string.detail_dialog_label) to (toolset.label ?: ""),
+                        stringResource(R.string.detail_dialog_description) to (toolset.description ?: ""),
+                        stringResource(R.string.detail_dialog_tools) to (toolset.tools.orEmpty().joinToString(", ")),
+                        stringResource(R.string.detail_dialog_status) to
+                            (
+                                if (toolset.enabled) {
+                                    stringResource(R.string.detail_dialog_status_enabled)
+                                } else {
+                                    stringResource(R.string.detail_dialog_status_disabled)
+                                }
+                            ),
+                    ),
+                onDismiss = { showDetail = null },
+            )
         }
     }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/webhooks/WebhooksScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/webhooks/WebhooksScreen.kt
@@ -61,6 +61,7 @@ import com.m57.hermescontrol.ui.common.StatusBadgeType
 import com.m57.hermescontrol.ui.common.ToastEffect
 import com.m57.hermescontrol.ui.common.listContentPadding
 import com.m57.hermescontrol.ui.common.listItemSpacing
+import com.m57.hermescontrol.ui.common.toDetailRows
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -371,26 +372,7 @@ fun WebhooksScreen(
     showDetail?.let { sub ->
         DetailDialog(
             title = sub.name,
-            rows =
-                listOf(
-                    stringResource(R.string.detail_dialog_status) to
-                        (
-                            if (sub.enabled == true) {
-                                stringResource(
-                                    R.string.detail_dialog_status_enabled,
-                                )
-                            } else {
-                                stringResource(R.string.detail_dialog_status_disabled)
-                            }
-                        ),
-                    stringResource(R.string.detail_dialog_deliver) to (sub.deliver ?: ""),
-                    stringResource(R.string.detail_dialog_description) to (sub.description ?: ""),
-                    stringResource(R.string.detail_dialog_events) to (sub.events.orEmpty().joinToString(", ")),
-                    stringResource(R.string.detail_dialog_prompt) to (sub.prompt ?: ""),
-                    stringResource(R.string.detail_dialog_skills) to (sub.skills.orEmpty().joinToString(", ")),
-                    stringResource(R.string.detail_dialog_url) to (sub.url),
-                    stringResource(R.string.detail_dialog_created_at) to (sub.created_at ?: ""),
-                ),
+            rows = sub.toDetailRows(),
             onDismiss = { showDetail = null },
         )
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/webhooks/WebhooksScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/webhooks/WebhooksScreen.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol.ui.webhooks
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
@@ -48,6 +49,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.WebhookSubscription
+import com.m57.hermescontrol.ui.common.DetailDialog
 import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.HermesScaffold
@@ -70,6 +72,7 @@ fun WebhooksScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     var query by remember { mutableStateOf("") }
+    var showDetail by remember { mutableStateOf<WebhookSubscription?>(null) }
 
     val filteredSubscriptions =
         remember(query, state.subscriptions) {
@@ -356,12 +359,40 @@ fun WebhooksScreen(
                                 isToggling = state.togglingName == sub.name,
                                 onToggle = { enabled -> viewModel.toggleSubscription(sub.name, enabled) },
                                 onDelete = { viewModel.promptDeleteSubscription(sub) },
+                                onClick = { showDetail = sub },
                             )
                         }
                     }
                 }
             }
         }
+    }
+
+    showDetail?.let { sub ->
+        DetailDialog(
+            title = sub.name,
+            rows =
+                listOf(
+                    stringResource(R.string.detail_dialog_status) to
+                        (
+                            if (sub.enabled == true) {
+                                stringResource(
+                                    R.string.detail_dialog_status_enabled,
+                                )
+                            } else {
+                                stringResource(R.string.detail_dialog_status_disabled)
+                            }
+                        ),
+                    stringResource(R.string.detail_dialog_deliver) to (sub.deliver ?: ""),
+                    stringResource(R.string.detail_dialog_description) to (sub.description ?: ""),
+                    stringResource(R.string.detail_dialog_events) to (sub.events.orEmpty().joinToString(", ")),
+                    stringResource(R.string.detail_dialog_prompt) to (sub.prompt ?: ""),
+                    stringResource(R.string.detail_dialog_skills) to (sub.skills.orEmpty().joinToString(", ")),
+                    stringResource(R.string.detail_dialog_url) to (sub.url),
+                    stringResource(R.string.detail_dialog_created_at) to (sub.created_at ?: ""),
+                ),
+            onDismiss = { showDetail = null },
+        )
     }
 }
 
@@ -371,11 +402,12 @@ private fun SubscriptionCard(
     isToggling: Boolean,
     onToggle: (Boolean) -> Unit,
     onDelete: () -> Unit,
+    onClick: () -> Unit,
 ) {
     val isEnabled = sub.enabled ?: true
 
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
         colors =
             CardDefaults.cardColors(
                 containerColor =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -653,6 +653,7 @@
     <string name="detail_dialog_error">Error</string>
     <string name="detail_dialog_status_enabled">Enabled</string>
     <string name="detail_dialog_status_disabled">Disabled</string>
+    <string name="detail_dialog_trust_level">Trust Level</string>
 
     <!-- McpServers Screen -->
     <string name="mcp_servers_label_transport">Transport: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -630,6 +630,30 @@
     <string name="plugins_show_in_sidebar">Show in sidebar</string>
     <string name="plugins_hide_from_sidebar">Hide from sidebar</string>
 
+    <!-- Shared detail dialog (issue #500) -->
+    <string name="detail_dialog_no_info">No additional details available.</string>
+    <string name="detail_dialog_category">Category</string>
+    <string name="detail_dialog_source">Source</string>
+    <string name="detail_dialog_version">Version</string>
+    <string name="detail_dialog_status">Status</string>
+    <string name="detail_dialog_description">Description</string>
+    <string name="detail_dialog_tags">Tags</string>
+    <string name="detail_dialog_transport">Transport</string>
+    <string name="detail_dialog_label">Label</string>
+    <string name="detail_dialog_url">URL</string>
+    <string name="detail_dialog_command">Command</string>
+    <string name="detail_dialog_args">Arguments</string>
+    <string name="detail_dialog_env_vars">Environment Variables</string>
+    <string name="detail_dialog_tools">Tools</string>
+    <string name="detail_dialog_events">Events</string>
+    <string name="detail_dialog_deliver">Deliver to</string>
+    <string name="detail_dialog_prompt">Prompt</string>
+    <string name="detail_dialog_skills">Skills</string>
+    <string name="detail_dialog_created_at">Created</string>
+    <string name="detail_dialog_error">Error</string>
+    <string name="detail_dialog_status_enabled">Enabled</string>
+    <string name="detail_dialog_status_disabled">Disabled</string>
+
     <!-- McpServers Screen -->
     <string name="mcp_servers_label_transport">Transport: %1$s</string>
     <string name="mcp_servers_label_command">Command:</string>


### PR DESCRIPTION
## Summary

Closes #500.

Several list screens truncate item descriptions with no way to read the full text. This adds a shared `DetailDialog` composable and wires tap-to-open detail dialogs across all affected screens.

## What changed

- **New** `ui/common/DetailDialog.kt` — reusable dialog (title + label/value rows + optional action slot) matching the existing `SkillPreviewDialog` style. Null/blank rows are skipped automatically.
- **Skills — Installed** (`InstalledSkillsTab` + `SkillsScreen`): tap card → full description, category, source.
- **Skills — Hub** (`HubSkillsTab`): tap row → full description, category, source, tags.
- **MCP Servers**: tap card → transport, status, URL/command, env-var summary, error (model has no description field, so config details are shown).
- **Plugins**: tap card (incl. orphan) → version, source, status, full description.
- **Toolsets**: tap card → label, full description, tools list, enabled/disabled state.
- **Webhooks**: tap card → status, deliver target, full description, events, prompt, skills, URL, created date.

## Design notes

- Action buttons (toggle / edit / install / uninstall / test / delete) **stay on the card** so they remain sticky and don't scroll away — only the card body tap opens the detail dialog.
- `ktlintCheck` passes locally (no Android SDK in this env, so `compileDebugKotlin` runs in CI).

## Acceptance criteria coverage

- [x] Installed skills: full description + category + source + tags
- [x] Hub skills: full description + install present on card
- [x] MCP installed: config details shown (description not in model)
- [x] Plugins: full description + version + source + status
- [x] Toolsets: full description
- [x] Webhooks: full description + metadata

## Summary by Sourcery

Introduce a shared DetailDialog composable and wire tap-to-reveal detail dialogs across list-based screens to show full item metadata when cards are tapped.

New Features:
- Add reusable DetailDialog composable for displaying labeled metadata rows in a scrollable dialog.
- Enable tap-to-open detail dialogs for installed skills, hub skills, MCP servers, plugins (including orphan plugins), toolsets, and webhooks to show full descriptions and related fields.

Enhancements:
- Make list item cards (skills, plugins, MCP servers, toolsets, webhooks) clickable while keeping their existing action controls on the cards.
- Add localized string resources for shared detail dialog labels and statuses used across multiple screens.