### PR TITLE
🧹 Refactor CronExpressionFormatter to flatten parseDaysOfWeek

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/util/CronExpressionFormatter.kt
+++ b/app/src/main/java/com/m57/hermescontrol/util/CronExpressionFormatter.kt
@@ -115,28 +115,30 @@ object CronExpressionFormatter {
         hoursList: List<Int>,
         minutesList: List<Int>,
     ): String? {
-        if (dowPart != "*" && domPart == "*" && monthPart == "*") {
-            if (hoursList.size == 1 && minutesList.size == 1) {
-                val timeStr = formatTime(hoursList[0], minutesList[0])
-                if (dowPart.contains("-")) {
-                    val bounds = dowPart.split("-")
-                    if (bounds.size == 2) {
-                        val start = bounds[0].toIntOrNull() ?: -1
-                        val end = bounds[1].toIntOrNull() ?: -1
-                        if (start in 0..7 && end in 0..7) {
-                            val startName = dowNames[start]
-                            val endName = dowNames[end]
-                            return "At $timeStr $startName through $endName"
-                        }
-                    }
-                }
-                val dows = parseField(dowPart, 0, 7)
-                if (dows.size == 1) {
-                    val dowName = dowNames[dows[0]]
-                    return "Every $dowName at $timeStr"
+        if (dowPart == "*" || domPart != "*" || monthPart != "*") return null
+        if (hoursList.size != 1 || minutesList.size != 1) return null
+
+        val timeStr = formatTime(hoursList[0], minutesList[0])
+
+        if (dowPart.contains("-")) {
+            val bounds = dowPart.split("-")
+            if (bounds.size == 2) {
+                val start = bounds[0].toIntOrNull() ?: -1
+                val end = bounds[1].toIntOrNull() ?: -1
+                if (start in 0..7 && end in 0..7) {
+                    val startName = dowNames[start]
+                    val endName = dowNames[end]
+                    return "At $timeStr $startName through $endName"
                 }
             }
         }
+
+        val dows = parseField(dowPart, 0, 7)
+        if (dows.size == 1) {
+            val dowName = dowNames[dows[0]]
+            return "Every $dowName at $timeStr"
+        }
+
         return null
     }
 


### PR DESCRIPTION
🎯 **What:** Flattened deeply nested logic in `CronExpressionFormatter.parseDaysOfWeek`.
💡 **Why:** Deep nesting makes code hard to read. Using guard clauses improves readability and maintainability.
✅ **Verification:** Verified changes by running the local `CronExpressionFormatterTest` unit tests, confirming they all passed.
✨ **Result:** A flatter and cleaner `parseDaysOfWeek` function.

---
*PR created automatically by Jules for task [79656058478006808](https://jules.google.com/task/79656058478006808) started by @Hy4ri*

## Summary by Sourcery

Enhancements:
- Flatten the parseDaysOfWeek logic with guard clauses while preserving existing behavior.