### PR TITLE
🧪 Add tests for SystemViewModel update confirm state

### DIFF
--- a/app/src/test/java/com/m57/hermescontrol/ui/system/SystemViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/system/SystemViewModelTest.kt
@@ -1,0 +1,51 @@
+package com.m57.hermescontrol.ui.system
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SystemViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `openUpdateConfirm sets updateConfirmOpen to true`() {
+        val viewModel = SystemViewModel()
+
+        assertFalse(viewModel.uiState.value.updateConfirmOpen)
+
+        viewModel.openUpdateConfirm()
+
+        assertTrue(viewModel.uiState.value.updateConfirmOpen)
+    }
+
+    @Test
+    fun `closeUpdateConfirm sets updateConfirmOpen to false`() {
+        val viewModel = SystemViewModel()
+
+        // First open it
+        viewModel.openUpdateConfirm()
+        assertTrue(viewModel.uiState.value.updateConfirmOpen)
+
+        // Then close it
+        viewModel.closeUpdateConfirm()
+        assertFalse(viewModel.uiState.value.updateConfirmOpen)
+    }
+}


### PR DESCRIPTION
🎯 **What:** The missing test for the `SystemViewModel`'s `openUpdateConfirm` and `closeUpdateConfirm` methods has been added. These methods toggle a simple boolean in the UI state.
📊 **Coverage:** The tests cover the happy paths of the two methods, asserting that the state starts as `false`, changes to `true` after `openUpdateConfirm` is called, and goes back to `false` when `closeUpdateConfirm` is called.
✨ **Result:** Test coverage for `SystemViewModel` is improved, ensuring the correct behavior of the update confirm dialog state without relying on manual verification or UI interactions.

---
*PR created automatically by Jules for task [3383857725682365556](https://jules.google.com/task/3383857725682365556) started by @Hy4ri*

## Summary by Sourcery

Tests:
- Introduce SystemViewModelTest to cover openUpdateConfirm and closeUpdateConfirm transitions of updateConfirmOpen in uiState.