### PR TITLE
🧹 Extract TODO tool formatting logic into separate function

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatBubble.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatBubble.kt
@@ -532,6 +532,76 @@ data class ParsedToolData(
     val isRunning: Boolean = false,
 )
 
+private fun formatTodoToolOutput(
+    dataSource: JsonObject,
+    args: Map<String, Any?>,
+    obj: JsonObject,
+    resolvedToolName: String?,
+    isRunning: Boolean,
+): ParsedToolData {
+    val todosArray =
+        dataSource
+            .get("todos")
+            ?.takeIf { !it.isJsonNull && it.isJsonArray }
+            ?.asJsonArray
+    val summaryObj =
+        dataSource
+            .get("summary")
+            ?.takeIf { !it.isJsonNull && it.isJsonObject }
+            ?.asJsonObject
+
+    val todoSummaryText =
+        summaryObj?.let { s ->
+            val total = s.get("total")?.asDouble?.toInt() ?: 0
+            val pending = s.get("pending")?.asDouble?.toInt() ?: 0
+            val inProgress = s.get("in_progress")?.asDouble?.toInt() ?: 0
+            val completed = s.get("completed")?.asDouble?.toInt() ?: 0
+            val cancelled = s.get("cancelled")?.asDouble?.toInt() ?: 0
+            val parts = mutableListOf<String>()
+            if (pending > 0) parts.add("$pending pending")
+            if (inProgress > 0) parts.add("$inProgress in_progress")
+            if (completed > 0) parts.add("$completed completed")
+            if (cancelled > 0) parts.add("$cancelled cancelled")
+            val itemWord = if (total == 1) "item" else "items"
+            if (parts.isEmpty()) {
+                "📋 0 items"
+            } else {
+                "📋 $total $itemWord (${parts.joinToString(", ")})"
+            }
+        }
+
+    val formattedTodos =
+        todosArray
+            ?.mapNotNull { element ->
+                if (!element.isJsonObject) return@mapNotNull null
+                val item = element.asJsonObject
+                val id = item.get("id")?.asString ?: ""
+                val content = item.get("content")?.asString ?: ""
+                val status = item.get("status")?.asString ?: "pending"
+                val marker =
+                    when (status) {
+                        "completed" -> "[x]"
+                        "in_progress" -> "[>]"
+                        "cancelled" -> "[~]"
+                        else -> "[ ]"
+                    }
+                "$marker $id. $content"
+            }?.joinToString("\n")
+            ?.takeIf { it.isNotEmpty() }
+
+    val duration = obj.get("duration_s")?.takeIf { !it.isJsonNull }?.asDouble
+
+    return ParsedToolData(
+        toolName = resolvedToolName ?: "",
+        args = args,
+        result = dataSource.entrySet().associate { it.key to it.value.toString() },
+        summaryText = todoSummaryText,
+        mainOutput = formattedTodos,
+        durationSec = duration,
+        isRunning = isRunning,
+    )
+}
+
 /**
  * Parses the tool.complete JSON payload into a [ParsedToolData].
  * The gateway sends a payload with `args` and `result` sub-objects
@@ -583,69 +653,12 @@ fun parseToolOutput(
                     ?.let { "${config.summaryPrefix}$it" }
             }
 
-        // ── Todo-specific formatting ──
-        // Extract the structured todos array and summary object from the result,
-        // build a clean one-line summary and formatted item list.
         if (resolvedToolName == "todo") {
-            val todosArray =
-                dataSource
-                    .get("todos")
-                    ?.takeIf { !it.isJsonNull && it.isJsonArray }
-                    ?.asJsonArray
-            val summaryObj =
-                dataSource
-                    .get("summary")
-                    ?.takeIf { !it.isJsonNull && it.isJsonObject }
-                    ?.asJsonObject
-
-            val todoSummaryText =
-                summaryObj?.let { s ->
-                    val total = s.get("total")?.asDouble?.toInt() ?: 0
-                    val pending = s.get("pending")?.asDouble?.toInt() ?: 0
-                    val inProgress = s.get("in_progress")?.asDouble?.toInt() ?: 0
-                    val completed = s.get("completed")?.asDouble?.toInt() ?: 0
-                    val cancelled = s.get("cancelled")?.asDouble?.toInt() ?: 0
-                    val parts = mutableListOf<String>()
-                    if (pending > 0) parts.add("$pending pending")
-                    if (inProgress > 0) parts.add("$inProgress in_progress")
-                    if (completed > 0) parts.add("$completed completed")
-                    if (cancelled > 0) parts.add("$cancelled cancelled")
-                    val itemWord = if (total == 1) "item" else "items"
-                    if (parts.isEmpty()) {
-                        "📋 0 items"
-                    } else {
-                        "📋 $total $itemWord (${parts.joinToString(", ")})"
-                    }
-                }
-
-            val formattedTodos =
-                todosArray
-                    ?.mapNotNull { element ->
-                        if (!element.isJsonObject) return@mapNotNull null
-                        val item = element.asJsonObject
-                        val id = item.get("id")?.asString ?: ""
-                        val content = item.get("content")?.asString ?: ""
-                        val status = item.get("status")?.asString ?: "pending"
-                        val marker =
-                            when (status) {
-                                "completed" -> "[x]"
-                                "in_progress" -> "[>]"
-                                "cancelled" -> "[~]"
-                                else -> "[ ]"
-                            }
-                        "$marker $id. $content"
-                    }?.joinToString("\n")
-                    ?.takeIf { it.isNotEmpty() }
-
-            val duration = obj.get("duration_s")?.takeIf { !it.isJsonNull }?.asDouble
-
-            return ParsedToolData(
-                toolName = resolvedToolName ?: "",
+            return formatTodoToolOutput(
+                dataSource = dataSource,
                 args = args,
-                result = dataSource.entrySet().associate { it.key to it.value.toString() },
-                summaryText = todoSummaryText,
-                mainOutput = formattedTodos,
-                durationSec = duration,
+                obj = obj,
+                resolvedToolName = resolvedToolName,
                 isRunning = isRunning,
             )
         }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `parseToolOutput` function in `ChatBubble.kt` contained a large block of logic specifically for handling the "todo" tool output. This inline logic increased the function's complexity and made it harder to maintain. The logic has been extracted into a private, self-contained function `formatTodoToolOutput`.

💡 **Why:** How this improves maintainability
Extracting this logic improves the readability of `parseToolOutput` by adhering more closely to the Single Responsibility Principle. It makes the main parsing function cleaner and easier to read, while encapsulating the specific logic for formatting TODO items into its own method.

✅ **Verification:** How you confirmed the change is safe
- Extracted the code verbatim into the new function, ensuring inputs and outputs match exactly.
- Ran `./gradlew testDebugUnitTest` and all tests passed.
- Checked formatting using `ktlint` standalone binary.
- Clean compilation checked via `./gradlew compileDebugKotlin`.

✨ **Result:** The improvement achieved
A cleaner `parseToolOutput` function and a dedicated `formatTodoToolOutput` function, improving code health and readability.

---
*PR created automatically by Jules for task [15762026832190280315](https://jules.google.com/task/15762026832190280315) started by @Hy4ri*

## Summary by Sourcery

Enhancements:
- Introduce a formatTodoToolOutput helper to encapsulate TODO tool result formatting and reduce parseToolOutput complexity.