### PR TITLE
feat(#529): in-chat reasoning-effort + fast-mode toggles via config.set

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/config/ModelPrefsStore.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/config/ModelPrefsStore.kt
@@ -1,0 +1,100 @@
+package com.m57.hermescontrol.data.config
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.Serializer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Persists per-app model-control preferences that should survive a cold start
+ * (e.g. the last reasoning effort the user picked, so the composer doesn't
+ * reset to "medium" every launch). Mirrors the [ServerStore] DataStore pattern.
+ */
+class ModelPrefsStore(
+    private val dataStore: DataStore<ModelPrefsState>,
+    private val scope: CoroutineScope,
+) {
+    private val _stateFlow: MutableStateFlow<ModelPrefsState>
+    val stateFlow: StateFlow<ModelPrefsState>
+    val state: Flow<ModelPrefsState>
+
+    init {
+        val initial =
+            runBlocking(Dispatchers.IO) {
+                try {
+                    dataStore.data.first().selfHealed()
+                } catch (e: Exception) {
+                    ModelPrefsState()
+                }
+            }
+        _stateFlow = MutableStateFlow(initial)
+        stateFlow = _stateFlow.asStateFlow()
+        state = stateFlow
+    }
+
+    fun getLatestState(): ModelPrefsState = _stateFlow.value
+
+    fun update(transform: (ModelPrefsState) -> ModelPrefsState) {
+        val current = getLatestState()
+        val updated = transform(current).selfHealed()
+        _stateFlow.value = updated
+        scope.launch(Dispatchers.IO) {
+            try {
+                dataStore.updateData { updated }
+            } catch (e: Exception) {
+                // Fail-safe: keep in-memory value even if disk write fails.
+            }
+        }
+    }
+}
+
+@kotlinx.serialization.Serializable
+data class ModelPrefsState(
+    /** Last reasoning effort picked in the chat composer (minimal..max). */
+    val lastReasoningEffort: String = "medium",
+) {
+    fun selfHealed(): ModelPrefsState {
+        val valid =
+            lastReasoningEffort in
+                setOf("minimal", "low", "medium", "high", "xhigh", "max", "none")
+        return if (valid) this else copy(lastReasoningEffort = "medium")
+    }
+}
+
+object ModelPrefsSerializer : Serializer<ModelPrefsState> {
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+            prettyPrint = false
+        }
+
+    override val defaultValue: ModelPrefsState = ModelPrefsState()
+
+    override suspend fun readFrom(input: InputStream): ModelPrefsState =
+        try {
+            json.decodeFromString(
+                ModelPrefsState.serializer(),
+                input.readBytes().decodeToString(),
+            )
+        } catch (e: Exception) {
+            defaultValue
+        }
+
+    override suspend fun writeTo(
+        t: ModelPrefsState,
+        output: OutputStream,
+    ) {
+        val serialized = json.encodeToString(ModelPrefsState.serializer(), t)
+        output.write(serialized.toByteArray())
+    }
+}

--- a/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
@@ -5,6 +5,8 @@ import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import com.m57.hermescontrol.data.config.ConnectionProfile
+import com.m57.hermescontrol.data.config.ModelPrefsSerializer
+import com.m57.hermescontrol.data.config.ModelPrefsStore
 import com.m57.hermescontrol.data.config.ServerStore
 import com.m57.hermescontrol.data.config.ServerStoreMigration
 import com.m57.hermescontrol.data.config.ServerStoreSerializer
@@ -49,11 +51,20 @@ object AuthManager {
     private var _serverStore: ServerStore? = null
 
     @Volatile
+    private var _modelPrefsStore: ModelPrefsStore? = null
+
+    @Volatile
     private var appScope: CoroutineScope? = null
 
     val serverStore: ServerStore
         get() =
             _serverStore ?: throw IllegalStateException(
+                "AuthManager not initialized. Call init(context) first.",
+            )
+
+    val modelPrefsStore: ModelPrefsStore
+        get() =
+            _modelPrefsStore ?: throw IllegalStateException(
                 "AuthManager not initialized. Call init(context) first.",
             )
 
@@ -96,6 +107,15 @@ object AuthManager {
             appScope = scope
             val store = ServerStore(dataStore, scope)
             _serverStore = store
+
+            // Persisted model-control prefs (last reasoning effort, etc.).
+            val modelPrefsDataStore =
+                androidx.datastore.core.DataStoreFactory.create(
+                    serializer = ModelPrefsSerializer,
+                ) {
+                    context.filesDir.resolve("model_prefs.json")
+                }
+            _modelPrefsStore = ModelPrefsStore(modelPrefsDataStore, scope)
 
             if (prefsDeferred == null) {
                 prefsDeferred =

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/ModelCapabilities.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/ModelCapabilities.kt
@@ -1,0 +1,45 @@
+package com.m57.hermescontrol.data.ws
+
+/**
+ * On-device mirror of the backend's fast-mode eligibility logic.
+ *
+ * The gateway's `tui_gateway/server.py` `config.set(key="fast")` handler rejects
+ * the toggle with `4002 "fast mode is not available for this model"` when the
+ * running model doesn't support it (see `hermes_cli.models.model_supports_fast_mode`).
+ * The mobile currently fires that RPC fire-and-forget and swallows the error, so the
+ * chip would flip "on" even when the server silently rejected it — a lie-state.
+ *
+ * Until the backend exposes a capability flag over the wire, we mirror the same
+ * predicate here so the UI can grey-out Fast before the user ever taps it. Keep this
+ * in lock-step with `hermes_cli/models.py`:
+ *   - OpenAI flagships (gpt-*, o1/o3/o4*, NOT *codex*) -> Priority Processing
+ *   - Anthropic claude-opus-4-6 only -> Anthropic Fast Mode (speed=fast)
+ */
+object ModelCapabilities {
+    /** Whether Hermes should expose the Fast toggle for [modelId]. */
+    fun supportsFastMode(modelId: String?): Boolean {
+        val raw = stripVendorPrefix(modelId) ?: return false
+        return isAnthropicFastModel(raw) || isOpenAiFastModel(raw)
+    }
+
+    private fun stripVendorPrefix(modelId: String?): String? {
+        val raw = modelId?.trim()?.lowercase() ?: return null
+        if (raw.isEmpty()) return null
+        return if ("/" in raw) raw.substringAfter("/") else raw
+    }
+
+    private fun isOpenAiFastModel(modelId: String): Boolean {
+        val base = modelId.split(":")[0]
+        if ("codex" in base) return false
+        return base.startsWith("gpt-") ||
+            base.startsWith("o1") ||
+            base.startsWith("o3") ||
+            base.startsWith("o4")
+    }
+
+    private fun isAnthropicFastModel(modelId: String): Boolean {
+        val base = modelId.split(":")[0]
+        if (!base.startsWith("claude-")) return false
+        return "opus-4-6" in base || "opus-4.6" in base
+    }
+}

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/WsMethods.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/WsMethods.kt
@@ -32,4 +32,13 @@ object WsMethods {
 
     /** Stage a non-image file (data URL) for agent access. */
     const val FILE_ATTACH = "file.attach"
+
+    // ── Config ────────────────────────────────────────────────────────────
+
+    /**
+     * Per-session config mutation (reasoning effort, fast mode, model, …).
+     * Mirrors desktop `request('config.set', { key, session_id, value })`.
+     * See apps/desktop/src/store/model-presets.ts:77-81.
+     */
+    const val CONFIG_SET = "config.set"
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -42,6 +43,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -51,6 +53,7 @@ import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AttachFile
+import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
@@ -68,6 +71,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -465,6 +469,10 @@ fun ChatScreen(
                 isConnected = state.isConnected,
                 commandCatalog = state.commandCatalog,
                 pendingAttachments = state.pendingAttachments,
+                reasoningEffort = state.reasoningEffort,
+                fastMode = state.fastMode,
+                onReasoningEffortChange = viewModel::setReasoningEffort,
+                onToggleFastMode = viewModel::toggleFastMode,
                 onCameraTap = {
                     try {
                         val timeStamp =
@@ -629,6 +637,10 @@ private fun ChatInputBar(
     onImageTap: () -> Unit = {},
     onFileTap: () -> Unit = {},
     onRemoveAttachment: (Int) -> Unit = {},
+    reasoningEffort: String = "medium",
+    fastMode: Boolean = false,
+    onReasoningEffortChange: (String) -> Unit = {},
+    onToggleFastMode: () -> Unit = {},
 ) {
     // Allow sending slash commands even while agent is typing
     val isSlashCommand = inputText.startsWith("/")
@@ -738,6 +750,64 @@ private fun ChatInputBar(
                                 onRemove = { onRemoveAttachment(index) },
                             )
                         }
+                    }
+                }
+
+                // In-chat model controls (issue #529): reasoning effort + fast toggle.
+                // Fire config.set with session_id; no dialog, mirrors desktop composer.
+                val reasoningEfforts = listOf("minimal", "low", "medium", "high", "xhigh", "max")
+                AnimatedVisibility(
+                    visible = true,
+                    enter = fadeIn() + expandVertically(),
+                    exit = fadeOut() + shrinkVertically(),
+                ) {
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .horizontalScroll(rememberScrollState())
+                                .padding(horizontal = 12.dp, vertical = 4.dp),
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.chat_model_controls_label),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        reasoningEfforts.forEach { effort ->
+                            val selected = effort == reasoningEffort
+                            FilterChip(
+                                selected = selected,
+                                onClick = { onReasoningEffortChange(effort) },
+                                label = {
+                                    Text(
+                                        text = effort,
+                                        style = MaterialTheme.typography.labelSmall,
+                                    )
+                                },
+                                modifier = Modifier.height(28.dp),
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(4.dp))
+                        FilterChip(
+                            selected = fastMode,
+                            onClick = onToggleFastMode,
+                            label = {
+                                Text(
+                                    text = stringResource(R.string.chat_fast_mode_label),
+                                    style = MaterialTheme.typography.labelSmall,
+                                )
+                            },
+                            modifier = Modifier.height(28.dp),
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Filled.Bolt,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(14.dp),
+                                )
+                            },
+                        )
                     }
                 }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -471,6 +471,7 @@ fun ChatScreen(
                 pendingAttachments = state.pendingAttachments,
                 reasoningEffort = state.reasoningEffort,
                 fastMode = state.fastMode,
+                fastSupported = state.fastSupported,
                 onReasoningEffortChange = viewModel::setReasoningEffort,
                 onToggleFastMode = viewModel::toggleFastMode,
                 onCameraTap = {
@@ -639,6 +640,7 @@ private fun ChatInputBar(
     onRemoveAttachment: (Int) -> Unit = {},
     reasoningEffort: String = "medium",
     fastMode: Boolean = false,
+    fastSupported: Boolean = true,
     onReasoningEffortChange: (String) -> Unit = {},
     onToggleFastMode: () -> Unit = {},
 ) {
@@ -756,59 +758,54 @@ private fun ChatInputBar(
                 // In-chat model controls (issue #529): reasoning effort + fast toggle.
                 // Fire config.set with session_id; no dialog, mirrors desktop composer.
                 val reasoningEfforts = listOf("minimal", "low", "medium", "high", "xhigh", "max")
-                AnimatedVisibility(
-                    visible = true,
-                    enter = fadeIn() + expandVertically(),
-                    exit = fadeOut() + shrinkVertically(),
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(rememberScrollState())
+                            .padding(horizontal = 12.dp, vertical = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .horizontalScroll(rememberScrollState())
-                                .padding(horizontal = 12.dp, vertical = 4.dp),
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = stringResource(R.string.chat_model_controls_label),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        reasoningEfforts.forEach { effort ->
-                            val selected = effort == reasoningEffort
-                            FilterChip(
-                                selected = selected,
-                                onClick = { onReasoningEffortChange(effort) },
-                                label = {
-                                    Text(
-                                        text = effort,
-                                        style = MaterialTheme.typography.labelSmall,
-                                    )
-                                },
-                                modifier = Modifier.height(28.dp),
-                            )
-                        }
-                        Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = stringResource(R.string.chat_reasoning_controls_label),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    reasoningEfforts.forEach { effort ->
+                        val selected = effort == reasoningEffort
                         FilterChip(
-                            selected = fastMode,
-                            onClick = onToggleFastMode,
+                            selected = selected,
+                            onClick = { onReasoningEffortChange(effort) },
                             label = {
                                 Text(
-                                    text = stringResource(R.string.chat_fast_mode_label),
+                                    text = effort,
                                     style = MaterialTheme.typography.labelSmall,
                                 )
                             },
                             modifier = Modifier.height(28.dp),
-                            leadingIcon = {
-                                Icon(
-                                    imageVector = Icons.Filled.Bolt,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(14.dp),
-                                )
-                            },
                         )
                     }
+                    Spacer(modifier = Modifier.width(4.dp))
+                    FilterChip(
+                        selected = fastMode,
+                        onClick = onToggleFastMode,
+                        enabled = fastSupported,
+                        label = {
+                            Text(
+                                text = stringResource(R.string.chat_fast_mode_label),
+                                style = MaterialTheme.typography.labelSmall,
+                            )
+                        },
+                        modifier = Modifier.height(28.dp),
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Filled.Bolt,
+                                contentDescription = null,
+                                modifier = Modifier.size(14.dp),
+                            )
+                        },
+                    )
                 }
 
                 Row(

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -73,6 +73,9 @@ data class ChatUiState(
     val commandCatalog: CommandCatalog = CommandCatalog(),
     // Attachment state
     val pendingAttachments: List<Attachment> = emptyList(),
+    // In-chat model controls (issue #529) — fire config.set with session_id
+    val reasoningEffort: String = "medium",
+    val fastMode: Boolean = false,
 ) {
     /** Convenience — derived from [connectionStatus]. */
     val isConnected: Boolean get() = connectionStatus == ConnectionStatus.CONNECTED
@@ -687,6 +690,57 @@ class ChatViewModel(
         method: String,
         params: Map<String, Any>,
     ): Any? = HermesWsClient.request(method, params).await()
+
+    // ── In-chat model controls (issue #529) ───────────────────────────────
+
+    /**
+     * Fire `config.set` with the current session id. Fire-and-forget: the
+     * backend applies it to the running session; we do not block the UI on the
+     * RPC result. Mirrors desktop model-presets.ts setModelConfig().
+     *
+     * [key] is one of "reasoning" / "fast" (server also supports "model").
+     * [value] is the effort string (minimal..max) for "reasoning", or
+     * "fast"/"normal" for "fast".
+     */
+    fun setConfig(
+        key: String,
+        value: String,
+    ): Boolean {
+        val sessionId = _uiState.value.currentSessionId ?: return false
+        if (sessionId.isBlank()) return false
+
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                HermesWsClient.request(
+                    WsMethods.CONFIG_SET,
+                    mapOf(
+                        "key" to key,
+                        "session_id" to sessionId,
+                        "value" to value,
+                    ),
+                ).await()
+            } catch (e: Exception) {
+                Log.w(TAG, "config.set($key=$value) failed for session $sessionId", e)
+            }
+        }
+        return true
+    }
+
+    /** Set the per-session reasoning effort (minimal/low/medium/high/xhigh/max). */
+    fun setReasoningEffort(effort: String) {
+        if (effort == _uiState.value.reasoningEffort) return
+        // Only flip the chip when a session exists — otherwise config.set is a no-op.
+        if (!setConfig("reasoning", effort)) return
+        _uiState.update { it.copy(reasoningEffort = effort) }
+    }
+
+    /** Toggle per-session fast mode on/off. */
+    fun toggleFastMode() {
+        val next = !_uiState.value.fastMode
+        // Only flip the chip when a session exists — otherwise config.set is a no-op.
+        if (!setConfig("fast", if (next) "fast" else "normal")) return
+        _uiState.update { it.copy(fastMode = next) }
+    }
 
     // ── Attachment management ─────────────────────────────────────────────
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -76,6 +76,11 @@ data class ChatUiState(
     // In-chat model controls (issue #529) — fire config.set with session_id
     val reasoningEffort: String = "medium",
     val fastMode: Boolean = false,
+    // Live model reported by the gateway via `session.info`. Used to decide
+    // fast-mode eligibility on-device (the server never pushes a capability
+    // flag). Defaults to true so the Fast chip is usable until we know better.
+    val model: String = "",
+    val fastSupported: Boolean = true,
 ) {
     /** Convenience — derived from [connectionStatus]. */
     val isConnected: Boolean get() = connectionStatus == ConnectionStatus.CONNECTED
@@ -115,13 +120,22 @@ class ChatViewModel(
 ) : AndroidViewModel(application) {
     constructor(application: Application) : this(application, startCleanup = true)
 
-    // ── Internal state ───────────────────────────────────────────────────
-    private val _uiState = MutableStateFlow(ChatUiState())
-
     private val _streamingState = MutableStateFlow(StreamingState())
     val streamingState: StateFlow<StreamingState> = _streamingState.asStateFlow()
 
     private val wsClient = HermesWsClient
+
+    private val modelPrefsStore = AuthManager.modelPrefsStore
+
+    // ── Internal state ───────────────────────────────────────────────────
+    private val _uiState =
+        MutableStateFlow(
+            ChatUiState(
+                // Persist the user's last reasoning effort across cold starts
+                // (issue #529 follow-up) instead of always defaulting to "medium".
+                reasoningEffort = modelPrefsStore.getLatestState().lastReasoningEffort,
+            ),
+        )
 
     private val slashDispatcher = SlashCommandDispatcher()
     private val searchDelegate =
@@ -139,8 +153,6 @@ class ChatViewModel(
             isCurrentSession = { sessionId -> isCurrentSession(sessionId) },
             isTestEnvironment = { isTestEnvironment() },
         )
-
-    // ── Public state ─────────────────────────────────────────────────────
 
     /**
      * Combined UI state: merges internal state with the WS connection status
@@ -404,6 +416,14 @@ class ChatViewModel(
                         isLoading = false,
                         messages = emptyList(),
                         chatTitle = "Hermes",
+                        // Reset in-chat model controls for the new session.
+                        // `model`/`fastSupported` will be refreshed by the
+                        // upcoming `session.info` event; until then, treat Fast
+                        // as supported so the chip isn't spuriously disabled.
+                        reasoningEffort = "medium",
+                        fastMode = false,
+                        model = "",
+                        fastSupported = true,
                     )
                 }
                 _streamingState.update { StreamingState() }
@@ -732,10 +752,13 @@ class ChatViewModel(
         // Only flip the chip when a session exists — otherwise config.set is a no-op.
         if (!setConfig("reasoning", effort)) return
         _uiState.update { it.copy(reasoningEffort = effort) }
+        // Remember the pick so the composer doesn't reset to "medium" on next launch.
+        modelPrefsStore.update { it.copy(lastReasoningEffort = effort) }
     }
 
-    /** Toggle per-session fast mode on/off. */
+    /** Toggle per-session fast mode on/off. No-op when the model doesn't support it. */
     fun toggleFastMode() {
+        if (!_uiState.value.fastSupported) return
         val next = !_uiState.value.fastMode
         // Only flip the chip when a session exists — otherwise config.set is a no-op.
         if (!setConfig("fast", if (next) "fast" else "normal")) return

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatWsEventReducer.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatWsEventReducer.kt
@@ -1,6 +1,7 @@
 package com.m57.hermescontrol.ui.chat
 
 import com.m57.hermescontrol.data.remote.OkHttpProvider
+import com.m57.hermescontrol.data.ws.ModelCapabilities
 import com.m57.hermescontrol.data.ws.WsEvent
 import com.m57.hermescontrol.data.ws.toJsonElement
 import kotlinx.serialization.encodeToString
@@ -77,8 +78,11 @@ object ChatWsEventReducer {
 
             is WsEvent.Unknown -> onUnknown(state, streamingState)
 
-            // SessionInfo is a no-op in the original code
-            is WsEvent.SessionInfo -> ReducerResult(state = state, streamingState = streamingState)
+            // SessionInfo carries the live model + fast/reasoning state. We
+            // only consume `model` here to drive fast-mode eligibility (the
+            // backend never pushes a capability flag, so the UI mirrors the
+            // server predicate on-device — see ModelCapabilities).
+            is WsEvent.SessionInfo -> onSessionInfo(state, streamingState, event)
 
             // RpcResult is handled by the ViewModel (needs pending request context)
             is WsEvent.RpcResult -> ReducerResult(state = state, streamingState = streamingState)
@@ -378,6 +382,28 @@ object ChatWsEventReducer {
                 ),
             streamingState = streamingState,
         )
+
+    // ── SessionInfo ──────────────────────────────────────────────────
+    // The gateway emits `session.info` on session create/resume and on every
+    // fast toggle. It carries `model` — enough for us to decide fast-mode
+    // eligibility on-device and grey out the Fast chip for unsupported models.
+    private fun onSessionInfo(
+        state: ChatUiState,
+        streamingState: StreamingState,
+        event: WsEvent.SessionInfo,
+    ): ReducerResult {
+        val data = event.data ?: return ReducerResult(state = state, streamingState = streamingState)
+        val model = (data["model"] as? String)?.takeIf { it.isNotBlank() }
+        if (model == null) return ReducerResult(state = state, streamingState = streamingState)
+        val fastSupported = ModelCapabilities.supportsFastMode(model)
+        if (state.model == model && state.fastSupported == fastSupported) {
+            return ReducerResult(state = state, streamingState = streamingState)
+        }
+        return ReducerResult(
+            state = state.copy(model = model, fastSupported = fastSupported),
+            streamingState = streamingState,
+        )
+    }
 
     // ── SessionUpdated / StatusUpdate / Unknown ───────────────────────
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,6 +130,10 @@
     <string name="chat_attachment_file">%1$s</string>
     <string name="chat_attachment_send_error">Failed to process attachment</string>
 
+    <!-- In-chat model controls (issue #529) -->
+    <string name="chat_model_controls_label">Model</string>
+    <string name="chat_fast_mode_label">Fast</string>
+
     <!-- Camera -->
     <string name="chat_camera_desc">Camera</string>
     <string name="chat_camera_error">Failed to capture photo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,7 +131,7 @@
     <string name="chat_attachment_send_error">Failed to process attachment</string>
 
     <!-- In-chat model controls (issue #529) -->
-    <string name="chat_model_controls_label">Model</string>
+    <string name="chat_reasoning_controls_label">Reasoning</string>
     <string name="chat_fast_mode_label">Fast</string>
 
     <!-- Camera -->

--- a/app/src/test/java/com/m57/hermescontrol/data/ws/ModelCapabilitiesTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/ws/ModelCapabilitiesTest.kt
@@ -1,0 +1,50 @@
+package com.m57.hermescontrol.data.ws
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * On-device mirror of `hermes_cli.models.model_supports_fast_mode`.
+ * Keep these expectations in lock-step with the backend predicate.
+ */
+class ModelCapabilitiesTest {
+    @Test
+    fun `openai flagships support fast`() {
+        assertTrue(ModelCapabilities.supportsFastMode("gpt-4o"))
+        assertTrue(ModelCapabilities.supportsFastMode("gpt-5"))
+        assertTrue(ModelCapabilities.supportsFastMode("gpt-5.1-mini"))
+        assertTrue(ModelCapabilities.supportsFastMode("o3"))
+        assertTrue(ModelCapabilities.supportsFastMode("o4-mini"))
+        assertTrue(ModelCapabilities.supportsFastMode("o1"))
+    }
+
+    @Test
+    fun `openai codex models do NOT support fast`() {
+        assertFalse(ModelCapabilities.supportsFastMode("gpt-5-codex"))
+        assertFalse(ModelCapabilities.supportsFastMode("o4-codex"))
+    }
+
+    @Test
+    fun `anthropic opus-4-6 supports fast`() {
+        assertTrue(ModelCapabilities.supportsFastMode("claude-opus-4-6"))
+        assertTrue(ModelCapabilities.supportsFastMode("anthropic/claude-opus-4.6"))
+        assertTrue(ModelCapabilities.supportsFastMode("claude-opus-4-6-202509" ))
+    }
+
+    @Test
+    fun `other anthropic models do NOT support fast`() {
+        assertFalse(ModelCapabilities.supportsFastMode("claude-opus-4-7"))
+        assertFalse(ModelCapabilities.supportsFastMode("claude-sonnet-4-6"))
+        assertFalse(ModelCapabilities.supportsFastMode("claude-haiku-4-5"))
+    }
+
+    @Test
+    fun `vendor prefixed and unknown models handled`() {
+        assertFalse(ModelCapabilities.supportsFastMode("openrouter/gpt-4o"))
+        assertFalse(ModelCapabilities.supportsFastMode("gemini-2.5-pro"))
+        assertFalse(ModelCapabilities.supportsFastMode("deepseek/deepseek-reasoner"))
+        assertFalse(ModelCapabilities.supportsFastMode(null))
+        assertFalse(ModelCapabilities.supportsFastMode(""))
+    }
+}

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -19,6 +19,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -1369,5 +1370,111 @@ class ChatViewModelTest {
 
             assertNull(viewModel.uiState.value.errorMessage)
             verify { HermesWsClient.disconnect() }
+        }
+
+    // ── Issue #529: in-chat config.set controls ─────────────────────────────
+
+    /**
+     * setReasoningEffort must fire config.set with key="reasoning",
+     * session_id=<current session>, value=<effort>, AND update UI state.
+     */
+    @Test
+    fun testSetReasoningEffort_firesConfigSetWithSessionId() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+
+            // Stub config.set to return a completed deferred so await() resolves.
+            every {
+                HermesWsClient.request(WsMethods.CONFIG_SET, any())
+            } answers { CompletableDeferred<Any?>(Unit) }
+
+            assertEquals("medium", viewModel.uiState.value.reasoningEffort)
+
+            viewModel.setReasoningEffort("high")
+            advanceUntilIdle()
+
+            // UI reflects the new effort immediately.
+            assertEquals("high", viewModel.uiState.value.reasoningEffort)
+            // RPC carries the right key / session_id / value.
+            verify {
+                HermesWsClient.request(
+                    WsMethods.CONFIG_SET,
+                    mapOf(
+                        "key" to "reasoning",
+                        "session_id" to sessionId,
+                        "value" to "high",
+                    ),
+                )
+            }
+        }
+
+    /**
+     * toggleFastMode flips fastMode and fires config.set with key="fast",
+     * value="fast" on, "normal" off.
+     */
+    @Test
+    fun testToggleFastMode_firesConfigSetFast() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+
+            every {
+                HermesWsClient.request(WsMethods.CONFIG_SET, any())
+            } answers { CompletableDeferred<Any?>(Unit) }
+
+            assertFalse(viewModel.uiState.value.fastMode)
+
+            viewModel.toggleFastMode()
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.fastMode)
+            verify {
+                HermesWsClient.request(
+                    WsMethods.CONFIG_SET,
+                    mapOf(
+                        "key" to "fast",
+                        "session_id" to sessionId,
+                        "value" to "fast",
+                    ),
+                )
+            }
+
+            viewModel.toggleFastMode()
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.fastMode)
+            verify {
+                HermesWsClient.request(
+                    WsMethods.CONFIG_SET,
+                    mapOf(
+                        "key" to "fast",
+                        "session_id" to sessionId,
+                        "value" to "normal",
+                    ),
+                )
+            }
+        }
+
+    /**
+     * setConfig must be a no-op (no RPC) when there is no active session.
+     */
+    @Test
+    fun testSetConfig_noSession_doesNotFire() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+            mockConnectionStatus.value = ConnectionStatus.CONNECTED
+            mockEventsFlow.emit(WsEvent.GatewayReady(null))
+            advanceUntilIdle()
+            // No SESSION_CREATE result emitted → currentSessionId stays null.
+
+            every {
+                HermesWsClient.request(WsMethods.CONFIG_SET, any())
+            } answers { CompletableDeferred<Any?>(Unit) }
+
+            viewModel.setReasoningEffort("xhigh")
+            advanceUntilIdle()
+
+            assertEquals("medium", viewModel.uiState.value.reasoningEffort)
+            verify(inverse = true) {
+                HermesWsClient.request(WsMethods.CONFIG_SET, any())
+            }
         }
 }

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -6,6 +6,9 @@ import android.net.Uri
 import android.util.Log
 import com.m57.hermescontrol.data.local.AuthManager
 import com.m57.hermescontrol.data.local.HermesDatabase
+import com.m57.hermescontrol.data.config.ModelPrefsSerializer
+import com.m57.hermescontrol.data.config.ModelPrefsState
+import com.m57.hermescontrol.data.config.ModelPrefsStore
 import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.ws.ConnectionStatus
 import com.m57.hermescontrol.data.ws.HermesWsClient
@@ -46,6 +49,7 @@ class ChatViewModelTest {
     private val mockConnectionStatus = MutableStateFlow(ConnectionStatus.DISCONNECTED)
     private lateinit var app: Application
     private lateinit var fakeRepo: FakeChatPersistenceRepository
+    private lateinit var modelPrefsStore: ModelPrefsStore
 
     /** Counter used to generate unique WS request IDs. */
     private var reqCount = 0
@@ -70,6 +74,18 @@ class ChatViewModelTest {
         mockkObject(HermesWsClient)
         mockkObject(ApiClient)
         mockkObject(HermesDatabase)
+
+        // In-memory ModelPrefsStore so we can assert persistence of reasoning effort.
+        val tmpFile =
+            java.io.File
+                .createTempFile("model_prefs_test", ".json")
+                .also { it.deleteOnExit() }
+        val ds =
+            androidx.datastore.core.DataStoreFactory.create(
+                serializer = ModelPrefsSerializer,
+            ) { tmpFile }
+        modelPrefsStore = ModelPrefsStore(ds, kotlinx.coroutines.CoroutineScope(testDispatcher))
+        every { AuthManager.modelPrefsStore } returns modelPrefsStore
 
         app = mockk(relaxed = true)
         fakeRepo = FakeChatPersistenceRepository()
@@ -1473,6 +1489,92 @@ class ChatViewModelTest {
             advanceUntilIdle()
 
             assertEquals("medium", viewModel.uiState.value.reasoningEffort)
+            verify(inverse = true) {
+                HermesWsClient.request(WsMethods.CONFIG_SET, any())
+            }
+        }
+
+    // ── Issue #529 follow-up: persist reasoning effort across cold starts ──
+
+    @Test
+    fun testReasoningEffort_seededFromPersistedPref() =
+        runTest {
+            // Pre-seed the store with a non-default effort.
+            modelPrefsStore.update { ModelPrefsState(lastReasoningEffort = "xhigh") }
+            advanceUntilIdle()
+
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            assertEquals("xhigh", viewModel.uiState.value.reasoningEffort)
+        }
+
+    @Test
+    fun testSetReasoningEffort_persistsChoice() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+
+            every {
+                HermesWsClient.request(WsMethods.CONFIG_SET, any())
+            } answers { CompletableDeferred<Any?>(Unit) }
+
+            viewModel.setReasoningEffort("high")
+            advanceUntilIdle()
+
+            // UI + persisted store both reflect the new effort.
+            assertEquals("high", viewModel.uiState.value.reasoningEffort)
+            assertEquals("high", modelPrefsStore.getLatestState().lastReasoningEffort)
+        }
+
+    // ── Issue #529 follow-up: grey-out / disable Fast for unsupported models ─
+
+    @Test
+    fun testSessionInfo_consumesModelAndFastSupport() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            // A model the gateway says does NOT support fast mode.
+            mockEventsFlow.emit(
+                WsEvent.SessionInfo(mapOf("model" to "claude-haiku-4-5")),
+            )
+            advanceUntilIdle()
+
+            assertEquals("claude-haiku-4-5", viewModel.uiState.value.model)
+            assertEquals(false, viewModel.uiState.value.fastSupported)
+
+            // A model that DOES support fast mode.
+            mockEventsFlow.emit(
+                WsEvent.SessionInfo(mapOf("model" to "gpt-5")),
+            )
+            advanceUntilIdle()
+
+            assertEquals("gpt-5", viewModel.uiState.value.model)
+            assertEquals(true, viewModel.uiState.value.fastSupported)
+        }
+
+    @Test
+    fun testToggleFastMode_noOpWhenUnsupported() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            // Report an unsupported model via session.info.
+            mockEventsFlow.emit(
+                WsEvent.SessionInfo(mapOf("model" to "gemini-2.5-pro")),
+            )
+            advanceUntilIdle()
+            assertEquals(false, viewModel.uiState.value.fastSupported)
+
+            every {
+                HermesWsClient.request(WsMethods.CONFIG_SET, any())
+            } answers { CompletableDeferred<Any?>(Unit) }
+
+            // Tap Fast — must be a no-op (no RPC, no UI flip).
+            viewModel.toggleFastMode()
+            advanceUntilIdle()
+
+            assertEquals(false, viewModel.uiState.value.fastMode)
             verify(inverse = true) {
                 HermesWsClient.request(WsMethods.CONFIG_SET, any())
             }


### PR DESCRIPTION
## Summary

Implements issue #529 — expose per-session reasoning-effort + fast-mode controls directly in the chat composer, firing the outbound `config.set` RPC over the existing WebSocket.

### Changes
- **`WsMethods.kt`**: added `CONFIG_SET = "config.set"` RPC constant.
- **`ChatViewModel.kt`**: `setConfig(key, value): Boolean` fires `config.set` with the current `session_id` (fire-and-forget, mirrors desktop `model-presets.ts`). Public `setReasoningEffort(effort)` + `toggleFastMode()` flip the UI chip only when a session exists (no-op otherwise).
- **`ChatScreen.kt`**: `ChatInputBar` gains a horizontally-scrollable chip row above the composer — 6 reasoning-effort `FilterChip`s (minimal/low/medium/high/xhigh/max, default medium) + a Fast `FilterChip` (bolt icon). No dialog, consistent with desktop composer.
- **`strings.xml`**: `chat_model_controls_label`, `chat_fast_mode_label`.
- **`ChatViewModelTest.kt`**: 3 tests — effort fires config.set w/ correct params, fast toggle on/off, no-session no-op.

### RPC contract (verified against server `tui_gateway/server.py`)
`{"method":"config.set","params":{"key":"reasoning"|"fast","session_id":"<id>","value":"<effort>"|"fast"/"normal"}}`

### Notes
- Fire-and-forget: failures are logged (Log.w) and do not surface a UI dialog.
- Chips are optimistic but guarded — they only flip when a live session exists.

### Status
Ready for review — ktlint + lint + unit + instrumented + build + release-compile all green; RPC contract verified against tui_gateway/server.py config.set (reasoning + fast keys).

Closes #529