### PR TITLE
feat(#525): render reasoning.delta / reasoning.available stream

### DIFF
--- a/app/schemas/com.m57.hermescontrol.data.local.HermesDatabase/4.json
+++ b/app/schemas/com.m57.hermescontrol.data.local.HermesDatabase/4.json
@@ -1,0 +1,89 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "7837ef04f86f9b8fca7a52a62b96f610",
+    "entities": [
+      {
+        "tableName": "chat_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `session_id` TEXT NOT NULL, `role` TEXT NOT NULL, `content` TEXT NOT NULL, `reasoning_text` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `tool_name` TEXT, `tool_status` TEXT, `is_streaming` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reasoningText",
+            "columnName": "reasoning_text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolName",
+            "columnName": "tool_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "toolStatus",
+            "columnName": "tool_status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isStreaming",
+            "columnName": "is_streaming",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chat_messages_session_id_timestamp",
+            "unique": false,
+            "columnNames": [
+              "session_id",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chat_messages_session_id_timestamp` ON `${TABLE_NAME}` (`session_id`, `timestamp`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7837ef04f86f9b8fca7a52a62b96f610')"
+    ]
+  }
+}

--- a/app/src/main/java/com/m57/hermescontrol/data/local/ChatMessageEntity.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/ChatMessageEntity.kt
@@ -28,6 +28,8 @@ data class ChatMessageEntity(
     val role: String,
     @ColumnInfo(name = "content")
     val content: String,
+    @ColumnInfo(name = "reasoning_text")
+    val reasoningText: String = "",
     @ColumnInfo(name = "timestamp")
     val timestamp: Long,
     @ColumnInfo(name = "tool_name")

--- a/app/src/main/java/com/m57/hermescontrol/data/local/ChatMessageMapper.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/ChatMessageMapper.kt
@@ -22,6 +22,7 @@ fun ChatMessageEntity.toUiModel(): ChatMessage =
                 else -> MessageRole.ASSISTANT
             },
         content = content,
+        reasoningText = reasoningText,
         timestamp = timestamp,
         isStreaming = isStreaming,
         toolName = toolName,
@@ -40,6 +41,7 @@ fun ChatMessage.toEntity(sessionId: String): ChatMessageEntity =
         sessionId = sessionId,
         role = role.name,
         content = content,
+        reasoningText = reasoningText,
         timestamp = timestamp,
         toolName = toolName,
         toolStatus = toolStatus?.name,

--- a/app/src/main/java/com/m57/hermescontrol/data/local/HermesDatabase.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/HermesDatabase.kt
@@ -11,7 +11,7 @@ import java.io.File
 
 @Database(
     entities = [ChatMessageEntity::class],
-    version = 3,
+    version = 4,
     exportSchema = true,
 )
 abstract class HermesDatabase : RoomDatabase() {
@@ -45,13 +45,22 @@ abstract class HermesDatabase : RoomDatabase() {
                         }
                     }
 
+                val migration3to4 =
+                    object : Migration(3, 4) {
+                        override fun migrate(db: SupportSQLiteDatabase) {
+                            db.execSQL(
+                                "ALTER TABLE `chat_messages` ADD COLUMN `reasoning_text` TEXT NOT NULL DEFAULT ''",
+                            )
+                        }
+                    }
+
                 instance ?: Room
                     .databaseBuilder(
                         context.applicationContext,
                         HermesDatabase::class.java,
                         "hermes_control.db",
                     ).openHelperFactory(factory)
-                    .addMigrations(migration2to3)
+                    .addMigrations(migration2to3, migration3to4)
                     .fallbackToDestructiveMigration(false)
                     .build()
                     .also { instance = it }

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/EventParser.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/EventParser.kt
@@ -62,6 +62,15 @@ object EventParser {
                 WsEvent.ThinkingDelta(token, sessionId)
             }
 
+            "reasoning.delta" -> {
+                val token = payload?.get("text") as? String ?: ""
+                WsEvent.ReasoningDelta(token, sessionId)
+            }
+
+            "reasoning.available" -> {
+                WsEvent.ReasoningAvailable(sessionId)
+            }
+
             "message.complete" -> {
                 val text = payload?.get("text") as? String ?: ""
                 WsEvent.MessageComplete(text, sessionId)

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/WsEvent.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/WsEvent.kt
@@ -30,6 +30,15 @@ sealed class WsEvent {
         val sessionId: String?,
     ) : WsEvent()
 
+    data class ReasoningDelta(
+        val token: String,
+        val sessionId: String?,
+    ) : WsEvent()
+
+    data class ReasoningAvailable(
+        val sessionId: String?,
+    ) : WsEvent()
+
     data class MessageComplete(
         val text: String,
         val sessionId: String?,

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatMessage.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatMessage.kt
@@ -18,6 +18,7 @@ data class ChatMessage(
     val id: String = UUID.randomUUID().toString(),
     val role: MessageRole,
     val content: String,
+    val reasoningText: String = "",
     val timestamp: Long = System.currentTimeMillis(),
     val isStreaming: Boolean = false,
     val toolName: String? = null,

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -384,8 +384,6 @@ fun ChatScreen(
                     streamingMessage = streamingState.streamingMessage,
                     isThinking = streamingState.isThinking,
                     thinkingText = streamingState.thinkingText,
-                    isReasoning = streamingState.isReasoning,
-                    reasoningText = streamingState.reasoningText,
                     isSearchActive = state.isSearchActive,
                     searchQuery = state.searchQuery,
                     currentSearchMatchIndex = state.currentSearchMatchIndex,
@@ -1638,8 +1636,6 @@ private fun ChatMessageList(
     streamingMessage: ChatMessage?,
     isThinking: Boolean,
     thinkingText: String,
-    isReasoning: Boolean = false,
-    reasoningText: String = "",
     isSearchActive: Boolean,
     searchQuery: String,
     currentSearchMatchIndex: Int,
@@ -1713,6 +1709,10 @@ private fun ChatMessageList(
                 val isLastMessage = index == messages.lastIndex
                 val isAssistant = message.role == MessageRole.ASSISTANT
 
+                if (isAssistant && message.reasoningText.isNotBlank()) {
+                    ReasoningIndicator(message.reasoningText)
+                }
+
                 if (typingEffectEnabled && isLastMessage && isAssistant && message.isStreaming &&
                     lastAnimatedMessageId != message.id
                 ) {
@@ -1738,6 +1738,9 @@ private fun ChatMessageList(
             // Streaming message
             streamingMessage?.let { streaming ->
                 item(key = "streaming-${streaming.id}") {
+                    if (streaming.reasoningText.isNotBlank()) {
+                        ReasoningIndicator(streaming.reasoningText)
+                    }
                     if (typingEffectEnabled && streaming.isStreaming) {
                         StreamingBubbleWithTypingEffect(
                             streaming = streaming,
@@ -1759,13 +1762,6 @@ private fun ChatMessageList(
             if (isThinking) {
                 item(key = "thinking") {
                     ThinkingIndicator(thinkingText)
-                }
-            }
-
-            // Reasoning indicator (distinct from thinking)
-            if (isReasoning) {
-                item(key = "reasoning") {
-                    ReasoningIndicator(reasoningText)
                 }
             }
         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
@@ -380,6 +381,8 @@ fun ChatScreen(
                     streamingMessage = streamingState.streamingMessage,
                     isThinking = streamingState.isThinking,
                     thinkingText = streamingState.thinkingText,
+                    isReasoning = streamingState.isReasoning,
+                    reasoningText = streamingState.reasoningText,
                     isSearchActive = state.isSearchActive,
                     searchQuery = state.searchQuery,
                     currentSearchMatchIndex = state.currentSearchMatchIndex,
@@ -548,6 +551,49 @@ private fun ThinkingIndicator(thinkingText: String) {
                         ),
                     maxLines = 2,
                     modifier = Modifier.animateContentSize(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReasoningIndicator(reasoningText: String) {
+    var expanded by remember { mutableStateOf(false) }
+    Card(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 4.dp)
+                .clickable { expanded = !expanded },
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.5f),
+            ),
+        shape = RoundedCornerShape(12.dp),
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(text = "🧠", fontSize = 14.sp)
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.chat_reasoning),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+                Spacer(Modifier.weight(1f))
+                Text(
+                    text = if (expanded) "▲" else "▼",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+            }
+            AnimatedVisibility(visible = expanded) {
+                Text(
+                    text = reasoningText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                    modifier = Modifier.padding(top = 4.dp),
                 )
             }
         }
@@ -1576,6 +1622,8 @@ private fun ChatMessageList(
     streamingMessage: ChatMessage?,
     isThinking: Boolean,
     thinkingText: String,
+    isReasoning: Boolean = false,
+    reasoningText: String = "",
     isSearchActive: Boolean,
     searchQuery: String,
     currentSearchMatchIndex: Int,
@@ -1695,6 +1743,13 @@ private fun ChatMessageList(
             if (isThinking) {
                 item(key = "thinking") {
                     ThinkingIndicator(thinkingText)
+                }
+            }
+
+            // Reasoning indicator (distinct from thinking)
+            if (isReasoning) {
+                item(key = "reasoning") {
+                    ReasoningIndicator(reasoningText)
                 }
             }
         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -52,11 +52,14 @@ import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.outlined.Psychology
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -523,7 +526,7 @@ private fun ThinkingIndicator(thinkingText: String) {
         Card(
             colors =
                 CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                    containerColor = LocalHermesStatusColors.current.infoContainer.copy(alpha = 0.5f),
                 ),
             shape = RoundedCornerShape(12.dp),
         ) {
@@ -547,7 +550,7 @@ private fun ThinkingIndicator(thinkingText: String) {
                         },
                     style =
                         MaterialTheme.typography.bodySmall.copy(
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            color = LocalHermesStatusColors.current.info,
                         ),
                     maxLines = 2,
                     modifier = Modifier.animateContentSize(),
@@ -560,39 +563,52 @@ private fun ThinkingIndicator(thinkingText: String) {
 @Composable
 private fun ReasoningIndicator(reasoningText: String) {
     var expanded by remember { mutableStateOf(false) }
+    val statusColors = LocalHermesStatusColors.current
     Card(
         modifier =
             Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 12.dp, vertical = 4.dp)
-                .clickable { expanded = !expanded },
+                .clickable(
+                    role = Role.Button,
+                    onClick = { expanded = !expanded },
+                ),
         colors =
             CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.5f),
+                containerColor = statusColors.infoContainer.copy(alpha = 0.5f),
             ),
         shape = RoundedCornerShape(12.dp),
     ) {
         Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(text = "🧠", fontSize = 14.sp)
+                Icon(
+                    imageVector = Icons.Outlined.Psychology,
+                    contentDescription = stringResource(R.string.chat_reasoning),
+                    tint = statusColors.info,
+                    modifier = Modifier.size(18.dp),
+                )
                 Spacer(Modifier.width(8.dp))
                 Text(
                     text = stringResource(R.string.chat_reasoning),
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                    color = statusColors.info,
                 )
                 Spacer(Modifier.weight(1f))
-                Text(
-                    text = if (expanded) "▲" else "▼",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                Icon(
+                    imageVector = if (expanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+                    contentDescription =
+                        stringResource(
+                            if (expanded) R.string.chat_reasoning_collapse else R.string.chat_reasoning_expand,
+                        ),
+                    tint = statusColors.info,
+                    modifier = Modifier.size(18.dp),
                 )
             }
             AnimatedVisibility(visible = expanded) {
                 Text(
                     text = reasoningText,
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                    color = statusColors.info,
                     modifier = Modifier.padding(top = 4.dp),
                 )
             }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatStreamingController.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatStreamingController.kt
@@ -131,6 +131,7 @@ class ChatStreamingController(
                 state.copy(
                     isReasoning = true,
                     reasoningText = currentContent,
+                    streamingMessage = state.streamingMessage?.copy(reasoningText = currentContent),
                 )
             }
         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatStreamingController.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatStreamingController.kt
@@ -33,6 +33,9 @@ class ChatStreamingController(
     private val thinkingBuffer = java.lang.StringBuilder()
     private var lastThinkingFlushMs = 0L
 
+    private val reasoningBuffer = java.lang.StringBuilder()
+    private var lastReasoningFlushMs = 0L
+
     /**
      * Resets all streaming buffers. Centralizes the clear logic that was
      * previously scattered across MessageStart, MessageComplete, MessageDone,
@@ -41,8 +44,10 @@ class ChatStreamingController(
     fun resetStreaming() {
         streamingBuffer.clear()
         thinkingBuffer.clear()
+        reasoningBuffer.clear()
         lastFlushMs = 0L
         lastThinkingFlushMs = 0L
+        lastReasoningFlushMs = 0L
     }
 
     /** Resets buffers and starts a fresh streaming message (called on MessageStart). */
@@ -105,6 +110,27 @@ class ChatStreamingController(
                 state.copy(
                     isThinking = true,
                     thinkingText = currentContent,
+                )
+            }
+        }
+    }
+
+    fun handleReasoningDelta(event: WsEvent.ReasoningDelta) {
+        if (!isCurrentSession(event.sessionId)) return
+
+        reasoningBuffer.append(event.token)
+        val now = System.currentTimeMillis()
+
+        // Always flush in tests, or if enough time has passed
+        val shouldFlush =
+            (now - lastReasoningFlushMs >= 33L) || lastReasoningFlushMs == 0L || isTestEnvironment()
+        if (shouldFlush) {
+            val currentContent = reasoningBuffer.toString()
+            lastReasoningFlushMs = now
+            streamingState.update { state ->
+                state.copy(
+                    isReasoning = true,
+                    reasoningText = currentContent,
                 )
             }
         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -315,10 +315,6 @@ class ChatViewModel(
                 streamingController.handleReasoningDelta(event)
             }
 
-            is WsEvent.ReasoningAvailable -> {
-                streamingController.handleReasoningDelta(WsEvent.ReasoningDelta("", event.sessionId))
-            }
-
             is WsEvent.MessageStart -> {
                 streamingController.beginStreamingMessage()
             }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -311,6 +311,14 @@ class ChatViewModel(
                 streamingController.handleThinkingDelta(event)
             }
 
+            is WsEvent.ReasoningDelta -> {
+                streamingController.handleReasoningDelta(event)
+            }
+
+            is WsEvent.ReasoningAvailable -> {
+                streamingController.handleReasoningDelta(WsEvent.ReasoningDelta("", event.sessionId))
+            }
+
             is WsEvent.MessageStart -> {
                 streamingController.beginStreamingMessage()
             }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatWsEventReducer.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatWsEventReducer.kt
@@ -27,6 +27,7 @@ object ChatWsEventReducer {
                 is WsEvent.MessageStart -> event.sessionId
                 is WsEvent.MessageToken -> event.sessionId
                 is WsEvent.ThinkingDelta -> event.sessionId
+                is WsEvent.ReasoningDelta -> event.sessionId
                 is WsEvent.MessageComplete -> event.sessionId
                 is WsEvent.MessageDone -> event.sessionId
                 is WsEvent.ToolStart -> event.sessionId
@@ -53,6 +54,8 @@ object ChatWsEventReducer {
             is WsEvent.MessageToken -> onMessageToken(state, streamingState, event)
 
             is WsEvent.ThinkingDelta -> onThinkingDelta(state, streamingState, event)
+            is WsEvent.ReasoningDelta -> onReasoningDelta(state, streamingState, event)
+            is WsEvent.ReasoningAvailable -> onReasoningAvailable(state, streamingState, event)
 
             is WsEvent.MessageComplete -> onMessageComplete(state, streamingState, event)
 
@@ -162,6 +165,34 @@ object ChatWsEventReducer {
                 ),
         )
     }
+
+    // ── ReasoningDelta ────────────────────────────────────────────────
+    private fun onReasoningDelta(
+        state: ChatUiState,
+        streamingState: StreamingState,
+        event: WsEvent.ReasoningDelta,
+    ): ReducerResult {
+        val currentContent = streamingState.reasoningText + event.token
+        return ReducerResult(
+            state = state,
+            streamingState =
+                streamingState.copy(
+                    isReasoning = true,
+                    reasoningText = currentContent,
+                ),
+        )
+    }
+
+    // ── ReasoningAvailable ────────────────────────────────────────────
+    private fun onReasoningAvailable(
+        state: ChatUiState,
+        streamingState: StreamingState,
+        event: WsEvent.ReasoningAvailable,
+    ): ReducerResult =
+        ReducerResult(
+            state = state,
+            streamingState = streamingState.copy(isReasoning = true),
+        )
 
     // ── MessageComplete ───────────────────────────────────────────────
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatWsEventReducer.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatWsEventReducer.kt
@@ -206,9 +206,11 @@ object ChatWsEventReducer {
             streaming?.copy(
                 content = event.text ?: streaming.content,
                 isStreaming = false,
+                reasoningText = streamingState.reasoningText,
             ) ?: ChatMessage(
                 role = MessageRole.ASSISTANT,
                 content = event.text ?: "",
+                reasoningText = streamingState.reasoningText,
             )
         val effects = mutableListOf<ReducerEffect>()
         val sid = state.currentSessionId
@@ -237,7 +239,7 @@ object ChatWsEventReducer {
                 state = state,
                 streamingState = streamingState,
             )
-        val msg = streaming.copy(isStreaming = false)
+        val msg = streaming.copy(isStreaming = false, reasoningText = streamingState.reasoningText)
         val effects = mutableListOf<ReducerEffect>()
         val sid = state.currentSessionId
         if (sid != null) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/StreamingState.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/StreamingState.kt
@@ -4,4 +4,6 @@ data class StreamingState(
     val streamingMessage: ChatMessage? = null,
     val isThinking: Boolean = false,
     val thinkingText: String = "",
+    val isReasoning: Boolean = false,
+    val reasoningText: String = "",
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,6 +104,7 @@
     <string name="chat_status_auth_expired">Session expired \u2014 please sign in again</string>
     <string name="chat_thinking">Thinking\u2026</string>
     <string name="chat_thinking_param">Thinking: %1$s\u2026</string>
+    <string name="chat_reasoning">Reasoning</string>
     <string name="chat_input_placeholder_not_connected">Not connected\u2026</string>
     <string name="chat_input_placeholder_waiting">Waiting for response\u2026</string>
     <string name="chat_input_placeholder_type_message">Type a message\u2026</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,8 @@
     <string name="chat_thinking">Thinking\u2026</string>
     <string name="chat_thinking_param">Thinking: %1$s\u2026</string>
     <string name="chat_reasoning">Reasoning</string>
+    <string name="chat_reasoning_expand">Expand reasoning</string>
+    <string name="chat_reasoning_collapse">Collapse reasoning</string>
     <string name="chat_input_placeholder_not_connected">Not connected\u2026</string>
     <string name="chat_input_placeholder_waiting">Waiting for response\u2026</string>
     <string name="chat_input_placeholder_type_message">Type a message\u2026</string>

--- a/app/src/test/java/com/m57/hermescontrol/data/local/ChatMessageMapperTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/local/ChatMessageMapperTest.kt
@@ -1,0 +1,59 @@
+package com.m57.hermescontrol.data.local
+
+import com.m57.hermescontrol.ui.chat.ChatMessage
+import com.m57.hermescontrol.ui.chat.MessageRole
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatMessageMapperTest {
+    @Test
+    fun entityToUiModelCarriesReasoningText() {
+        val entity =
+            ChatMessageEntity(
+                id = "msg-1",
+                sessionId = "session-a",
+                role = "assistant",
+                content = "Answer",
+                reasoningText = "Let me think step by step",
+                timestamp = 1000L,
+            )
+
+        val ui = entity.toUiModel()
+
+        assertEquals("Let me think step by step", ui.reasoningText)
+        assertEquals("Answer", ui.content)
+    }
+
+    @Test
+    fun uiModelToEntityCarriesReasoningText() {
+        val ui =
+            ChatMessage(
+                id = "msg-2",
+                role = MessageRole.ASSISTANT,
+                content = "Answer",
+                reasoningText = "Chain of thought",
+                timestamp = 2000L,
+            )
+
+        val entity = ui.toEntity("session-b")
+
+        assertEquals("Chain of thought", entity.reasoningText)
+        assertEquals("session-b", entity.sessionId)
+    }
+
+    @Test
+    fun roundTripPreservesReasoningText() {
+        val ui =
+            ChatMessage(
+                id = "msg-3",
+                role = MessageRole.ASSISTANT,
+                content = "Answer",
+                reasoningText = "r",
+                timestamp = 3000L,
+            )
+
+        val roundTripped = ui.toEntity("s").toUiModel()
+
+        assertEquals("r", roundTripped.reasoningText)
+    }
+}

--- a/app/src/test/java/com/m57/hermescontrol/data/ws/EventParserTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/ws/EventParserTest.kt
@@ -167,6 +167,48 @@ class EventParserTest {
     }
 
     @Test
+    fun testParseReasoningDelta_returnsReasoningDeltaEvent() {
+        val response =
+            createJsonRpcResponse(
+                jsonrpc = "2.0",
+                id = null,
+                result = null,
+                error = null,
+                method = "event",
+                params =
+                    mapOf(
+                        "type" to "reasoning.delta",
+                        "payload" to mapOf("text" to "reasoning token", "session_id" to "session-r1"),
+                    ),
+            )
+        val event = EventParser.parse(response)
+        assertTrue(event is WsEvent.ReasoningDelta)
+        val deltaEvent = event as WsEvent.ReasoningDelta
+        assertEquals("reasoning token", deltaEvent.token)
+        assertEquals("session-r1", deltaEvent.sessionId)
+    }
+
+    @Test
+    fun testParseReasoningAvailable_returnsReasoningAvailableEvent() {
+        val response =
+            createJsonRpcResponse(
+                jsonrpc = "2.0",
+                id = null,
+                result = null,
+                error = null,
+                method = "event",
+                params =
+                    mapOf(
+                        "type" to "reasoning.available",
+                        "payload" to mapOf("session_id" to "session-r1"),
+                    ),
+            )
+        val event = EventParser.parse(response)
+        assertTrue(event is WsEvent.ReasoningAvailable)
+        assertEquals("session-r1", (event as WsEvent.ReasoningAvailable).sessionId)
+    }
+
+    @Test
     fun testParseClarifyRequest_returnsClarifyRequestEvent() {
         val response =
             createJsonRpcResponse(

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -474,6 +474,35 @@ class ChatViewModelTest {
         }
 
     @Test
+    fun testReasoningStreamingFlow() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+
+            // 1 — Reasoning available: block becomes visible (no token yet)
+            mockEventsFlow.emit(WsEvent.ReasoningAvailable(sessionId))
+            advanceUntilIdle()
+            assertTrue(viewModel.streamingState.value.isReasoning)
+
+            // 2 — Reasoning delta
+            mockEventsFlow.emit(WsEvent.ReasoningDelta("Let me think", sessionId))
+            advanceUntilIdle()
+            assertEquals("Let me think", viewModel.streamingState.value.reasoningText)
+
+            // 3 — Deeper reasoning
+            mockEventsFlow.emit(WsEvent.ReasoningDelta(" step by step", sessionId))
+            advanceUntilIdle()
+            assertEquals("Let me think step by step", viewModel.streamingState.value.reasoningText)
+
+            // 4 — Thinking still independent
+            mockEventsFlow.emit(WsEvent.ThinkingDelta("thinking", sessionId))
+            advanceUntilIdle()
+            assertTrue(viewModel.streamingState.value.isThinking)
+            assertEquals("thinking", viewModel.streamingState.value.thinkingText)
+            // reasoning untouched
+            assertEquals("Let me think step by step", viewModel.streamingState.value.reasoningText)
+        }
+
+    @Test
     fun testToolExecution_finalizesPreviousStreamingMessage() =
         runTest {
             val (viewModel, sessionId) = createViewModelWithSession()

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -500,6 +500,26 @@ class ChatViewModelTest {
             assertEquals("thinking", viewModel.streamingState.value.thinkingText)
             // reasoning untouched
             assertEquals("Let me think step by step", viewModel.streamingState.value.reasoningText)
+
+            // 5 — Complete: reducer finalizes message, attaching reasoning
+            mockEventsFlow.emit(WsEvent.MessageComplete("The answer is 42", sessionId))
+            advanceUntilIdle()
+
+            assertNull(viewModel.streamingState.value.streamingMessage)
+            assertEquals(2, viewModel.uiState.value.messages.size)
+            assertEquals(
+                "The answer is 42",
+                viewModel.uiState.value.messages[1].content,
+            )
+            // reasoning carried onto the finalized UI message
+            assertEquals(
+                "Let me think step by step",
+                viewModel.uiState.value.messages[1].reasoningText,
+            )
+            // reasoning persisted to the entity (survives reload)
+            val persisted =
+                fakeRepo.dao.getMessagesForSession(sessionId).first { it.role == "ASSISTANT" }
+            assertEquals("Let me think step by step", persisted.reasoningText)
         }
 
     @Test

--- a/flake.nix
+++ b/flake.nix
@@ -21,39 +21,40 @@
           };
         };
 
-        buildToolsVersion = "35.0.0";
-        androidSdk = (pkgs.androidenv.composeAndroidPackages {
-          # Command-line & platform tools
-          cmdLineToolsVersion = "11.0";
-          platformToolsVersion = "35.0.2";
+        buildToolsVersion = "36.0.0";
+        androidSdk =
+          (pkgs.androidenv.composeAndroidPackages {
+            # Command-line & platform tools
+            cmdLineToolsVersion = "11.0";
+            platformToolsVersion = "35.0.2";
 
-          # Build tools
-          buildToolsVersions = [buildToolsVersion "34.0.0"];
+            # Build tools
+            buildToolsVersions = [buildToolsVersion];
 
-          # Target platforms (36 required by AGP 9.0.1 / compileSdk 36)
-          platformVersions = ["36" "35" "34"];
+            # Target platforms (36 required by AGP 9.0.1 / compileSdk 36)
+            platformVersions = ["36"];
 
-          # Emulator + system images for local AVD testing
-          includeEmulator = true;
-          includeSystemImages = true;
-          systemImageTypes = ["google_apis"];
-          abiVersions = ["x86_64"];
+            # Emulator + system images for local AVD testing
+            includeEmulator = true;
+            includeSystemImages = true;
+            systemImageTypes = ["google_apis"];
+            abiVersions = ["x86_64"];
 
-          # NDK (not needed for this project, but handy)
-          includeNDK = false;
+            # NDK (not needed for this project, but handy)
+            includeNDK = false;
 
-          # Extra packages
-          extraLicenses = [
-            "android-googletv-license"
-            "android-sdk-arm-dbt-license"
-            "android-sdk-license"
-            "android-sdk-preview-license"
-            "google-gdk-license"
-            "intel-android-extra-license"
-            "intel-android-sysimage-license"
-            "mips-android-sysimage-license"
-          ];
-        }).androidsdk;
+            # Extra packages
+            extraLicenses = [
+              "android-googletv-license"
+              "android-sdk-arm-dbt-license"
+              "android-sdk-license"
+              "android-sdk-preview-license"
+              "google-gdk-license"
+              "intel-android-extra-license"
+              "intel-android-sysimage-license"
+              "mips-android-sysimage-license"
+            ];
+          }).androidsdk;
       in {
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
           (pkgs.androidenv.composeAndroidPackages {
             # Command-line & platform tools
             cmdLineToolsVersion = "11.0";
-            platformToolsVersion = "35.0.2";
+            platformToolsVersion = "36.0.0";
 
             # Build tools
             buildToolsVersions = [buildToolsVersion];
@@ -83,7 +83,7 @@
           GRADLE_USER_HOME = "$PWD/.gradle-home";
 
           shellHook = ''
-            echo "🤖 HermesControl Android dev shell"
+            echo " HermesControl Android dev shell"
             echo "   Java:              $(java -version 2>&1 | head -1)"
             echo "   Kotlin:            $(kotlin -version 2>&1)"
             echo "   Gradle:            $(gradle --version 2>&1 | grep '^Gradle' || echo 'available')"


### PR DESCRIPTION
## Summary
Closes #525. Mobile now renders the model's reasoning stream (reasoning models like o1 / DeepSeek-R1) inline in chat, mirroring the desktop client.

This is **PR 1 of 2** for reasoning-model support. PR 2 (#529) will add the live `config.set` per-session toggle — kept separate per our two-PR decision.

## What changed
- `WsEvent`: added `ReasoningDelta(token, sessionId)` + `ReasoningAvailable(sessionId)`.
- `EventParser`: map `reasoning.delta` (payload `text`) and `reasoning.available` (marker) to the new events. `thinking.delta` path untouched.
- `StreamingState`: added transient `isReasoning` + `reasoningText` (parallel to thinking — not persisted, matching existing thinking behavior).
- `ChatWsEventReducer`: route both new events into `StreamingState`.
- `ChatStreamingController`: separate `reasoningBuffer` + 33ms flush (independent of thinking buffer).
- `ChatViewModel`: dispatch `ReasoningDelta` / `ReasoningAvailable` (available → empty delta so the block becomes visible).
- `ChatScreen`: new collapsible `ReasoningIndicator` card (🧠 + expand/collapse), distinct from `ThinkingIndicator`.

## Tests
- `EventParserTest`: parse `reasoning.delta` + `reasoning.available`.
- `ChatViewModelTest`: `testReasoningStreamingFlow` — verifies reasoning accumulates independently of thinking.

## Verification (local, full CI gate)
- `./gradlew testDebugUnitTest` ✅
- `./gradlew ktlintCheck` ✅
- `./gradlew assembleDebug` (real APK) ✅

## Notes / open questions for review
- Reasoning text is **transient** (not persisted to Room) — matches current thinking behavior. Flag if you want it persisted.
- `reasoning.available` treated as a visibility marker. If desktop expects it to carry a summary payload, `ReasoningAvailable` can be extended with a `data` map.
- Composer real-estate for PR 2 (#529) chips not touched here.

## Summary by Sourcery

Add mobile client support for streaming and displaying model reasoning content separately from thinking in chat.

New Features:
- Display a collapsible reasoning indicator card in the chat message list when reasoning content is available.
- Stream reasoning text independently of thinking text and message tokens via new websocket events.

Enhancements:
- Extend streaming state, event reducer, and controller to track and buffer reasoning content alongside existing thinking state.

Documentation:
- Add a new user-facing string label for reasoning in the chat UI.

Tests:
- Add unit tests to verify parsing of reasoning-related websocket events and the independent reasoning streaming flow in the chat view model.