### PR TITLE
feat(chat): handle sudo.request / secret.request and respond via RPC (fixes #524)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/ws/EventParser.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/EventParser.kt
@@ -115,6 +115,16 @@ object EventParser {
                 WsEvent.ApprovalRequest(command, description, patternKeys, sessionId)
             }
 
+            "sudo.request" -> {
+                val requestId = payload?.get("request_id") as? String
+                WsEvent.SudoRequest(requestId, sessionId)
+            }
+
+            "secret.request" -> {
+                val requestId = payload?.get("request_id") as? String
+                WsEvent.SecretRequest(requestId, sessionId)
+            }
+
             else -> {
                 Log.w(TAG, "Unknown event type: $eventType")
                 WsEvent.Unknown(rawJson)

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/WsEvent.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/WsEvent.kt
@@ -94,6 +94,28 @@ sealed class WsEvent {
         val sessionId: String?,
     ) : WsEvent()
 
+    // ── Sudo / secret requests ─────────────────────────────────────────
+
+    /**
+     * Backend needs the user's sudo password to continue a turn
+     * (desktop: `sudo.request` → `sudo.respond {request_id, password}`).
+     * Mobile previously dropped this and the agent hung forever.
+     */
+    data class SudoRequest(
+        val requestId: String?,
+        val sessionId: String?,
+    ) : WsEvent()
+
+    /**
+     * Backend needs a secret value (password / token) to continue a turn
+     * (desktop: `secret.request` → `secret.respond {request_id, value}`).
+     * Mobile previously dropped this and the agent hung forever.
+     */
+    data class SecretRequest(
+        val requestId: String?,
+        val sessionId: String?,
+    ) : WsEvent()
+
     // ── Fallback ─────────────────────────────────────────────────────────
 
     data class Unknown(

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/WsMethods.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/WsMethods.kt
@@ -17,6 +17,8 @@ object WsMethods {
     const val PROMPT_SUBMIT = "prompt.submit"
     const val CLARIFY_RESPOND = "clarify.respond"
     const val APPROVAL_RESPOND = "approval.respond"
+    const val SUDO_RESPOND = "sudo.respond"
+    const val SECRET_RESPOND = "secret.respond"
 
     // ── Commands catalog ──────────────────────────────────────────────────
     const val COMMANDS_CATALOG = "commands.catalog"

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -101,6 +101,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -275,6 +277,8 @@ fun ChatScreen(
         currentSearchMatchIndex = state.currentSearchMatchIndex,
         searchMatchIndices = state.searchMatchIndices,
         clarifyRequest = state.clarifyRequest,
+        sudoPrompt = state.sudoPrompt,
+        secretPrompt = state.secretPrompt,
         listState = listState,
         snackbarHostState = snackbarHostState,
         viewModel = viewModel,
@@ -1004,6 +1008,106 @@ private fun ClarifyDialog(
     )
 }
 
+/**
+ * Secure password dialog for a pending `sudo.request` (issue #524).
+ * The backend blocked the turn waiting for the sudo password — previously
+ * mobile dropped the event and the agent hung forever.
+ */
+@Composable
+private fun SudoPromptDialog(
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var password by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.chat_sudo_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(text = stringResource(R.string.chat_sudo_body))
+                Spacer(modifier = Modifier.height(4.dp))
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = { password = it },
+                    label = { Text(stringResource(R.string.chat_sudo_password)) },
+                    modifier = Modifier.fillMaxWidth().testTag("sudo_password_input"),
+                    singleLine = true,
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(autoCorrect = false, keyboardType = KeyboardType.Password),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (password.isNotBlank()) {
+                        onConfirm(password)
+                    }
+                },
+                enabled = password.isNotBlank(),
+            ) {
+                Text(stringResource(R.string.chat_send))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.chat_dismiss))
+            }
+        },
+    )
+}
+
+/**
+ * Secure value dialog for a pending `secret.request` (issue #524).
+ * The backend blocked the turn waiting for a secret (token/password) —
+ * previously mobile dropped the event and the agent hung forever.
+ */
+@Composable
+private fun SecretPromptDialog(
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var secret by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.chat_secret_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(text = stringResource(R.string.chat_secret_body))
+                Spacer(modifier = Modifier.height(4.dp))
+                OutlinedTextField(
+                    value = secret,
+                    onValueChange = { secret = it },
+                    label = { Text(stringResource(R.string.chat_secret_value)) },
+                    modifier = Modifier.fillMaxWidth().testTag("secret_value_input"),
+                    singleLine = true,
+                    visualTransformation = PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(autoCorrect = false, keyboardType = KeyboardType.Password),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (secret.isNotBlank()) {
+                        onConfirm(secret)
+                    }
+                },
+                enabled = secret.isNotBlank(),
+            ) {
+                Text(stringResource(R.string.chat_send))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.chat_dismiss))
+            }
+        },
+    )
+}
+
 @Composable
 private fun CompactSearchInput(
     value: String,
@@ -1230,6 +1334,8 @@ private fun ChatLifecycleEffects(
     currentSearchMatchIndex: Int,
     searchMatchIndices: List<Int>,
     clarifyRequest: ClarifyUi?,
+    sudoPrompt: SudoPromptUi?,
+    secretPrompt: SecretPromptUi?,
     listState: LazyListState,
     snackbarHostState: SnackbarHostState,
     viewModel: ChatViewModel,
@@ -1327,6 +1433,21 @@ private fun ChatLifecycleEffects(
             clarify = clarify,
             onOptionSelected = viewModel::respondToClarify,
             onDismiss = viewModel::dismissClarify,
+        )
+    }
+
+    // Sudo / secret prompt dialogs (issue #524)
+    sudoPrompt?.let { prompt ->
+        SudoPromptDialog(
+            onConfirm = viewModel::respondToSudo,
+            onDismiss = viewModel::dismissSudo,
+        )
+    }
+
+    secretPrompt?.let { prompt ->
+        SecretPromptDialog(
+            onConfirm = viewModel::respondToSecret,
+            onDismiss = viewModel::dismissSecret,
         )
     }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -70,6 +70,9 @@ data class ChatUiState(
     val streamingMessage: ChatMessage? = null,
     val errorMessage: String? = null,
     val clarifyRequest: ClarifyUi? = null,
+    // Sudo / secret prompts — surfaced as dialogs (issue #524)
+    val sudoPrompt: SudoPromptUi? = null,
+    val secretPrompt: SecretPromptUi? = null,
     val showSessionPicker: Boolean = false,
     // Search state
     val isSearchActive: Boolean = false,
@@ -98,6 +101,18 @@ data class ClarifyUi(
     val text: String,
     val options: List<String>,
     val clarifyId: String? = null,
+)
+
+/** Transient — not persisted. Holds a pending sudo.password request. */
+data class SudoPromptUi(
+    val requestId: String?,
+    val sessionId: String?,
+)
+
+/** Transient — not persisted. Holds a pending secret (token/password) request. */
+data class SecretPromptUi(
+    val requestId: String?,
+    val sessionId: String?,
 )
 
 class ChatViewModel(
@@ -356,6 +371,14 @@ class ChatViewModel(
 
             is WsEvent.ApprovalRequest -> {
                 handleApprovalRequest(event)
+            }
+
+            is WsEvent.SudoRequest -> {
+                handleSudoRequest(event)
+            }
+
+            is WsEvent.SecretRequest -> {
+                handleSecretRequest(event)
             }
 
             else -> { /* reducer handles these */ }
@@ -1092,6 +1115,94 @@ class ChatViewModel(
                         "all" to false,
                     ),
                 onSent = { id -> trackRequest(id, WsMethods.APPROVAL_RESPOND) },
+            )
+        }
+    }
+
+    // ── Sudo / secret prompt flow (issue #524) ──────────────────────────
+
+    /**
+     * The agent needs the user's sudo password. Previously dropped → agent
+     * hung forever. Now we surface a secure dialog and reply via sudo.respond.
+     */
+    private fun handleSudoRequest(event: WsEvent.SudoRequest) {
+        _uiState.update {
+            it.copy(
+                sudoPrompt = SudoPromptUi(event.requestId, event.sessionId),
+                isAgentTyping = false,
+            )
+        }
+    }
+
+    /**
+     * The agent needs a secret value (token/password). Previously dropped →
+     * agent hung forever. Now we surface a secure dialog and reply via
+     * secret.respond.
+     */
+    private fun handleSecretRequest(event: WsEvent.SecretRequest) {
+        _uiState.update {
+            it.copy(
+                secretPrompt = SecretPromptUi(event.requestId, event.sessionId),
+                isAgentTyping = false,
+            )
+        }
+    }
+
+    fun dismissSudo() {
+        _uiState.update { it.copy(sudoPrompt = null) }
+    }
+
+    fun dismissSecret() {
+        _uiState.update { it.copy(secretPrompt = null) }
+    }
+
+    /**
+     * Send the user's sudo password back to the gateway. Mirrors
+     * respondToApproval: clear the prompt immediately, then fire the RPC.
+     */
+    fun respondToSudo(password: String) {
+        val prompt = _uiState.value.sudoPrompt ?: return
+        val sessionId = prompt.sessionId ?: _uiState.value.currentSessionId ?: return
+        if (password.isBlank()) return
+
+        _uiState.update { it.copy(sudoPrompt = null) }
+
+        viewModelScope.launch(Dispatchers.IO) {
+            val params =
+                mutableMapOf<String, Any>(
+                    "session_id" to sessionId,
+                    "password" to password,
+                )
+            prompt.requestId?.let { id -> params["request_id"] = id }
+            wsClient.send(
+                method = WsMethods.SUDO_RESPOND,
+                params = params,
+                onSent = { id -> trackRequest(id, WsMethods.SUDO_RESPOND) },
+            )
+        }
+    }
+
+    /**
+     * Send the user's secret value back to the gateway. Mirrors respondToSudo.
+     */
+    fun respondToSecret(value: String) {
+        val prompt = _uiState.value.secretPrompt ?: return
+        val sessionId = prompt.sessionId ?: _uiState.value.currentSessionId ?: return
+        if (value.isBlank()) return
+
+        _uiState.update { it.copy(secretPrompt = null) }
+
+        viewModelScope.launch(Dispatchers.IO) {
+            val params =
+                mutableMapOf<String, Any>(
+                    "session_id" to sessionId,
+                    "value" to value,
+                )
+            prompt.requestId?.let { id -> params["request_id"] = id }
+            wsClient.send(
+                method = WsMethods.SECRET_RESPOND,
+                params = params,
+                onSent = { id -> trackRequest(id, WsMethods.SECRET_RESPOND) },
             )
         }
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatWsEventReducer.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatWsEventReducer.kt
@@ -80,6 +80,10 @@ object ChatWsEventReducer {
 
             // ApprovalRequest is handled by the ViewModel (needs active session + WS client)
             is WsEvent.ApprovalRequest -> ReducerResult(state = state, streamingState = streamingState)
+
+            // SudoRequest / SecretRequest are handled by the ViewModel (issue #524)
+            is WsEvent.SudoRequest -> ReducerResult(state = state, streamingState = streamingState)
+            is WsEvent.SecretRequest -> ReducerResult(state = state, streamingState = streamingState)
         }
 
     // ── GatewayReady ──────────────────────────────────────────────────

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,12 @@
     <string name="chat_clarify_response">Response</string>
     <string name="chat_send">Send</string>
     <string name="chat_dismiss">Dismiss</string>
+    <string name="chat_sudo_title">Sudo Password Required</string>
+    <string name="chat_sudo_body">The agent needs your sudo password to continue. It will not be shown.</string>
+    <string name="chat_sudo_password">Password</string>
+    <string name="chat_secret_title">Secret Required</string>
+    <string name="chat_secret_body">The agent needs a secret value (token or password) to continue. It will not be shown.</string>
+    <string name="chat_secret_value">Secret</string>
     <string name="chat_search_placeholder">Search messages\u2026</string>
     <string name="chat_clear_search_desc">Clear</string>
     <string name="chat_prev_match_desc">Previous match</string>

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -1035,6 +1035,130 @@ class ChatViewModelTest {
             assertNull(msgAfter!!.approvalInfo)
         }
 
+    // ── Sudo / secret prompt flow (issue #524) ───────────────────────────
+
+    @Test
+    fun testSudoRequest_setsPromptState() =
+        runTest {
+            val (viewModel, _) = createViewModelWithSession()
+            advanceUntilIdle()
+
+            mockEventsFlow.emit(
+                WsEvent.SudoRequest(requestId = "sudo-1", sessionId = null),
+            )
+            advanceUntilIdle()
+
+            val prompt = viewModel.uiState.value.sudoPrompt
+            assertNotNull(prompt)
+            assertEquals("sudo-1", prompt?.requestId)
+        }
+
+    @Test
+    fun testRespondToSudo_sendsRpc() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+            advanceUntilIdle()
+
+            mockEventsFlow.emit(
+                WsEvent.SudoRequest(requestId = "sudo-1", sessionId = null),
+            )
+            advanceUntilIdle()
+
+            viewModel.respondToSudo("hunter2")
+            advanceUntilIdle()
+
+            verify {
+                HermesWsClient.send(
+                    WsMethods.SUDO_RESPOND,
+                    withArg { params ->
+                        assertEquals(sessionId, params["session_id"])
+                        assertEquals("hunter2", params["password"])
+                        assertEquals("sudo-1", params["request_id"])
+                    },
+                    any(),
+                )
+            }
+        }
+
+    @Test
+    fun testRespondToSudo_clearsPrompt() =
+        runTest {
+            val (viewModel, _) = createViewModelWithSession()
+            advanceUntilIdle()
+
+            mockEventsFlow.emit(
+                WsEvent.SudoRequest(requestId = "sudo-1", sessionId = null),
+            )
+            advanceUntilIdle()
+            assertNotNull(viewModel.uiState.value.sudoPrompt)
+
+            viewModel.respondToSudo("hunter2")
+            advanceUntilIdle()
+
+            assertNull(viewModel.uiState.value.sudoPrompt)
+        }
+
+    @Test
+    fun testSecretRequest_setsPromptState() =
+        runTest {
+            val (viewModel, _) = createViewModelWithSession()
+            advanceUntilIdle()
+
+            mockEventsFlow.emit(
+                WsEvent.SecretRequest(requestId = "secret-1", sessionId = null),
+            )
+            advanceUntilIdle()
+
+            val prompt = viewModel.uiState.value.secretPrompt
+            assertNotNull(prompt)
+            assertEquals("secret-1", prompt?.requestId)
+        }
+
+    @Test
+    fun testRespondToSecret_sendsRpc() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+            advanceUntilIdle()
+
+            mockEventsFlow.emit(
+                WsEvent.SecretRequest(requestId = "secret-1", sessionId = null),
+            )
+            advanceUntilIdle()
+
+            viewModel.respondToSecret("super-secret-token")
+            advanceUntilIdle()
+
+            verify {
+                HermesWsClient.send(
+                    WsMethods.SECRET_RESPOND,
+                    withArg { params ->
+                        assertEquals(sessionId, params["session_id"])
+                        assertEquals("super-secret-token", params["value"])
+                        assertEquals("secret-1", params["request_id"])
+                    },
+                    any(),
+                )
+            }
+        }
+
+    @Test
+    fun testRespondToSecret_clearsPrompt() =
+        runTest {
+            val (viewModel, _) = createViewModelWithSession()
+            advanceUntilIdle()
+
+            mockEventsFlow.emit(
+                WsEvent.SecretRequest(requestId = "secret-1", sessionId = null),
+            )
+            advanceUntilIdle()
+            assertNotNull(viewModel.uiState.value.secretPrompt)
+
+            viewModel.respondToSecret("super-secret-token")
+            advanceUntilIdle()
+
+            assertNull(viewModel.uiState.value.secretPrompt)
+        }
+
     // ── Settings ─────────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary
Fixes #524. Mobile previously **dropped** the gateway's `sudo.request` / `secret.request` events, so any agent turn needing a sudo password or a secret value **hung forever** with no UI and no feedback.

This mirrors the desktop/web contract (`apps/shared` `GatewayEventName` + `tui_gateway/server.py`): mobile now parses, surfaces, and responds to both events.

### Changes
- `EventParser.kt` — maps `sudo.request` / `secret.request` → `WsEvent.SudoRequest` / `SecretRequest`
- `WsEvent.kt` — new event data classes
- `WsMethods.kt` — `SUDO_RESPOND` / `SECRET_RESPOND` RPC constants
- `ChatViewModel.kt` — `handleSudoRequest`/`handleSecretRequest` set a secure prompt state (`SudoPromptUi`/`SecretPromptUi`, clears typing); `respondToSudo`/`respondToSecret` send the RPC (`session_id` + `request_id` + `password`/`value`) and clear the prompt; `dismissSudo`/`dismissSecret`
- `ChatWsEventReducer.kt` — explicitly branches the two new events (no-op, VM-owned) so the `when` stays exhaustive
- `ChatScreen.kt` — password-masked `SudoPromptDialog` / `SecretPromptDialog` (AlertDialog + `PasswordVisualTransformation`)
- `strings.xml` — `chat_sudo_*` / `chat_secret_*`
- `ChatViewModelTest.kt` — 6 tests (prompt-state set, RPC params verified, prompt cleared) for both flows

## Verification
- `./gradlew ktlintCheck compileDebugKotlin testDebugUnitTest --tests ChatViewModelTest` → **green**
- `ChatViewModelTest`: 45 tests, 0 skipped, 0 failures, 0 errors (includes the 6 new tests)

## Test plan
- [ ] Agent turn that triggers `sudo.request` shows the password dialog; entering it resumes the turn
- [ ] Agent turn that triggers `secret.request` shows the secret dialog; entering it resumes the turn
- [ ] Dismiss closes the dialog without sending (turn stays blocked, as expected)
- [ ] Values are masked while typing

Derived from the desktop-app audit in /opt/hermes-agent (Electron shell + `tui_gateway` JSON-RPC/WS + `apps/shared` client shared with the web dashboard).

## Summary by Sourcery

Handle gateway sudo and secret request events in mobile chat, surfacing secure prompts and responding via RPC to unblock agent turns.

New Features:
- Add UI state and dialogs for sudo password and secret value prompts in the chat screen, with masked input and dismiss/send actions.
- Introduce websocket event types and RPC methods for sudo and secret responses to align mobile with the gateway protocol.

Enhancements:
- Update chat lifecycle and event handling to route sudo/secret requests through the ViewModel while keeping the reducer exhaustive.

Tests:
- Extend ChatViewModelTest with coverage for sudo and secret prompt flows, including state updates, RPC parameters, and prompt clearing.