### PR TITLE
🧪 Add tests for Gateway loadStatus in GatewayViewModel

### DIFF
--- a/app/src/test/java/com/m57/hermescontrol/ui/gateway/GatewayViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/gateway/GatewayViewModelTest.kt
@@ -1,0 +1,109 @@
+package com.m57.hermescontrol.ui.gateway
+
+import com.m57.hermescontrol.data.model.StatusResponse
+import com.m57.hermescontrol.data.remote.ApiClient
+import com.m57.hermescontrol.data.remote.HermesApiService
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GatewayViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var mockApi: HermesApiService
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns testDispatcher
+
+        mockApi = mockk()
+        mockkObject(ApiClient)
+        every { ApiClient.hermesApi } returns mockApi
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun `loadStatus success updates state with status data`() =
+        runTest {
+            val mockResponse = mockk<StatusResponse>()
+            coEvery { mockApi.getStatus() } returns Response.success(mockResponse)
+
+            val viewModel = GatewayViewModel()
+
+            // Before calling, status should be null
+            assertNull(viewModel.uiState.value.status)
+            assertFalse(viewModel.uiState.value.isLoading)
+
+            viewModel.loadStatus()
+
+            // Assert loading state (before coroutine executes)
+            assertTrue(viewModel.uiState.value.isLoading)
+            assertNull(viewModel.uiState.value.errorMessage)
+
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Assert final state
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertEquals(mockResponse, viewModel.uiState.value.status)
+            assertNull(viewModel.uiState.value.errorMessage)
+        }
+
+    @Test
+    fun `loadStatus error updates state with error message`() =
+        runTest {
+            coEvery { mockApi.getStatus() } returns Response.error(500, "Server Error".toResponseBody(null))
+
+            val viewModel = GatewayViewModel()
+
+            viewModel.loadStatus()
+            assertTrue(viewModel.uiState.value.isLoading)
+
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertNull(viewModel.uiState.value.status)
+            assertTrue(viewModel.uiState.value.errorMessage?.contains("500") == true)
+        }
+
+    @Test
+    fun `loadStatus network exception updates state with error message`() =
+        runTest {
+            coEvery { mockApi.getStatus() } throws RuntimeException("Network timeout")
+
+            val viewModel = GatewayViewModel()
+
+            viewModel.loadStatus()
+
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.isLoading)
+            assertNull(viewModel.uiState.value.status)
+            assertTrue(viewModel.uiState.value.errorMessage?.contains("Network timeout") == true)
+        }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `loadStatus` function inside `GatewayViewModel` was previously untested. It manages the `uiState` (loading status, error messages, and fetched status) around the `hermesApi.getStatus()` call.

📊 **Coverage:** What scenarios are now tested
- Success state updates (verifying that `isLoading` flips correctly and the status updates).
- HTTP error state updates (verifying that the error message contains the status code/details and `isLoading` finishes).
- Network exception state updates (verifying the `safeLaunchLoad`'s fallback error mapping correctly handles thrown exceptions).

✨ **Result:** The improvement in test coverage
`GatewayViewModel` now has a dedicated `GatewayViewModelTest.kt` file which fully verifies the API data mapping into `GatewayUiState`. This improves reliability for the Gateway Control screen and adds a safety net for future refactors of the `loadStatus` logic.

---
*PR created automatically by Jules for task [18256475968480720328](https://jules.google.com/task/18256475968480720328) started by @Hy4ri*

## Summary by Sourcery

Tests:
- Introduce GatewayViewModelTest to verify uiState updates for successful status responses, HTTP error responses, and thrown network exceptions during loadStatus.