### PR TITLE
fix: move skill source badge beside install button in hub cards

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -683,26 +683,17 @@ private fun HubSkillCard(
         Column(
             modifier = Modifier.fillMaxWidth().padding(16.dp),
         ) {
-            // ── Top row: name + source badge ──
-            Row(
+            // ── Top row: name ──
+            Text(
+                text = hubSkill.name,
+                style =
+                    MaterialTheme.typography.titleMedium.copy(
+                        fontWeight = FontWeight.SemiBold,
+                    ),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = hubSkill.name,
-                    style =
-                        MaterialTheme.typography.titleMedium.copy(
-                            fontWeight = FontWeight.SemiBold,
-                        ),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f),
-                )
-                hubSkill.source?.let { source ->
-                    Spacer(modifier = Modifier.width(6.dp))
-                    SourceBadge(source = source)
-                }
-            }
+            )
 
             // ── Category ──
             hubSkill.category?.let { cat ->
@@ -726,12 +717,17 @@ private fun HubSkillCard(
                 )
             }
 
-            // ── Install button ──
+            // ── Source badge + Install button ──
             Spacer(modifier = Modifier.height(8.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
+                hubSkill.source?.let { source ->
+                    SourceBadge(source = source)
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                Spacer(modifier = Modifier.weight(1f))
                 Button(
                     onClick = onInstall,
                     enabled = !isInstalling,


### PR DESCRIPTION
## Summary
- The hub skill cards are rendered by the **local private** HubSkillCard inside SkillsScreen.kt (a duplicate components/HubSkillsTab.kt copy exists but is NOT used — it is shadowed by the private one).
- Moved SourceBadge out of the top-right of the skill-name row to the **left of the Install button** in the card footer (left-aligned source, right-aligned action), so the origin (hub / built-in / optional / clawhub / raw string) sits next to the install action.

## Before vs After
BEFORE: [ skill-name ... [clawhub] ] / [Install]
AFTER:  [ skill-name ] / [clawhub] ... [Install]

## Verification
- ktlint --format clean on the edited file.
- compileDebugKotlin -> BUILD SUCCESSFUL (local Android SDK).
- Branch touches ONLY SkillsScreen.kt (the unused duplicate file is reverted to main).

## Type of change
- UI tweak (no install-logic change)