### PR TITLE
🧪 [Testing Improvement] Add unit test for ChatViewModel.refreshSettings

### DIFF
--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -894,15 +894,21 @@ class ChatViewModelTest {
     @Test
     fun testRefreshSettings_updatesUiState() =
         runTest {
-            // Given the default setup, let's override the AuthManager properties
-            // differently than the setUp defaults to verify the refresh action.
-            every { AuthManager.isTypingEffectEnabled() } returns false
-            every { AuthManager.getTypingEffectDelayMs() } returns 50
-
+            // Given the default setup, init{} already calls refreshSettings() once,
+            // so the initial state reflects the setUp defaults (typingEffectEnabled=true,
+            // typingEffectDelayMs=30).
             val viewModel = createViewModel()
             advanceUntilIdle()
+            with(viewModel.uiState.value) {
+                assertTrue(typingEffectEnabled)
+                assertEquals(30, typingEffectDelayMs)
+            }
 
-            // When
+            // When settings change after construction and refreshSettings() is re-invoked,
+            // the UI state must reflect the NEW values — this proves refreshSettings()
+            // re-reads AuthManager live (the real regression scenario).
+            every { AuthManager.isTypingEffectEnabled() } returns false
+            every { AuthManager.getTypingEffectDelayMs() } returns 50
             viewModel.refreshSettings()
             advanceUntilIdle()
 

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -888,4 +888,27 @@ class ChatViewModelTest {
             assertNotNull(msgAfter)
             assertNull(msgAfter!!.approvalInfo)
         }
+
+    // ── Settings ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun testRefreshSettings_updatesUiState() =
+        runTest {
+            // Given the default setup, let's override the AuthManager properties
+            // differently than the setUp defaults to verify the refresh action.
+            every { AuthManager.isTypingEffectEnabled() } returns false
+            every { AuthManager.getTypingEffectDelayMs() } returns 50
+
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            // When
+            viewModel.refreshSettings()
+            advanceUntilIdle()
+
+            // Then
+            val state = viewModel.uiState.value
+            assertFalse(state.typingEffectEnabled)
+            assertEquals(50, state.typingEffectDelayMs)
+        }
 }

--- a/test_plan.md
+++ b/test_plan.md
@@ -1,4 +1,0 @@
-1. Add a new test case `testRefreshSettings_updatesUiState` in `app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt`.
-2. The test will mock `AuthManager` properties, call `refreshSettings()`, and verify that `uiState.value.typingEffectEnabled` and `uiState.value.typingEffectDelayMs` are updated accordingly.
-3. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
-4. Submit the pull request with a descriptive title and description outlining the testing gap addressed, scenarios covered, and improvement in test coverage.

--- a/test_plan.md
+++ b/test_plan.md
@@ -1,0 +1,4 @@
+1. Add a new test case `testRefreshSettings_updatesUiState` in `app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt`.
+2. The test will mock `AuthManager` properties, call `refreshSettings()`, and verify that `uiState.value.typingEffectEnabled` and `uiState.value.typingEffectDelayMs` are updated accordingly.
+3. Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+4. Submit the pull request with a descriptive title and description outlining the testing gap addressed, scenarios covered, and improvement in test coverage.


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for the `refreshSettings` method in `ChatViewModel`.
📊 **Coverage:** Specifically tested that `uiState.typingEffectEnabled` and `uiState.typingEffectDelayMs` accurately reflect the values returned by `AuthManager` when `refreshSettings()` is invoked.
✨ **Result:** Increased test coverage for `ChatViewModel`, ensuring that state updates reliant on settings modifications work deterministically.

---
*PR created automatically by Jules for task [16572352253623561998](https://jules.google.com/task/16572352253623561998) started by @Hy4ri*

## Summary by Sourcery

Add a unit test to verify ChatViewModel.refreshSettings correctly updates typing-related UI state from AuthManager settings.

Documentation:
- Add a brief test plan document outlining the steps to add and validate the new ChatViewModel.refreshSettings test.

Tests:
- Add a new ChatViewModelTest case to ensure refreshSettings synchronizes typing effect enabled flag and delay with AuthManager configuration.