### PR TITLE
🧪 Add tests for KeysViewModel field updates

### DIFF
--- a/app/src/test/java/com/m57/hermescontrol/ui/keys/KeysViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/keys/KeysViewModelTest.kt
@@ -1,0 +1,57 @@
+package com.m57.hermescontrol.ui.keys
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class KeysViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    private fun createViewModel(): KeysViewModel {
+        val vm = KeysViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+        return vm
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `setNewKeyName updates state flow correctly`() {
+        val viewModel = createViewModel()
+
+        assertEquals("", viewModel.uiState.value.newKeyName)
+
+        viewModel.setNewKeyName("MY_NEW_API_KEY")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("MY_NEW_API_KEY", viewModel.uiState.value.newKeyName)
+    }
+
+    @Test
+    fun `setNewKeyValue updates state flow correctly`() {
+        val viewModel = createViewModel()
+
+        assertEquals("", viewModel.uiState.value.newKeyValue)
+
+        viewModel.setNewKeyValue("dummy_token_value_that_is_long_enough")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("dummy_token_value_that_is_long_enough", viewModel.uiState.value.newKeyValue)
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added tests to cover the `setNewKeyName` and `setNewKeyValue` functions in `KeysViewModel` which were missing test coverage.
📊 **Coverage:** Covered happy paths for updating the `newKeyName` and `newKeyValue` property states in the `KeysUiState`. Tests run asynchronously using `StandardTestDispatcher` and `advanceUntilIdle` for correct observation of the UI state changes.
✨ **Result:** Improved confidence in the key creation flow and increased the codebase test coverage.

---
*PR created automatically by Jules for task [18291972005956801126](https://jules.google.com/task/18291972005956801126) started by @Hy4ri*

## Summary by Sourcery

Tests:
- Add coroutine-based tests ensuring setNewKeyName and setNewKeyValue correctly update KeysUiState flows.