### PR TITLE
🧪 Add testing for AuthLoginViewModel dashboard probe error paths

### DIFF
--- a/app/src/test/java/com/m57/hermescontrol/ui/authlogin/AuthLoginViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/authlogin/AuthLoginViewModelTest.kt
@@ -1,19 +1,26 @@
 package com.m57.hermescontrol.ui.authlogin
 
 import android.app.Application
+import android.util.Log
+import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.local.AuthManager
 import com.m57.hermescontrol.data.remote.OkHttpProvider
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
+import okhttp3.Response
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
+import java.io.IOException
 
 class AuthLoginViewModelTest {
     private lateinit var viewModel: AuthLoginViewModel
@@ -28,6 +35,12 @@ class AuthLoginViewModelTest {
 
         mockkObject(OkHttpProvider)
         every { OkHttpProvider.probe } returns mockk<OkHttpClient>(relaxed = true)
+
+        mockkStatic(Log::class)
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.d(any<String>(), any<String>()) } returns 0
+
+        every { app.getString(R.string.auth_login_error_unreachable) } returns "Dashboard unreachable"
 
         viewModel = AuthLoginViewModel(app)
     }
@@ -65,5 +78,35 @@ class AuthLoginViewModelTest {
         assertFalse(state.connectionSuccess)
         assertFalse(state.isLoading)
         assertNull(state.errorMessage)
+    }
+
+    @Test
+    fun `probe when status probe throws IOException updates error state`() {
+        val mockCall = mockk<okhttp3.Call>()
+        every { OkHttpProvider.probe.newCall(any()) } returns mockCall
+        every { mockCall.execute() } throws IOException("Connection refused")
+
+        viewModel.probe()
+
+        val state = runBlocking { viewModel.uiState.first { !it.probing } }
+        assertFalse(state.probing)
+        assertNull(state.authMode)
+        assertEquals("Dashboard unreachable", state.errorMessage)
+    }
+
+    @Test
+    fun `probe when status probe returns unsuccessful updates error state`() {
+        val mockCall = mockk<okhttp3.Call>()
+        val mockResponse = mockk<Response>()
+        every { OkHttpProvider.probe.newCall(any()) } returns mockCall
+        every { mockCall.execute() } returns mockResponse
+        every { mockResponse.isSuccessful } returns false
+
+        viewModel.probe()
+
+        val state = runBlocking { viewModel.uiState.first { !it.probing } }
+        assertFalse(state.probing)
+        assertNull(state.authMode)
+        assertEquals("Dashboard unreachable", state.errorMessage)
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap in `AuthLoginViewModel.kt`'s `probe()` error paths addressed by adding test coverage.
📊 **Coverage:** The tests cover the scenarios where the initial `http://baseUrl/api/status` probe via OkHttp throws an exception (e.g., connection refused) or returns an unsuccessful HTTP code.
✨ **Result:** Increased test coverage for authentication network probing logic and enhanced reliability.

---
*PR created automatically by Jules for task [2659945243808316795](https://jules.google.com/task/2659945243808316795) started by @Hy4ri*

## Summary by Sourcery

Add unit tests for AuthLoginViewModel to cover dashboard probe failure scenarios and resulting UI state updates.

Tests:
- Add tests verifying probe error handling when the status request throws an IOException.
- Add tests verifying probe error handling when the status request returns an unsuccessful HTTP response.