### PR TITLE
🧪 Add unit tests for ChatViewModel attachment manipulation

### DIFF
--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -668,6 +668,17 @@ class ChatViewModelTest {
 
     // ── Attachments ──────────────────────────────────────────────────────────
 
+    /** Add [count] dummy attachments so a test starts with a populated list. */
+    private fun TestScope.addDummyAttachments(
+        viewModel: ChatViewModel,
+        count: Int,
+    ) {
+        repeat(count) { i ->
+            viewModel.addAttachment("uri$i", "file$i.txt", "text/plain", (i + 1) * 100L)
+        }
+        advanceUntilIdle()
+    }
+
     @Test
     fun testAddAttachment() =
         runTest {
@@ -727,6 +738,34 @@ class ChatViewModelTest {
             val pending = viewModel.uiState.value.pendingAttachments
             assertEquals(1, pending.size)
             assertEquals("uri1", pending[0].uri)
+        }
+
+    @Test
+    fun testRemoveAttachment_mixedValidAndInvalidSequence() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+            addDummyAttachments(viewModel, 3) // [uri0, uri1, uri2]
+
+            // 1. Remove a valid index (the middle item) → list shrinks correctly.
+            viewModel.removeAttachment(1)
+            advanceUntilIdle()
+            assertEquals(2, viewModel.uiState.value.pendingAttachments.size)
+            assertEquals("uri0", viewModel.uiState.value.pendingAttachments[0].uri)
+            assertEquals("uri2", viewModel.uiState.value.pendingAttachments[1].uri)
+
+            // 2. Fire invalid removals (out of bounds + negative) — must be no-ops.
+            viewModel.removeAttachment(99)
+            viewModel.removeAttachment(-1)
+            advanceUntilIdle()
+            assertEquals(2, viewModel.uiState.value.pendingAttachments.size)
+
+            // 3. Another valid removal on the shifted list → still consistent.
+            viewModel.removeAttachment(1)
+            advanceUntilIdle()
+            val pending = viewModel.uiState.value.pendingAttachments
+            assertEquals(1, pending.size)
+            assertEquals("uri0", pending[0].uri)
         }
 
     @Test

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -666,6 +666,88 @@ class ChatViewModelTest {
             }
         }
 
+    // ── Attachments ──────────────────────────────────────────────────────────
+
+    @Test
+    fun testAddAttachment() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.addAttachment(
+                uri = "content://dummy/1",
+                name = "dummy.txt",
+                mimeType = "text/plain",
+                size = 1024L,
+            )
+            advanceUntilIdle()
+
+            val pending = viewModel.uiState.value.pendingAttachments
+            assertEquals(1, pending.size)
+            assertEquals("content://dummy/1", pending[0].uri)
+            assertEquals("dummy.txt", pending[0].name)
+        }
+
+    @Test
+    fun testRemoveAttachment_validIndex() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.addAttachment("uri1", "file1.txt", "text/plain", 100)
+            viewModel.addAttachment("uri2", "file2.txt", "text/plain", 200)
+            advanceUntilIdle()
+
+            assertEquals(2, viewModel.uiState.value.pendingAttachments.size)
+
+            viewModel.removeAttachment(0)
+            advanceUntilIdle()
+
+            val pending = viewModel.uiState.value.pendingAttachments
+            assertEquals(1, pending.size)
+            assertEquals("uri2", pending[0].uri)
+        }
+
+    @Test
+    fun testRemoveAttachment_invalidIndex() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.addAttachment("uri1", "file1.txt", "text/plain", 100)
+            advanceUntilIdle()
+
+            assertEquals(1, viewModel.uiState.value.pendingAttachments.size)
+
+            // Out of bounds index should not crash or change list
+            viewModel.removeAttachment(5)
+            viewModel.removeAttachment(-1)
+            advanceUntilIdle()
+
+            val pending = viewModel.uiState.value.pendingAttachments
+            assertEquals(1, pending.size)
+            assertEquals("uri1", pending[0].uri)
+        }
+
+    @Test
+    fun testClearAttachments() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.addAttachment("uri1", "file1.txt", "text/plain", 100)
+            viewModel.addAttachment("uri2", "file2.txt", "text/plain", 200)
+            advanceUntilIdle()
+
+            assertEquals(2, viewModel.uiState.value.pendingAttachments.size)
+
+            viewModel.clearAttachments()
+            advanceUntilIdle()
+
+            val pending = viewModel.uiState.value.pendingAttachments
+            assertTrue(pending.isEmpty())
+        }
+
     // ── Send message ─────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
🎯 **What:** The testing gap in `ChatViewModel` regarding `removeAttachment` and `clearAttachments` has been addressed. These methods, which delegate to `ChatAttachmentsDelegate` for list state modification, were completely untested.

📊 **Coverage:** The following scenarios are now fully tested in `ChatViewModelTest.kt`:
* Adding an attachment correctly updates the UI state list.
* Removing an attachment at a valid index drops the correct item.
* Attempting to remove an attachment at an invalid or out-of-bounds index (e.g. negative or too large) safely exits without modifying the list or throwing exceptions.
* Clearing all attachments resets the list to empty.

✨ **Result:** Increased unit test coverage for the ViewModel and prevents potential regressions in attachment state handling during future refactors.

---
*PR created automatically by Jules for task [15156922385508991621](https://jules.google.com/task/15156922385508991621) started by @Hy4ri*

## Summary by Sourcery

Add unit tests to verify ChatViewModel attachment list handling.

Tests:
- Add coverage for adding attachments and reflecting them in the pendingAttachments UI state.
- Verify removing attachments at valid indices updates the list correctly.
- Ensure removing attachments at invalid indices leaves the list unchanged and does not crash.
- Test clearing all attachments resets the pendingAttachments list to empty.