### PR TITLE
fix(network): scope management REST calls with ?profile= (fixes #528)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/remote/ApiClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/ApiClient.kt
@@ -117,6 +117,7 @@ object ApiClient {
                 .base
                 .newBuilder()
                 .addInterceptor(authInterceptor)
+                .addInterceptor(ProfileScopeInterceptor)
                 .addInterceptor(logging)
                 .authenticator(TokenRefreshAuthenticator)
                 .certificatePinner(certificatePinner)

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/ProfileScopeInterceptor.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/ProfileScopeInterceptor.kt
@@ -1,0 +1,71 @@
+package com.m57.hermescontrol.data.remote
+
+import com.m57.hermescontrol.data.local.AuthManager
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Appends `?profile=<activeProfile>` to profile-scoped management endpoints,
+ * mirroring the desktop/web dashboard contract
+ * (`web/src/lib/api.ts` → `PROFILE_SCOPED_PREFIXES` + `withManagementProfile`).
+ *
+ * Without this, mobile fired all management REST calls with NO profile scope,
+ * so every profile read/wrote the backend's implicit default profile —
+ * multi-profile setups silently corrupted config/skills/toolsets/mcp/model/env
+ * (issue #528).
+ *
+ * Rules (copied from the desktop contract):
+ *  - If no profile is active, pass through unchanged (legacy "default" behavior).
+ *  - If the URL already carries an explicit `profile=` query, leave it
+ *    untouched — explicit beats global.
+ *  - Only the endpoint families below honor `?profile=` on the backend;
+ *    everything else (ops, pairing, cron, profiles themselves) is
+ *    machine-global or self-scoped and must NOT be rewritten.
+ */
+object ProfileScopeInterceptor : Interceptor {
+    private val PROFILE_SCOPED_PREFIXES =
+        listOf(
+            "/api/status",
+            "/api/gateway",
+            "/api/analytics",
+            "/api/skills",
+            "/api/tools/toolsets",
+            "/api/config",
+            "/api/env",
+            "/api/mcp",
+            "/api/messaging/platforms",
+            "/api/messaging/telegram/onboarding",
+            "/api/messaging/whatsapp/onboarding",
+            "/api/model/info",
+            "/api/model/set",
+            "/api/model/auxiliary",
+            "/api/model/moa",
+            "/api/model/options",
+        )
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val profile =
+            AuthManager.getSelectedProfileId()
+                ?: return chain.proceed(request)
+
+        val url = request.url
+        if (url.queryParameter("profile") != null) {
+            return chain.proceed(request) // explicit param wins
+        }
+
+        val path = url.encodedPath
+        val isScoped = PROFILE_SCOPED_PREFIXES.any { prefix -> path.startsWith(prefix) }
+        if (!isScoped) {
+            return chain.proceed(request)
+        }
+
+        val scopedUrl =
+            url
+                .newBuilder()
+                .addQueryParameter("profile", profile)
+                .build()
+
+        return chain.proceed(request.newBuilder().url(scopedUrl).build())
+    }
+}

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/ProfileScopeInterceptor.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/ProfileScopeInterceptor.kt
@@ -43,6 +43,14 @@ object ProfileScopeInterceptor : Interceptor {
             "/api/model/options",
         )
 
+    /**
+     * True only when [path] matches a scoped prefix as a whole path segment —
+     * e.g. `/api/status` or `/api/status/health`, but NOT `/api/statusXYZ`
+     * or `/api/gatewayExtra` (Sourcery review, PR #540).
+     */
+    private fun isProfileScopedPath(path: String): Boolean =
+        PROFILE_SCOPED_PREFIXES.any { prefix -> path == prefix || path.startsWith("$prefix/") }
+
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
         val profile =
@@ -54,9 +62,7 @@ object ProfileScopeInterceptor : Interceptor {
             return chain.proceed(request) // explicit param wins
         }
 
-        val path = url.encodedPath
-        val isScoped = PROFILE_SCOPED_PREFIXES.any { prefix -> path.startsWith(prefix) }
-        if (!isScoped) {
+        if (!isProfileScopedPath(url.encodedPath)) {
             return chain.proceed(request)
         }
 

--- a/app/src/test/java/com/m57/hermescontrol/data/remote/ApiClientTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/remote/ApiClientTest.kt
@@ -43,6 +43,11 @@ class ApiClientTest {
         every { AuthManager.baseUrl() } returns mockWebServer.url("/").toString()
         every { AuthManager.getHost() } returns "127.0.0.1"
         every { AuthManager.getPort() } returns 9119
+
+        // PR #540 registers ProfileScopeInterceptor in ApiClient.buildService(),
+        // which calls getSelectedProfileId(). Stub it to null so the interceptor
+        // short-circuits (no profile scope) and these auth tests stay focused.
+        every { AuthManager.getSelectedProfileId() } returns null
     }
 
     @AfterEach

--- a/app/src/test/java/com/m57/hermescontrol/data/remote/ProfileScopeInterceptorTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/remote/ProfileScopeInterceptorTest.kt
@@ -1,0 +1,101 @@
+package com.m57.hermescontrol.data.remote
+
+import com.m57.hermescontrol.data.local.AuthManager
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class ProfileScopeInterceptorTest {
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        mockkObject(AuthManager)
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+        unmockkAll()
+    }
+
+    /** Builds a real client with the interceptor + a stubbed AuthManager profile. */
+    private fun clientFor(profile: String?): OkHttpClient {
+        every { AuthManager.getSelectedProfileId() } returns profile
+        return OkHttpClient
+            .Builder()
+            .addInterceptor(ProfileScopeInterceptor)
+            .build()
+    }
+
+    private fun lastRequestedPath(client: OkHttpClient): HttpUrl {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val req = Request.Builder().url(server.url("api/config")).build()
+        client.newCall(req).execute().close()
+        return server.takeRequest().requestUrl!!
+    }
+
+    @Test
+    fun scopedEndpoint_appendsProfile() {
+        val client = clientFor("work")
+        val url = lastRequestedPath(client)
+        assertEquals("work", url.queryParameter("profile"))
+        assertEquals("/api/config", url.encodedPath)
+    }
+
+    @Test
+    fun noActiveProfile_passesThrough() {
+        val client = clientFor(null)
+        val url = lastRequestedPath(client)
+        assertNull(url.queryParameter("profile"))
+    }
+
+    @Test
+    fun explicitProfileParam_wins() {
+        every { AuthManager.getSelectedProfileId() } returns "work"
+        val client = OkHttpClient.Builder().addInterceptor(ProfileScopeInterceptor).build()
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val req =
+            Request
+                .Builder()
+                .url(server.url("api/config?profile=other"))
+                .build()
+        client.newCall(req).execute().close()
+        val url = server.takeRequest().requestUrl!!
+        assertEquals("other", url.queryParameter("profile"))
+    }
+
+    @Test
+    fun nonScopedEndpoint_untouched() {
+        every { AuthManager.getSelectedProfileId() } returns "work"
+        val client = OkHttpClient.Builder().addInterceptor(ProfileScopeInterceptor).build()
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val req = Request.Builder().url(server.url("api/cron/jobs")).build()
+        client.newCall(req).execute().close()
+        val url = server.takeRequest().requestUrl!!
+        assertNull(url.queryParameter("profile"))
+        assertEquals("/api/cron/jobs", url.encodedPath)
+    }
+
+    @Test
+    fun skillsEndpoint_isScoped() {
+        val client = clientFor("alpha")
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val req = Request.Builder().url(server.url("api/skills")).build()
+        client.newCall(req).execute().close()
+        val url = server.takeRequest().requestUrl!!
+        assertEquals("alpha", url.queryParameter("profile"))
+    }
+}

--- a/app/src/test/java/com/m57/hermescontrol/data/remote/ProfileScopeInterceptorTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/remote/ProfileScopeInterceptorTest.kt
@@ -98,4 +98,32 @@ class ProfileScopeInterceptorTest {
         val url = server.takeRequest().requestUrl!!
         assertEquals("alpha", url.queryParameter("profile"))
     }
+
+    @Test
+    fun lookalikePath_notScoped() {
+        // Sourcery review (PR #540): `startsWith` must not match non-segment
+        // suffixes like /api/statusXYZ or /api/gatewayExtra.
+        every { AuthManager.getSelectedProfileId() } returns "work"
+        val client = OkHttpClient.Builder().addInterceptor(ProfileScopeInterceptor).build()
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val req = Request.Builder().url(server.url("api/statusXYZ")).build()
+        client.newCall(req).execute().close()
+        val url = server.takeRequest().requestUrl!!
+        assertNull(url.queryParameter("profile"))
+        assertEquals("/api/statusXYZ", url.encodedPath)
+    }
+
+    @Test
+    fun scopedSubPath_isScoped() {
+        // A scoped prefix with a trailing segment (/api/status/health) MUST
+        // still receive the profile param.
+        every { AuthManager.getSelectedProfileId() } returns "work"
+        val client = OkHttpClient.Builder().addInterceptor(ProfileScopeInterceptor).build()
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val req = Request.Builder().url(server.url("api/status/health")).build()
+        client.newCall(req).execute().close()
+        val url = server.takeRequest().requestUrl!!
+        assertEquals("work", url.queryParameter("profile"))
+        assertEquals("/api/status/health", url.encodedPath)
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #528. Mobile fired **all** management REST calls with **no** `?profile=` scope, so every profile read/wrote the backend's implicit default profile. On multi-profile setups this silently corrupted `config` / `skills` / `toolsets` / `mcp` / `model` / `env` for the wrong profile.

This mirrors the desktop/web dashboard contract exactly (`web/src/lib/api.ts` → `PROFILE_SCOPED_PREFIXES` + `withManagementProfile`).

### Changes
- **New `ProfileScopeInterceptor`** (OkHttp `Interceptor`): at request time reads the active profile via `AuthManager.getSelectedProfileId()` and appends `?profile=<profile>` to the scoped endpoint families. Rules copied from the desktop contract:
  - no active profile → pass through (legacy default behavior)
  - URL already carries explicit `?profile=` → left untouched (explicit beats global)
  - only the scoped families are rewritten; ops / pairing / cron / profiles themselves stay machine-global
- **`ApiClient.buildService()`**: registers `ProfileScopeInterceptor` after the auth interceptor.
- **`ProfileScopeInterceptorTest`**: 5 `MockWebServer` tests — scoped append, explicit-param precedence, no-profile passthrough, non-scoped skip (`/api/cron/jobs`), and skills scoping.

### Scoped families (identical to desktop)
`/api/status`, `/api/gateway`, `/api/analytics`, `/api/skills`, `/api/tools/toolsets`, `/api/config`, `/api/env`, `/api/mcp`, `/api/messaging/platforms`, `/api/messaging/telegram/onboarding`, `/api/messaging/whatsapp/onboarding`, `/api/model/{info,set,auxiliary,moa,options}`

## Verification
- `./gradlew ktlintCheck compileDebugKotlin testDebugUnitTest --tests ProfileScopeInterceptorTest` → **green**
- `ProfileScopeInterceptorTest`: 5 tests, 0 skipped, 0 failures, 0 errors

## Test plan
- [ ] With 2 profiles, edit config in profile B from mobile → backend shows the change under profile B (not default)
- [ ] Toggle a toolset / install a skill in a non-default profile → persists to that profile
- [ ] Calls without a selected profile behave as before (default)

Derived from the desktop-app audit in /opt/hermes-agent (Electron shell + `tui_gateway` + `apps/shared` client; profile scoping lives in `web/src/lib/api.ts`).

## Summary by Sourcery

Scope mobile management REST calls to the active profile by introducing a profile-aware HTTP interceptor and wiring it into the API client.

New Features:
- Add a ProfileScopeInterceptor that appends the active profile as a query parameter to profile-scoped management endpoints when present.

Enhancements:
- Integrate ProfileScopeInterceptor into ApiClient so management calls respect the selected profile instead of always using the backend default.

Tests:
- Add ProfileScopeInterceptorTest to validate profile appending behavior, explicit profile precedence, passthrough when no profile is selected, skipping non-scoped endpoints, and scoping for skills endpoints.