### PR TITLE
🧪 test: add test for KeysViewModel toggleCategory

### DIFF
--- a/app/src/test/java/com/m57/hermescontrol/ui/keys/KeysViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/keys/KeysViewModelTest.kt
@@ -1,13 +1,18 @@
 package com.m57.hermescontrol.ui.keys
 
+import com.m57.hermescontrol.data.model.EnvVarConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -53,5 +58,92 @@ class KeysViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals("dummy_token_value_that_is_long_enough", viewModel.uiState.value.newKeyValue)
+    }
+
+    @Test
+    fun testToggleCategory() {
+        // Arrange
+        val viewModel = createViewModel()
+
+        // Seed initial categories via reflection (no test-only seeding path exists in source)
+        val uiStateField = KeysViewModel::class.java.getDeclaredField("_uiState")
+        uiStateField.isAccessible = true
+        val uiStateFlow =
+            uiStateField.get(viewModel) as MutableStateFlow<KeysUiState>
+
+        val initialCategories =
+            listOf(
+                CategorySection(
+                    name = "LLM Providers",
+                    vars =
+                        mapOf(
+                            "OPENAI_API_KEY" to
+                                EnvVarConfig(
+                                    isSet = true,
+                                    category = "LLM Providers",
+                                    isPassword = true,
+                                ),
+                        ),
+                    expanded = false,
+                ),
+                CategorySection(
+                    name = "Tool API Keys",
+                    vars =
+                        mapOf(
+                            "WEATHER_API_KEY" to
+                                EnvVarConfig(
+                                    isSet = true,
+                                    category = "Tool API Keys",
+                                    isPassword = true,
+                                ),
+                        ),
+                    expanded = true,
+                ),
+            )
+        uiStateFlow.update { it.copy(categories = initialCategories) }
+
+        // Act - expand an unexpanded category
+        viewModel.toggleCategory("LLM Providers")
+
+        // Assert
+        var categories = viewModel.uiState.value.categories
+        assertEquals(2, categories.size)
+        assertTrue(
+            "LLM Providers should be expanded",
+            categories.first { it.name == "LLM Providers" }.expanded,
+        )
+        assertTrue(
+            "Tool API Keys should remain expanded",
+            categories.first { it.name == "Tool API Keys" }.expanded,
+        )
+
+        // Act - collapse it again
+        viewModel.toggleCategory("LLM Providers")
+
+        // Assert
+        categories = viewModel.uiState.value.categories
+        assertEquals(2, categories.size)
+        assertFalse(
+            "LLM Providers should be collapsed",
+            categories.first { it.name == "LLM Providers" }.expanded,
+        )
+        assertTrue(
+            "Tool API Keys should remain expanded",
+            categories.first { it.name == "Tool API Keys" }.expanded,
+        )
+
+        // Act - toggle the other category, ensure first stays untouched
+        viewModel.toggleCategory("Tool API Keys")
+
+        // Assert
+        categories = viewModel.uiState.value.categories
+        assertFalse(
+            "LLM Providers should stay collapsed",
+            categories.first { it.name == "LLM Providers" }.expanded,
+        )
+        assertFalse(
+            "Tool API Keys should now be collapsed",
+            categories.first { it.name == "Tool API Keys" }.expanded,
+        )
     }
 }


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for the `KeysViewModel.toggleCategory` function.
📊 **Coverage:** Tests the happy path where a category is expanded when closed, and collapsed when already expanded, while ensuring other categories remain untouched.
✨ **Result:** Increased test coverage and confidence in the UI state mutation logic for the Keys screen.

---
*PR created automatically by Jules for task [13740513951308077752](https://jules.google.com/task/13740513951308077752) started by @Hy4ri*

## Summary by Sourcery

Tests:
- Add KeysViewModelTest to verify toggleCategory expands and collapses categories without affecting others.