### PR TITLE
Add error handling unit test for ChatViewModel readContentUriBytes

### DIFF
--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -737,6 +737,40 @@ class ChatViewModelTest {
             )
         }
 
+    @Test
+    fun testReadContentUriBytes_errorReading_skipsAttachment() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+
+            try {
+                // Setup mocks for Uri and ContentResolver
+                val uriString = "content://error-uri"
+                val mockUri = mockk<android.net.Uri>()
+                mockkStatic(android.net.Uri::class)
+                every { android.net.Uri.parse(uriString) } returns mockUri
+
+                val mockResolver = mockk<android.content.ContentResolver>()
+                every { app.contentResolver } returns mockResolver
+                every { mockResolver.openInputStream(mockUri) } throws SecurityException("Permission denied")
+
+                // Add attachment
+                viewModel.addAttachment(uriString, "error.txt", "text/plain", 100L)
+                advanceUntilIdle()
+
+                // Action
+                viewModel.sendMessage("Test prompt")
+                advanceUntilIdle()
+
+                // Verify Log.e was called
+                verify { Log.e("ChatViewModel", match { it.contains("Failed to read attachment bytes") }, any<SecurityException>()) }
+
+                // Verify that the prompt was submitted anyway (HermesWsClient.sendMessage)
+                verify { HermesWsClient.sendMessage(sessionId, "Test prompt", any()) }
+            } finally {
+                io.mockk.unmockkStatic(android.net.Uri::class)
+            }
+        }
+
     // ── Session mismatch ─────────────────────────────────────────────────────
 
     @Test

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -762,7 +762,13 @@ class ChatViewModelTest {
                 advanceUntilIdle()
 
                 // Verify Log.e was called
-                verify { Log.e("ChatViewModel", match { it.contains("Failed to read attachment bytes") }, any<SecurityException>()) }
+                verify {
+                    Log.e(
+                        "ChatViewModel",
+                        match { it.contains("Failed to read attachment bytes") },
+                        any<SecurityException>(),
+                    )
+                }
 
                 // Verify that the prompt was submitted anyway (HermesWsClient.sendMessage)
                 verify { HermesWsClient.sendMessage(sessionId, "Test prompt", any()) }


### PR DESCRIPTION
🎯 **What:** The missing testing gap for the error handling in `ChatViewModel.readContentUriBytes` when reading an attachment file throws an exception.
📊 **Coverage:** The new test covers the exception branch, ensuring it handles `SecurityException` during `openInputStream` without crashing and correctly sends the rest of the message payload.
✨ **Result:** Test coverage for `ChatViewModel.kt` attachment handling logic is improved, preventing regressions where missing/unreadable files might unexpectedly crash the message dispatch flow.

---
*PR created automatically by Jules for task [14394668811484636452](https://jules.google.com/task/14394668811484636452) started by @Hy4ri*

## Summary by Sourcery

Tests:
- Add a test ensuring attachment reading failures (e.g., SecurityException from openInputStream) are logged and do not prevent message sending.