### PR TITLE
🧪 Test PairingCodeEntryViewModel onManualCodeChange

### DIFF
--- a/app/src/test/java/com/m57/hermescontrol/ui/pairing/PairingCodeEntryViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/pairing/PairingCodeEntryViewModelTest.kt
@@ -1,0 +1,56 @@
+package com.m57.hermescontrol.ui.pairing
+
+import android.app.Application
+import android.util.Log
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class PairingCodeEntryViewModelTest {
+
+    private val mockApp: Application = mockk(relaxed = true)
+
+    @Before
+    fun setup() {
+        mockkStatic(Log::class)
+        every { Log.d(any(), any()) } returns 0
+        every { Log.e(any(), any(), any()) } returns 0
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun testOnManualCodeChange_updatesStateAndClearsError() {
+        val viewModel = PairingCodeEntryViewModel(mockApp)
+
+        // Force an error to verify it gets cleared
+        // using onCodeDetected with invalid input to set the error
+        viewModel.onCodeDetected("invalid-code")
+        assertEquals(true, viewModel.uiState.value.errorMessage != null)
+
+        viewModel.onManualCodeChange("new-code")
+
+        val state = viewModel.uiState.value
+        assertEquals("new-code", state.manualCode)
+        assertNull(state.errorMessage)
+    }
+
+    @Test
+    fun testOnManualCodeChange_trimsInput() {
+        val viewModel = PairingCodeEntryViewModel(mockApp)
+
+        viewModel.onManualCodeChange("  trimmed-code  \n")
+
+        val state = viewModel.uiState.value
+        assertEquals("trimmed-code", state.manualCode)
+    }
+}

--- a/app/src/test/java/com/m57/hermescontrol/ui/pairing/PairingCodeEntryViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/pairing/PairingCodeEntryViewModelTest.kt
@@ -13,7 +13,6 @@ import org.junit.Before
 import org.junit.Test
 
 class PairingCodeEntryViewModelTest {
-
     private val mockApp: Application = mockk(relaxed = true)
 
     @Before


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This pull request addresses the missing unit tests for the `onManualCodeChange` function in `PairingCodeEntryViewModel`. It focuses on testing the primary responsibilities of the function which involves modifying the UI state by storing user input, trimming it correctly, and cleaning out any prior error state.

📊 **Coverage:** What scenarios are now tested
- The happy path is covered, proving the input manual code updates correctly into the state.
- Ensures the manual code is properly trimmed of excess whitespace or newlines before persisting in the state.
- Ensures any pre-existing `errorMessage` in the state is explicitly cleared back to `null` when the function is triggered.

✨ **Result:** The improvement in test coverage
The module `com.m57.hermescontrol.ui.pairing` now possesses improved test coverage ensuring modifications within `onManualCodeChange` do not introduce regressions into user input capture.

---
*PR created automatically by Jules for task [3293992410626988991](https://jules.google.com/task/3293992410626988991) started by @Hy4ri*

## Summary by Sourcery

Tests:
- Add tests verifying onManualCodeChange updates the manual code state, trims whitespace, and clears existing error messages.