### PR TITLE
🧪 test: add unit test for ChatViewModel search toggle

### DIFF
--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -1061,4 +1061,27 @@ class ChatViewModelTest {
             assertFalse(state.typingEffectEnabled)
             assertEquals(50, state.typingEffectDelayMs)
         }
+
+    @Test
+    fun testToggleSearch() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.isSearchActive)
+
+            viewModel.toggleSearch()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.isSearchActive)
+
+            viewModel.setSearchQuery("test")
+            advanceUntilIdle()
+
+            viewModel.toggleSearch()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.isSearchActive)
+            assertEquals("", viewModel.uiState.value.searchQuery)
+        }
 }


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for the `toggleSearch` function in `ChatViewModel.kt`.
📊 **Coverage:** The new test `testToggleSearch` validates the initial state of the search functionality, the transition to active search, setting a query, and finally toggling back to inactive, ensuring the state is correctly reset.
✨ **Result:** Improved test coverage for `ChatViewModel` by verifying the self-contained state manipulation of the search toggle feature.

---
*PR created automatically by Jules for task [10813632986052227366](https://jules.google.com/task/10813632986052227366) started by @Hy4ri*

## Summary by Sourcery

Tests:
- Add testToggleSearch to verify activating search, updating the query, and resetting state on toggle.