### PR TITLE
🧪 [Test] Add unit tests for ChatViewModel.interruptSession

### DIFF
--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -711,6 +711,29 @@ class ChatViewModelTest {
             verify { HermesWsClient.send(WsMethods.SESSION_RESUME, mapOf("session_id" to "session-456"), any()) }
         }
 
+    @Test
+    fun testInterruptSession_withSessionId_sendsRpc() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+
+            viewModel.interruptSession()
+            advanceUntilIdle()
+
+            verify { HermesWsClient.send(WsMethods.SESSION_INTERRUPT, mapOf("session_id" to sessionId), any()) }
+        }
+
+    @Test
+    fun testInterruptSession_withoutSessionId_doesNotSendRpc() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.interruptSession()
+            advanceUntilIdle()
+
+            verify(exactly = 0) { HermesWsClient.send(WsMethods.SESSION_INTERRUPT, any(), any()) }
+        }
+
     // ── Error handling ───────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests for the `interruptSession` function in `ChatViewModel.kt`.
📊 **Coverage:** The new tests cover two scenarios:
1. When a valid `currentSessionId` exists, it verifies that the `SESSION_INTERRUPT` WebSocket RPC is sent with the correct session ID.
2. When no session is active (i.e., `currentSessionId` is null), it verifies that the ViewModel does not attempt to send any RPC requests over the WebSocket client.
✨ **Result:** The improvement in test coverage ensures that future refactors or changes to session interruption logic can be confidently verified and that edge cases involving missing session states are handled gracefully.

---
*PR created automatically by Jules for task [4175228135621457404](https://jules.google.com/task/4175228135621457404) started by @Hy4ri*

## Summary by Sourcery

Add unit tests for ChatViewModel session interruption behavior.

Tests:
- Add tests verifying SESSION_INTERRUPT RPC is sent when a session is active.
- Add tests verifying no RPC is sent when interrupting without an active session.