### PR TITLE
feat(#530): server-backed session search (FTS5)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/model/SessionListResponse.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/SessionListResponse.kt
@@ -21,6 +21,7 @@ data class SessionInfo(
     val source: String? = null,
     val parent_session_id: String? = null,
     val display_name: String? = null,
+    val model: String? = null,
 )
 
 @Serializable

--- a/app/src/main/java/com/m57/hermescontrol/data/model/SessionSearchModels.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/SessionSearchModels.kt
@@ -1,0 +1,18 @@
+package com.m57.hermescontrol.data.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SessionSearchResponse(
+    val results: List<SessionSearchResult> = emptyList(),
+)
+
+@Serializable
+data class SessionSearchResult(
+    val session_id: String,
+    val snippet: String? = null,
+    val role: String? = null,
+    val source: String? = null,
+    val model: String? = null,
+    val session_started: Double? = null,
+)

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -67,6 +67,7 @@ import com.m57.hermescontrol.data.model.RecentUnlock
 import com.m57.hermescontrol.data.model.SaveSkillContentRequest
 import com.m57.hermescontrol.data.model.ScanStatus
 import com.m57.hermescontrol.data.model.SessionListResponse
+import com.m57.hermescontrol.data.model.SessionSearchResponse
 import com.m57.hermescontrol.data.model.SessionMessagesResponse
 import com.m57.hermescontrol.data.model.SessionPromptResponse
 import com.m57.hermescontrol.data.model.SessionRenameRequest
@@ -131,6 +132,12 @@ interface HermesApiService {
         @Query("offset") offset: Int = 0,
         @Query("order") order: String = "recent",
     ): Response<SessionListResponse>
+
+    @GET("api/sessions/search")
+    suspend fun searchSessions(
+        @Query("q") q: String,
+        @Query("profile") profile: String? = null,
+    ): Response<SessionSearchResponse>
 
     @GET("api/sessions/{id}/messages")
     suspend fun getSessionMessages(

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -67,10 +67,10 @@ import com.m57.hermescontrol.data.model.RecentUnlock
 import com.m57.hermescontrol.data.model.SaveSkillContentRequest
 import com.m57.hermescontrol.data.model.ScanStatus
 import com.m57.hermescontrol.data.model.SessionListResponse
-import com.m57.hermescontrol.data.model.SessionSearchResponse
 import com.m57.hermescontrol.data.model.SessionMessagesResponse
 import com.m57.hermescontrol.data.model.SessionPromptResponse
 import com.m57.hermescontrol.data.model.SessionRenameRequest
+import com.m57.hermescontrol.data.model.SessionSearchResponse
 import com.m57.hermescontrol.data.model.SessionStatsResponse
 import com.m57.hermescontrol.data.model.SetActiveProfileRequest
 import com.m57.hermescontrol.data.model.Skill

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.m57.hermescontrol.ChatScreen
@@ -93,6 +94,11 @@ import com.m57.hermescontrol.ui.common.StatusBadgeType
 import com.m57.hermescontrol.ui.common.ToastEffect
 import com.m57.hermescontrol.ui.common.listContentPadding
 import com.m57.hermescontrol.ui.common.listItemSpacing
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import kotlin.math.abs
 
 /**
  * Maps a session source string to a Material icon for visual identification.
@@ -157,17 +163,50 @@ private fun highlightText(
         }
     }
 
-/** Maps a backend FTS5 search hit into the card's display model. */
+/**
+ * Converts a backend search hit into a display model WITHOUT faking a title.
+ * The backend returns no session name, only a matched `snippet` + metadata, so the
+ * card must render the snippet as a match excerpt (never as the title). `title` is
+ * deliberately left null so [SearchResultCard] shows the honest "Match" layout.
+ */
 private fun SessionSearchResult.toSessionInfo(): SessionInfo =
     SessionInfo(
         id = session_id,
-        // Backend returns the matched excerpt in `snippet`; SessionCard
-        // renders `title` (and highlights it), so map snippet → title.
-        title = snippet,
+        title = null,
         preview = snippet,
         source = source,
+        model = model,
         started_at = session_started,
+        // message_count/status aren't in the search payload; leave null so the
+        // search card hides those normal-list affordances.
     )
+
+/**
+ * Formats a backend epoch-seconds timestamp into a friendly, local relative/absolute
+ * string. Used for search results where the session name is unknown.
+ */
+private fun formatPlayedAt(epochSeconds: Double?): String? {
+    if (epochSeconds == null || epochSeconds <= 0.0) return null
+    val instant =
+        try {
+            Instant.ofEpochSecond(epochSeconds.toLong())
+        } catch (_: Exception) {
+            return null
+        }
+    val now = Instant.now()
+    val diffSec = abs(now.epochSecond - instant.epochSecond)
+    val absFormatter =
+        DateTimeFormatter
+            .ofLocalizedDateTime(FormatStyle.MEDIUM)
+            .withZone(ZoneId.systemDefault())
+    return when {
+        diffSec < 60 -> "just now"
+        diffSec < 3600 -> "${diffSec / 60}m ago"
+        diffSec < 86400 -> "${diffSec / 3600}h ago"
+        diffSec < 7 * 86400 -> "${diffSec / 86400}d ago"
+        else -> absFormatter.format(instant)
+    }
+}
 
 /**
  * Builds the list of sessions to display. In search mode the backend results are
@@ -402,37 +441,60 @@ fun SessionsScreen(
                                     )
                                 }
                                 else -> {
-                                    LazyColumn(
-                                        modifier = Modifier.fillMaxSize(),
-                                        contentPadding = listContentPadding,
-                                        verticalArrangement = listItemSpacing,
-                                    ) {
-                                        items(sessionsToDisplay, key = { it.id }) { session ->
-                                            SessionCard(
-                                                session = session,
-                                                query = state.searchQuery,
-                                                isSelecting = state.isSelecting,
-                                                isSelected = session.id in state.selectedIds,
-                                                isDeleting = session.id in state.deletingSessionIds,
-                                                highlightBackground = primaryContainer,
-                                                highlightForeground = onPrimaryContainer,
-                                                onCardClick = {
-                                                    if (state.isSelecting) {
-                                                        viewModel.toggleSessionSelection(session.id)
-                                                    } else {
-                                                        NavigationController.pendingSessionId = session.id
-                                                        NavigationController.navigateTo(ChatScreen)
-                                                    }
-                                                },
-                                                onCardLongClick = {
-                                                    if (!state.isSelecting) {
-                                                        viewModel.toggleSelecting()
-                                                        viewModel.toggleSessionSelection(session.id)
-                                                    }
-                                                },
-                                                onToggleSelection = { viewModel.toggleSessionSelection(session.id) },
-                                                onDelete = { viewModel.requestDeleteSession(session.id) },
-                                            )
+                                    Column(modifier = Modifier.fillMaxSize()) {
+                                        Text(
+                                            text =
+                                                stringResource(
+                                                    R.string.sessions_search_results_header,
+                                                    state.searchResults.size,
+                                                    state.searchQuery,
+                                                ),
+                                            style = MaterialTheme.typography.labelMedium,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier =
+                                                Modifier
+                                                    .fillMaxWidth()
+                                                    .padding(
+                                                        horizontal = spacing.md,
+                                                        vertical = spacing.sm,
+                                                    ),
+                                        )
+                                        LazyColumn(
+                                            modifier = Modifier.fillMaxSize(),
+                                            contentPadding = listContentPadding,
+                                            verticalArrangement = listItemSpacing,
+                                        ) {
+                                            items(sessionsToDisplay, key = { it.id }) { session ->
+                                                SearchResultCard(
+                                                    session = session,
+                                                    query = state.searchQuery,
+                                                    isSelecting = state.isSelecting,
+                                                    isSelected = session.id in state.selectedIds,
+                                                    isDeleting = session.id in state.deletingSessionIds,
+                                                    highlightBackground = primaryContainer,
+                                                    highlightForeground = onPrimaryContainer,
+                                                    onCardClick = {
+                                                        if (state.isSelecting) {
+                                                            viewModel.toggleSessionSelection(session.id)
+                                                        } else {
+                                                            NavigationController.pendingSessionId = session.id
+                                                            NavigationController.navigateTo(ChatScreen)
+                                                        }
+                                                    },
+                                                    onCardLongClick = {
+                                                        if (!state.isSelecting) {
+                                                            viewModel.toggleSelecting()
+                                                            viewModel.toggleSessionSelection(session.id)
+                                                        }
+                                                    },
+                                                    onToggleSelection = {
+                                                        viewModel.toggleSessionSelection(
+                                                            session.id,
+                                                        )
+                                                    },
+                                                    onDelete = { viewModel.requestDeleteSession(session.id) },
+                                                )
+                                            }
                                         }
                                     }
                                 }
@@ -795,6 +857,172 @@ private fun SessionCard(
             if (!isSelecting) {
                 Row(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
                     // Delete
+                    if (isDeleting) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        IconButton(
+                            onClick = onDelete,
+                            modifier = Modifier.size(32.dp),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Delete,
+                                contentDescription = stringResource(R.string.action_delete),
+                                modifier = Modifier.size(16.dp),
+                                tint = statusColors.error,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Search-result card. The backend search payload has no session title, so this card is
+ * honest about it: it shows a "Match" label + the highlighted snippet as the body, plus
+ * source / model / played-at metadata chips. It never presents the snippet as a name.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun SearchResultCard(
+    session: com.m57.hermescontrol.data.model.SessionInfo,
+    query: String,
+    isSelecting: Boolean,
+    isSelected: Boolean,
+    isDeleting: Boolean,
+    highlightBackground: Color,
+    highlightForeground: Color,
+    onCardClick: () -> Unit,
+    onCardLongClick: () -> Unit,
+    onToggleSelection: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val spacing = LocalSpacing.current
+    val statusColors = LocalHermesStatusColors.current
+    val snippet = session.preview?.takeIf { it.isNotBlank() } ?: stringResource(R.string.history_untitled)
+    val playedAt = formatPlayedAt(session.started_at)
+
+    Card(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .testTag("session_card_${session.id}")
+                .combinedClickable(
+                    onClick = onCardClick,
+                    onLongClick = onCardLongClick,
+                ),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainer,
+            ),
+        border =
+            if (isSelected) {
+                BorderStroke(2.dp, MaterialTheme.colorScheme.primary)
+            } else {
+                null
+            },
+    ) {
+        Row(
+            modifier = Modifier.padding(spacing.md),
+            verticalAlignment = Alignment.Top,
+        ) {
+            // Checkbox in select mode
+            if (isSelecting) {
+                Checkbox(
+                    checked = isSelected,
+                    onCheckedChange = { onToggleSelection() },
+                    modifier = Modifier.testTag("session_checkbox_${session.id}"),
+                )
+                Spacer(modifier = Modifier.width(spacing.sm))
+            }
+
+            Column(modifier = Modifier.weight(1f)) {
+                // Header row: "Match" label + source icon
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                ) {
+                    val srcIcon = sourceIcon(session.source)
+                    if (srcIcon != null && !isSelecting) {
+                        Icon(
+                            imageVector = srcIcon,
+                            contentDescription = sourceLabel(session.source),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(16.dp),
+                        )
+                    }
+                    Text(
+                        text = stringResource(R.string.sessions_search_match_label),
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary,
+                        letterSpacing = 0.5.sp,
+                    )
+                    if (!session.id.isNullOrBlank()) {
+                        Text(
+                            text = "· ${session.id.take(8)}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(spacing.xs))
+
+                // The matched snippet, highlighted — shown as the body, NOT as a title.
+                Text(
+                    text = highlightText(snippet, query, highlightBackground, highlightForeground),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 4,
+                    overflow = TextOverflow.Ellipsis,
+                )
+
+                Spacer(modifier = Modifier.height(spacing.sm))
+
+                // Metadata chips row
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                ) {
+                    session.source?.let { src ->
+                        StatusBadge(
+                            text = sourceLabel(src),
+                            status = StatusBadgeType.NEUTRAL,
+                        )
+                    }
+                    session.model?.let { mdl ->
+                        StatusBadge(
+                            text = stringResource(R.string.sessions_search_model_label) + ": " + mdl,
+                            status = StatusBadgeType.INFO,
+                        )
+                    }
+                    playedAt?.let { time ->
+                        StatusBadge(
+                            text = stringResource(R.string.sessions_search_played_at, time),
+                            status = StatusBadgeType.NEUTRAL,
+                        )
+                    }
+                }
+
+                // Tap hint when not selecting
+                if (!isSelecting) {
+                    Spacer(modifier = Modifier.height(spacing.xs))
+                    Text(
+                        text = stringResource(R.string.sessions_search_open_hint),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+
+            // Action buttons (not in select mode)
+            if (!isSelecting) {
+                Row(horizontalArrangement = Arrangement.spacedBy(spacing.xs)) {
                     if (isDeleting) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(16.dp),

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
@@ -12,6 +12,9 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -94,7 +97,6 @@ import com.m57.hermescontrol.ui.common.StatCard
 import com.m57.hermescontrol.ui.common.StatusBadge
 import com.m57.hermescontrol.ui.common.StatusBadgeType
 import com.m57.hermescontrol.ui.common.ToastEffect
-import com.m57.hermescontrol.ui.common.listContentPadding
 import com.m57.hermescontrol.ui.common.listItemSpacing
 import java.time.Instant
 import java.time.ZoneId
@@ -218,7 +220,8 @@ private fun displayedSessions(state: SessionsUiState): List<SessionTreeItem> =
                 session = session,
                 depth = 0,
                 branchStem = null,
-                displayTitle = session.title?.takeIf(String::isNotBlank)
+                displayTitle =
+                    session.title?.takeIf(String::isNotBlank)
                     ?: session.display_name?.takeIf(String::isNotBlank)
                     ?: session.preview?.takeIf(String::isNotBlank)?.take(80)
                     ?: "Untitled",
@@ -254,6 +257,18 @@ fun SessionsScreen(
         }
 
     val hasSelection = state.selectedIds.isNotEmpty()
+    val visibleSessionIds =
+        remember(sessionsToDisplay) {
+            sessionsToDisplay.mapTo(linkedSetOf()) { it.session.id }
+        }
+    val allVisibleSessionsSelected =
+        visibleSessionIds.isNotEmpty() && visibleSessionIds.all { it in state.selectedIds }
+    val listPadding =
+        PaddingValues(
+            horizontal = 12.dp,
+            vertical = 8.dp,
+            bottom = if (hasSelection) 72.dp else 8.dp,
+        )
 
     LaunchedEffect(Unit) {
         viewModel.loadSessions()
@@ -321,7 +336,14 @@ fun SessionsScreen(
             state.sessions
                 .find { it.id == sessionToDelete }
                 ?.title
-                ?.takeIf { it.isNotBlank() } ?: stringResource(R.string.history_untitled)
+                ?.takeIf { it.isNotBlank() }
+                ?: state.searchResults
+                    .find { it.session_id == sessionToDelete }
+                    ?.snippet
+                    ?.replace(">>>", "")
+                    ?.replace("<<<", "")
+                    ?.take(80)
+                ?: stringResource(R.string.history_untitled)
         AlertDialog(
             onDismissRequest = { viewModel.cancelDeleteSession() },
             title = { Text(stringResource(R.string.sessions_delete_title)) },
@@ -467,7 +489,7 @@ fun SessionsScreen(
                                         )
                                         LazyColumn(
                                             modifier = Modifier.fillMaxSize(),
-                                            contentPadding = listContentPadding,
+                                            contentPadding = listPadding,
                                             verticalArrangement = listItemSpacing,
                                         ) {
                                             items(sessionsToDisplay, key = { it.session.id }) { item ->
@@ -596,7 +618,7 @@ fun SessionsScreen(
                             // ── Session list ────────────────────────────────────
                             LazyColumn(
                                 modifier = Modifier.fillMaxSize(),
-                                contentPadding = listContentPadding,
+                                contentPadding = listPadding,
                                 verticalArrangement = listItemSpacing,
                             ) {
                                 items(sessionsToDisplay, key = { it.session.id }) { item ->
@@ -697,16 +719,16 @@ fun SessionsScreen(
                         // Select all / deselect
                         OutlinedButton(
                             onClick = {
-                                if (state.selectedIds.size == state.sessions.size) {
+                                if (allVisibleSessionsSelected) {
                                     viewModel.clearSelection()
                                 } else {
-                                    viewModel.selectAll()
+                                    viewModel.selectAll(visibleSessionIds)
                                 }
                             },
                         ) {
                             Icon(
                                 imageVector =
-                                    if (state.selectedIds.size == state.sessions.size) {
+                                    if (allVisibleSessionsSelected) {
                                         Icons.Filled.Close
                                     } else {
                                         Icons.Filled.SelectAll
@@ -716,7 +738,7 @@ fun SessionsScreen(
                             )
                             Spacer(modifier = Modifier.width(spacing.xs))
                             Text(
-                                if (state.selectedIds.size == state.sessions.size) {
+                                if (allVisibleSessionsSelected) {
                                     stringResource(R.string.sessions_action_deselect_all)
                                 } else {
                                     stringResource(R.string.sessions_action_select_all)
@@ -910,7 +932,7 @@ private fun SessionCard(
  * honest about it: it shows a "Match" label + the highlighted snippet as the body, plus
  * source / model / played-at metadata chips. It never presents the snippet as a name.
  */
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalLayoutApi::class)
 @Composable
 private fun SearchResultCard(
     session: com.m57.hermescontrol.data.model.SessionInfo,
@@ -1013,9 +1035,9 @@ private fun SearchResultCard(
                 Spacer(modifier = Modifier.height(spacing.xs))
 
                 // Metadata chips row
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
+                FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                    verticalArrangement = Arrangement.spacedBy(spacing.xs),
                 ) {
                     session.source?.let { src ->
                         StatusBadge(

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
@@ -161,7 +161,9 @@ private fun highlightText(
 private fun SessionSearchResult.toSessionInfo(): SessionInfo =
     SessionInfo(
         id = session_id,
-        title = null,
+        // Backend returns the matched excerpt in `snippet`; SessionCard
+        // renders `title` (and highlights it), so map snippet → title.
+        title = snippet,
         preview = snippet,
         source = source,
         started_at = session_started,

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.Terminal
@@ -77,6 +78,8 @@ import com.m57.hermescontrol.ChatScreen
 import com.m57.hermescontrol.NavigationController
 import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.SessionInfo
+import com.m57.hermescontrol.data.model.SessionSearchResult
+import com.m57.hermescontrol.data.model.SessionTreeItem
 import com.m57.hermescontrol.data.model.flattenSessionTree
 import com.m57.hermescontrol.theme.LocalHermesStatusColors
 import com.m57.hermescontrol.theme.LocalSpacing
@@ -156,6 +159,34 @@ private fun highlightText(
         }
     }
 
+/** Maps a backend FTS5 search hit into the card's display model. */
+private fun SessionSearchResult.toSessionInfo(): SessionInfo =
+    SessionInfo(
+        id = session_id,
+        title = null,
+        preview = snippet,
+        source = source,
+        started_at = session_started,
+    )
+
+private fun displayedSessions(state: SessionsUiState): List<SessionTreeItem> =
+    if (state.isSearchMode) {
+        state.searchResults.map { searchResult ->
+            val session = searchResult.toSessionInfo()
+            SessionTreeItem(
+                session = session,
+                depth = 0,
+                branchStem = null,
+                displayTitle = session.title?.takeIf(String::isNotBlank)
+                    ?: session.display_name?.takeIf(String::isNotBlank)
+                    ?: session.preview?.takeIf(String::isNotBlank)?.take(80)
+                    ?: "Untitled",
+            )
+        }
+    } else {
+        flattenSessionTree(state.sessions)
+    }
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SessionsScreen(
@@ -169,22 +200,16 @@ fun SessionsScreen(
     val primaryContainer = MaterialTheme.colorScheme.primaryContainer
     val onPrimaryContainer = MaterialTheme.colorScheme.onPrimaryContainer
 
-    var query by remember { mutableStateOf("") }
     var pruneDays by remember { mutableStateOf("7") }
 
-    val sessionTree = remember(state.sessions) { flattenSessionTree(state.sessions) }
-    val filteredSessions =
-        remember(query, sessionTree) {
-            if (query.isBlank()) {
-                sessionTree
-            } else {
-                sessionTree.filter { item ->
-                    item.displayTitle.contains(query, ignoreCase = true) ||
-                        item.session.preview?.contains(query, ignoreCase = true) == true ||
-                        item.session.status?.contains(query, ignoreCase = true) == true
-                }
-            }
-        }
+    val sessionsToDisplay = remember(
+        state.isSearchMode,
+        state.searchQuery,
+        state.sessions,
+        state.searchResults,
+    ) {
+        displayedSessions(state)
+    }
 
     val hasSelection = state.selectedIds.isNotEmpty()
 
@@ -319,7 +344,99 @@ fun SessionsScreen(
         onRefresh = { viewModel.loadSessions() },
         modifier = modifier,
     ) {
+        // ── Search + bulk toggle (always visible) ──────────────
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = spacing.md),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            SearchBar(
+                query = state.searchQuery,
+                onQueryChange = { viewModel.setSearchQuery(it) },
+                placeholder = stringResource(R.string.sessions_search_placeholder),
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(modifier = Modifier.width(spacing.sm))
+            IconButton(onClick = { viewModel.toggleSelecting() }) {
+                Icon(
+                    imageVector = if (state.isSelecting) Icons.Filled.Close else Icons.Filled.SelectAll,
+                    contentDescription =
+                        if (state.isSelecting) {
+                            stringResource(R.string.content_desc_exit_selection)
+                        } else {
+                            stringResource(R.string.content_desc_enter_selection)
+                        },
+                )
+            }
+        }
+
         when {
+            state.isSearchMode -> {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    when {
+                        state.isSearching && state.searchResults.isEmpty() -> {
+                            LoadingState()
+                        }
+                        state.searchError != null -> {
+                            ErrorState(
+                                message =
+                                    state.searchError
+                                        ?: stringResource(R.string.error_unknown),
+                                onRetry = { viewModel.setSearchQuery(state.searchQuery) },
+                            )
+                        }
+                        state.searchResults.isEmpty() -> {
+                            EmptyState(
+                                title = stringResource(R.string.sessions_search_empty_title),
+                                subtitle =
+                                    stringResource(
+                                        R.string.sessions_search_empty_desc,
+                                        state.searchQuery,
+                                    ),
+                                icon = Icons.Filled.Search,
+                            )
+                        }
+                        else -> {
+                            LazyColumn(
+                                modifier = Modifier.fillMaxSize(),
+                                contentPadding = listContentPadding,
+                                verticalArrangement = listItemSpacing,
+                            ) {
+                                items(sessionsToDisplay, key = { it.id }) { session ->
+                                    SessionCard(
+                                        session = session,
+                                        query = state.searchQuery,
+                                        isSelecting = state.isSelecting,
+                                        isSelected = session.id in state.selectedIds,
+                                        isDeleting = session.id in state.deletingSessionIds,
+                                        highlightBackground = primaryContainer,
+                                        highlightForeground = onPrimaryContainer,
+                                        onCardClick = {
+                                            if (state.isSelecting) {
+                                                viewModel.toggleSessionSelection(session.id)
+                                            } else {
+                                                NavigationController.pendingSessionId = session.id
+                                                NavigationController.navigateTo(ChatScreen)
+                                            }
+                                        },
+                                        onCardLongClick = {
+                                            if (!state.isSelecting) {
+                                                viewModel.toggleSelecting()
+                                                viewModel.toggleSessionSelection(session.id)
+                                            }
+                                        },
+                                        onToggleSelection = { viewModel.toggleSessionSelection(session.id) },
+                                        onDelete = { viewModel.requestDeleteSession(session.id) },
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             state.isLoading && state.sessions.isEmpty() -> {
                 LoadingState()
             }
@@ -404,48 +521,20 @@ fun SessionsScreen(
                         )
                     }
 
-                    // ── Search + bulk toggle ────────────────────────────
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = spacing.md),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        SearchBar(
-                            query = query,
-                            onQueryChange = { query = it },
-                            placeholder = stringResource(R.string.sessions_search_placeholder),
-                            modifier = Modifier.weight(1f),
-                        )
-                        Spacer(modifier = Modifier.width(spacing.sm))
-                        IconButton(onClick = { viewModel.toggleSelecting() }) {
-                            Icon(
-                                imageVector = if (state.isSelecting) Icons.Filled.Close else Icons.Filled.SelectAll,
-                                contentDescription =
-                                    if (state.isSelecting) {
-                                        stringResource(R.string.content_desc_exit_selection)
-                                    } else {
-                                        stringResource(R.string.content_desc_enter_selection)
-                                    },
-                            )
-                        }
-                    }
-
                     // ── Session list ────────────────────────────────────
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = listContentPadding,
                         verticalArrangement = listItemSpacing,
                     ) {
-                        items(filteredSessions, key = { it.session.id }) { item ->
+                        items(sessionsToDisplay, key = { it.session.id }) { item ->
                             val session = item.session
                             SessionCard(
                                 session = session,
                                 displayTitle = item.displayTitle,
                                 depth = item.depth,
                                 branchStem = item.branchStem,
-                                query = query,
+                                query = state.searchQuery,
                                 isSelecting = state.isSelecting,
                                 isSelected = session.id in state.selectedIds,
                                 isDeleting = session.id in state.deletingSessionIds,
@@ -535,7 +624,7 @@ fun SessionsScreen(
                     // Select all / deselect
                     OutlinedButton(
                         onClick = {
-                            if (state.selectedIds.size == filteredSessions.size) {
+                            if (state.selectedIds.size == state.sessions.size) {
                                 viewModel.clearSelection()
                             } else {
                                 viewModel.selectAll()
@@ -544,7 +633,7 @@ fun SessionsScreen(
                     ) {
                         Icon(
                             imageVector =
-                                if (state.selectedIds.size == filteredSessions.size) {
+                                if (state.selectedIds.size == state.sessions.size) {
                                     Icons.Filled.Close
                                 } else {
                                     Icons.Filled.SelectAll
@@ -554,7 +643,7 @@ fun SessionsScreen(
                         )
                         Spacer(modifier = Modifier.width(spacing.xs))
                         Text(
-                            if (state.selectedIds.size == filteredSessions.size) {
+                            if (state.selectedIds.size == state.sessions.size) {
                                 stringResource(R.string.sessions_action_deselect_all)
                             } else {
                                 stringResource(R.string.sessions_action_select_all)

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
@@ -927,7 +927,7 @@ private fun SearchResultCard(
             },
     ) {
         Row(
-            modifier = Modifier.padding(spacing.md),
+            modifier = Modifier.padding(spacing.sm),
             verticalAlignment = Alignment.Top,
         ) {
             // Checkbox in select mode
@@ -982,7 +982,7 @@ private fun SearchResultCard(
                     overflow = TextOverflow.Ellipsis,
                 )
 
-                Spacer(modifier = Modifier.height(spacing.sm))
+                Spacer(modifier = Modifier.height(spacing.xs))
 
                 // Metadata chips row
                 Row(
@@ -1007,16 +1007,6 @@ private fun SearchResultCard(
                             status = StatusBadgeType.NEUTRAL,
                         )
                     }
-                }
-
-                // Tap hint when not selecting
-                if (!isSelecting) {
-                    Spacer(modifier = Modifier.height(spacing.xs))
-                    Text(
-                        text = stringResource(R.string.sessions_search_open_hint),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
                 }
             }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
@@ -98,6 +98,12 @@ import com.m57.hermescontrol.ui.common.StatusBadge
 import com.m57.hermescontrol.ui.common.StatusBadgeType
 import com.m57.hermescontrol.ui.common.ToastEffect
 import com.m57.hermescontrol.ui.common.listItemSpacing
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -212,6 +218,48 @@ private fun formatPlayedAt(epochSeconds: Double?): String? {
     }
 }
 
+private val searchSnippetJson = Json { isLenient = true }
+
+/**
+ * Makes a backend FTS snippet safe to present as prose. Some indexed messages are stored as
+ * JSON, so prefer their human-readable text fields rather than rendering the entire payload.
+ */
+internal fun cleanSearchSnippet(snippet: String): String {
+    val withoutHighlightMarkers = snippet.replace(">>>", "").replace("<<<", "").trim()
+    val parsedSnippet =
+        runCatching { searchSnippetJson.parseToJsonElement(withoutHighlightMarkers) }.getOrNull()
+    val displayText = parsedSnippet?.searchText() ?: withoutHighlightMarkers
+    return displayText
+        .replace(Regex("\\s+"), " ")
+        .trim()
+}
+
+private fun JsonElement.searchText(): String? =
+    when (this) {
+        is JsonPrimitive -> {
+            contentOrNull?.takeIf(String::isNotBlank)
+        }
+
+        is JsonArray -> {
+            mapNotNull { it.searchText() }
+                .joinToString(" ")
+                .takeIf(String::isNotBlank)
+        }
+
+        is JsonObject -> {
+            val textFieldNames =
+                listOf("content", "text", "message", "body", "prompt", "summary", "title")
+            val wrapperFieldNames = listOf("data", "result", "payload", "parts")
+            textFieldNames
+                .firstNotNullOfOrNull { fieldName -> this[fieldName]?.searchText() }
+                ?: wrapperFieldNames.firstNotNullOfOrNull { fieldName -> this[fieldName]?.searchText() }
+        }
+
+        else -> {
+            null
+        }
+    }
+
 private fun displayedSessions(state: SessionsUiState): List<SessionTreeItem> =
     if (state.isSearchMode) {
         state.searchResults.map { searchResult ->
@@ -222,9 +270,9 @@ private fun displayedSessions(state: SessionsUiState): List<SessionTreeItem> =
                 branchStem = null,
                 displayTitle =
                     session.title?.takeIf(String::isNotBlank)
-                    ?: session.display_name?.takeIf(String::isNotBlank)
-                    ?: session.preview?.takeIf(String::isNotBlank)?.take(80)
-                    ?: "Untitled",
+                        ?: session.display_name?.takeIf(String::isNotBlank)
+                        ?: session.preview?.takeIf(String::isNotBlank)?.take(80)
+                        ?: "Untitled",
             )
         }
     } else {
@@ -341,8 +389,7 @@ fun SessionsScreen(
                 ?: state.searchResults
                     .find { it.session_id == sessionToDelete }
                     ?.snippet
-                    ?.replace(">>>", "")
-                    ?.replace("<<<", "")
+                    ?.let(::cleanSearchSnippet)
                     ?.take(80)
                 ?: stringResource(R.string.history_untitled)
         AlertDialog(
@@ -450,6 +497,7 @@ fun SessionsScreen(
                                 state.isSearching && state.searchResults.isEmpty() -> {
                                     LoadingState()
                                 }
+
                                 state.searchError != null -> {
                                     ErrorState(
                                         message =
@@ -458,6 +506,7 @@ fun SessionsScreen(
                                         onRetry = { viewModel.setSearchQuery(state.searchQuery) },
                                     )
                                 }
+
                                 state.searchResults.isEmpty() -> {
                                     EmptyState(
                                         title = stringResource(R.string.sessions_search_empty_title),
@@ -469,6 +518,7 @@ fun SessionsScreen(
                                         icon = Icons.Filled.Search,
                                     )
                                 }
+
                                 else -> {
                                     Column(modifier = Modifier.fillMaxSize()) {
                                         Text(
@@ -951,10 +1001,7 @@ private fun SearchResultCard(
     val spacing = LocalSpacing.current
     val statusColors = LocalHermesStatusColors.current
     val snippet = session.preview?.takeIf { it.isNotBlank() } ?: stringResource(R.string.history_untitled)
-    // Backend search snippets carry FTS5 highlight markers (>>>term<<<). The mobile
-    // highlights by the raw query term, so strip those markers before display to avoid
-    // rendering literal ">>>"/"<<<" in the result text.
-    val cleanSnippet = snippet.replace(">>>", "").replace("<<<", "")
+    val cleanSnippet = cleanSearchSnippet(snippet)
     val playedAt = formatPlayedAt(session.started_at)
 
     Card(

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
@@ -79,8 +79,6 @@ import com.m57.hermescontrol.NavigationController
 import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.SessionInfo
 import com.m57.hermescontrol.data.model.SessionSearchResult
-import com.m57.hermescontrol.data.model.SessionTreeItem
-import com.m57.hermescontrol.data.model.flattenSessionTree
 import com.m57.hermescontrol.theme.LocalHermesStatusColors
 import com.m57.hermescontrol.theme.LocalSpacing
 import com.m57.hermescontrol.ui.common.EmptyState
@@ -169,22 +167,18 @@ private fun SessionSearchResult.toSessionInfo(): SessionInfo =
         started_at = session_started,
     )
 
-private fun displayedSessions(state: SessionsUiState): List<SessionTreeItem> =
+/**
+ * Builds the list of sessions to display. In search mode the backend results are
+ * used; otherwise the locally-paginated list is filtered by title/status as before.
+ */
+private fun displayedSessions(state: SessionsUiState): List<SessionInfo> =
     if (state.isSearchMode) {
-        state.searchResults.map { searchResult ->
-            val session = searchResult.toSessionInfo()
-            SessionTreeItem(
-                session = session,
-                depth = 0,
-                branchStem = null,
-                displayTitle = session.title?.takeIf(String::isNotBlank)
-                    ?: session.display_name?.takeIf(String::isNotBlank)
-                    ?: session.preview?.takeIf(String::isNotBlank)?.take(80)
-                    ?: "Untitled",
-            )
-        }
+        state.searchResults.map { it.toSessionInfo() }
     } else {
-        flattenSessionTree(state.sessions)
+        state.sessions.filter { session ->
+            session.title?.contains(state.searchQuery, ignoreCase = true) == true ||
+                session.status?.contains(state.searchQuery, ignoreCase = true) == true
+        }
     }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -202,14 +196,15 @@ fun SessionsScreen(
 
     var pruneDays by remember { mutableStateOf("7") }
 
-    val sessionsToDisplay = remember(
-        state.isSearchMode,
-        state.searchQuery,
-        state.sessions,
-        state.searchResults,
-    ) {
-        displayedSessions(state)
-    }
+    val sessionsToDisplay =
+        remember(
+            state.isSearchMode,
+            state.searchQuery,
+            state.sessions,
+            state.searchResults,
+        ) {
+            displayedSessions(state)
+        }
 
     val hasSelection = state.selectedIds.isNotEmpty()
 
@@ -344,61 +339,190 @@ fun SessionsScreen(
         onRefresh = { viewModel.loadSessions() },
         modifier = modifier,
     ) {
-        // ── Search + bulk toggle (always visible) ──────────────
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = spacing.md),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            SearchBar(
-                query = state.searchQuery,
-                onQueryChange = { viewModel.setSearchQuery(it) },
-                placeholder = stringResource(R.string.sessions_search_placeholder),
-                modifier = Modifier.weight(1f),
-            )
-            Spacer(modifier = Modifier.width(spacing.sm))
-            IconButton(onClick = { viewModel.toggleSelecting() }) {
-                Icon(
-                    imageVector = if (state.isSelecting) Icons.Filled.Close else Icons.Filled.SelectAll,
-                    contentDescription =
-                        if (state.isSelecting) {
-                            stringResource(R.string.content_desc_exit_selection)
-                        } else {
-                            stringResource(R.string.content_desc_enter_selection)
-                        },
+        // Single scrolling column: search bar pinned on top, list fills below.
+        // (The scaffold already applies top-bar padding via its inner Box, so we
+        //  must NOT re-apply paddingValues here.)
+        Column(modifier = Modifier.fillMaxSize()) {
+            // ── Search + bulk toggle (always visible) ─────────────
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = spacing.md, vertical = spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                SearchBar(
+                    query = state.searchQuery,
+                    onQueryChange = { viewModel.setSearchQuery(it) },
+                    placeholder = stringResource(R.string.sessions_search_placeholder),
+                    modifier = Modifier.weight(1f),
                 )
+                Spacer(modifier = Modifier.width(spacing.sm))
+                IconButton(onClick = { viewModel.toggleSelecting() }) {
+                    Icon(
+                        imageVector = if (state.isSelecting) Icons.Filled.Close else Icons.Filled.SelectAll,
+                        contentDescription =
+                            if (state.isSelecting) {
+                                stringResource(R.string.content_desc_exit_selection)
+                            } else {
+                                stringResource(R.string.content_desc_enter_selection)
+                            },
+                    )
+                }
             }
-        }
 
-        when {
-            state.isSearchMode -> {
-                Column(modifier = Modifier.fillMaxSize()) {
-                    when {
-                        state.isSearching && state.searchResults.isEmpty() -> {
-                            LoadingState()
+            // List/state area takes all remaining height below the search bar.
+            Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                when {
+                    state.isSearchMode -> {
+                        Column(modifier = Modifier.fillMaxSize()) {
+                            when {
+                                state.isSearching && state.searchResults.isEmpty() -> {
+                                    LoadingState()
+                                }
+                                state.searchError != null -> {
+                                    ErrorState(
+                                        message =
+                                            state.searchError
+                                                ?: stringResource(R.string.error_unknown),
+                                        onRetry = { viewModel.setSearchQuery(state.searchQuery) },
+                                    )
+                                }
+                                state.searchResults.isEmpty() -> {
+                                    EmptyState(
+                                        title = stringResource(R.string.sessions_search_empty_title),
+                                        subtitle =
+                                            stringResource(
+                                                R.string.sessions_search_empty_desc,
+                                                state.searchQuery,
+                                            ),
+                                        icon = Icons.Filled.Search,
+                                    )
+                                }
+                                else -> {
+                                    LazyColumn(
+                                        modifier = Modifier.fillMaxSize(),
+                                        contentPadding = listContentPadding,
+                                        verticalArrangement = listItemSpacing,
+                                    ) {
+                                        items(sessionsToDisplay, key = { it.id }) { session ->
+                                            SessionCard(
+                                                session = session,
+                                                query = state.searchQuery,
+                                                isSelecting = state.isSelecting,
+                                                isSelected = session.id in state.selectedIds,
+                                                isDeleting = session.id in state.deletingSessionIds,
+                                                highlightBackground = primaryContainer,
+                                                highlightForeground = onPrimaryContainer,
+                                                onCardClick = {
+                                                    if (state.isSelecting) {
+                                                        viewModel.toggleSessionSelection(session.id)
+                                                    } else {
+                                                        NavigationController.pendingSessionId = session.id
+                                                        NavigationController.navigateTo(ChatScreen)
+                                                    }
+                                                },
+                                                onCardLongClick = {
+                                                    if (!state.isSelecting) {
+                                                        viewModel.toggleSelecting()
+                                                        viewModel.toggleSessionSelection(session.id)
+                                                    }
+                                                },
+                                                onToggleSelection = { viewModel.toggleSessionSelection(session.id) },
+                                                onDelete = { viewModel.requestDeleteSession(session.id) },
+                                            )
+                                        }
+                                    }
+                                }
+                            }
                         }
-                        state.searchError != null -> {
-                            ErrorState(
-                                message =
-                                    state.searchError
-                                        ?: stringResource(R.string.error_unknown),
-                                onRetry = { viewModel.setSearchQuery(state.searchQuery) },
-                            )
-                        }
-                        state.searchResults.isEmpty() -> {
-                            EmptyState(
-                                title = stringResource(R.string.sessions_search_empty_title),
-                                subtitle =
-                                    stringResource(
-                                        R.string.sessions_search_empty_desc,
-                                        state.searchQuery,
-                                    ),
-                                icon = Icons.Filled.Search,
-                            )
-                        }
-                        else -> {
+                    }
+
+                    state.isLoading && state.sessions.isEmpty() -> {
+                        LoadingState()
+                    }
+
+                    state.errorMessage != null -> {
+                        val errorMsg = state.errorMessage
+                        ErrorState(
+                            message = errorMsg ?: stringResource(R.string.error_unknown),
+                            onRetry = { viewModel.loadSessions() },
+                        )
+                    }
+
+                    state.sessions.isEmpty() -> {
+                        EmptyState(
+                            title = stringResource(R.string.history_empty_title),
+                            subtitle = stringResource(R.string.history_empty_desc),
+                            icon = Icons.Filled.History,
+                        )
+                    }
+
+                    else -> {
+                        Column(modifier = Modifier.fillMaxSize()) {
+                            // ── Stats row ───────────────────────────────────────
+                            Row(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = spacing.md, vertical = spacing.sm),
+                                horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                            ) {
+                                StatCard(
+                                    label = stringResource(R.string.sessions_stat_total),
+                                    value = if (state.isLoadingStats) "…" else state.stats.total.toString(),
+                                    icon = Icons.Filled.History,
+                                    modifier = Modifier.weight(1f),
+                                )
+                                StatCard(
+                                    label = stringResource(R.string.sessions_stat_active),
+                                    value = if (state.isLoadingStats) "…" else state.stats.active.toString(),
+                                    icon = Icons.Filled.CheckCircle,
+                                    accentColor = statusColors.success,
+                                    modifier = Modifier.weight(1f),
+                                )
+                                // Prune button card
+                                Card(
+                                    modifier = Modifier.weight(1f),
+                                    colors =
+                                        CardDefaults.cardColors(
+                                            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                                        ),
+                                    onClick = { viewModel.showPruneDialog() },
+                                ) {
+                                    Box(
+                                        modifier = Modifier.padding(spacing.md),
+                                        contentAlignment = Alignment.Center,
+                                    ) {
+                                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                            Icon(
+                                                imageVector = Icons.Filled.DeleteSweep,
+                                                contentDescription = null,
+                                                tint = statusColors.warning,
+                                                modifier = Modifier.size(20.dp),
+                                            )
+                                            Spacer(modifier = Modifier.height(spacing.xs))
+                                            Text(
+                                                text = stringResource(R.string.sessions_action_prune),
+                                                style = MaterialTheme.typography.labelSmall,
+                                                color = statusColors.warning,
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                            // Stats error snack
+                            val statsError = state.statsError
+                            if (statsError != null) {
+                                Text(
+                                    text = statsError,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = statusColors.error,
+                                    modifier = Modifier.padding(horizontal = spacing.md),
+                                )
+                            }
+
+                            // ── Session list ────────────────────────────────────
                             LazyColumn(
                                 modifier = Modifier.fillMaxSize(),
                                 contentPadding = listContentPadding,
@@ -431,161 +555,36 @@ fun SessionsScreen(
                                         onDelete = { viewModel.requestDeleteSession(session.id) },
                                     )
                                 }
-                            }
-                        }
-                    }
-                }
-            }
 
-            state.isLoading && state.sessions.isEmpty() -> {
-                LoadingState()
-            }
-
-            state.errorMessage != null -> {
-                val errorMsg = state.errorMessage
-                ErrorState(
-                    message = errorMsg ?: stringResource(R.string.error_unknown),
-                    onRetry = { viewModel.loadSessions() },
-                )
-            }
-
-            state.sessions.isEmpty() -> {
-                EmptyState(
-                    title = stringResource(R.string.history_empty_title),
-                    subtitle = stringResource(R.string.history_empty_desc),
-                    icon = Icons.Filled.History,
-                )
-            }
-
-            else -> {
-                Column(modifier = Modifier.fillMaxSize()) {
-                    // ── Stats row ───────────────────────────────────────
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = spacing.md, vertical = spacing.sm),
-                        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
-                    ) {
-                        StatCard(
-                            label = stringResource(R.string.sessions_stat_total),
-                            value = if (state.isLoadingStats) "…" else state.stats.total.toString(),
-                            icon = Icons.Filled.History,
-                            modifier = Modifier.weight(1f),
-                        )
-                        StatCard(
-                            label = stringResource(R.string.sessions_stat_active),
-                            value = if (state.isLoadingStats) "…" else state.stats.active.toString(),
-                            icon = Icons.Filled.CheckCircle,
-                            accentColor = statusColors.success,
-                            modifier = Modifier.weight(1f),
-                        )
-                        // Prune button card
-                        Card(
-                            modifier = Modifier.weight(1f),
-                            colors =
-                                CardDefaults.cardColors(
-                                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
-                                ),
-                            onClick = { viewModel.showPruneDialog() },
-                        ) {
-                            Box(
-                                modifier = Modifier.padding(spacing.md),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                    Icon(
-                                        imageVector = Icons.Filled.DeleteSweep,
-                                        contentDescription = null,
-                                        tint = statusColors.warning,
-                                        modifier = Modifier.size(20.dp),
-                                    )
-                                    Spacer(modifier = Modifier.height(spacing.xs))
-                                    Text(
-                                        text = stringResource(R.string.sessions_action_prune),
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = statusColors.warning,
-                                    )
-                                }
-                            }
-                        }
-                    }
-                    // Stats error snack
-                    val statsError = state.statsError
-                    if (statsError != null) {
-                        Text(
-                            text = statsError,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = statusColors.error,
-                            modifier = Modifier.padding(horizontal = spacing.md),
-                        )
-                    }
-
-                    // ── Session list ────────────────────────────────────
-                    LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
-                        contentPadding = listContentPadding,
-                        verticalArrangement = listItemSpacing,
-                    ) {
-                        items(sessionsToDisplay, key = { it.session.id }) { item ->
-                            val session = item.session
-                            SessionCard(
-                                session = session,
-                                displayTitle = item.displayTitle,
-                                depth = item.depth,
-                                branchStem = item.branchStem,
-                                query = state.searchQuery,
-                                isSelecting = state.isSelecting,
-                                isSelected = session.id in state.selectedIds,
-                                isDeleting = session.id in state.deletingSessionIds,
-                                highlightBackground = primaryContainer,
-                                highlightForeground = onPrimaryContainer,
-                                onCardClick = {
-                                    if (state.isSelecting) {
-                                        viewModel.toggleSessionSelection(session.id)
-                                    } else {
-                                        NavigationController.pendingSessionId = session.id
-                                        NavigationController.navigateTo(ChatScreen)
-                                    }
-                                },
-                                onCardLongClick = {
-                                    if (!state.isSelecting) {
-                                        viewModel.toggleSelecting()
-                                        viewModel.toggleSessionSelection(session.id)
-                                    }
-                                },
-                                onToggleSelection = { viewModel.toggleSessionSelection(session.id) },
-                                onDelete = { viewModel.requestDeleteSession(session.id) },
-                            )
-                        }
-
-                        // Load more
-                        if (state.hasMore || state.isLoadingMore) {
-                            item {
-                                Box(
-                                    modifier =
-                                        Modifier
-                                            .fillMaxWidth()
-                                            .padding(vertical = spacing.sm),
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    if (state.isLoadingMore) {
-                                        CircularProgressIndicator(
-                                            modifier = Modifier.size(24.dp),
-                                            strokeWidth = 2.dp,
-                                        )
-                                    } else {
-                                        Text(
-                                            text = stringResource(R.string.history_load_more),
-                                            style = MaterialTheme.typography.labelLarge,
-                                            color = MaterialTheme.colorScheme.primary,
+                                // Load more
+                                if (state.hasMore || state.isLoadingMore) {
+                                    item {
+                                        Box(
                                             modifier =
                                                 Modifier
-                                                    .testTag("load_more_sessions")
-                                                    .clickable(role = Role.Button) {
-                                                        viewModel.loadMore()
-                                                    },
-                                        )
+                                                    .fillMaxWidth()
+                                                    .padding(vertical = spacing.sm),
+                                            contentAlignment = Alignment.Center,
+                                        ) {
+                                            if (state.isLoadingMore) {
+                                                CircularProgressIndicator(
+                                                    modifier = Modifier.size(24.dp),
+                                                    strokeWidth = 2.dp,
+                                                )
+                                            } else {
+                                                Text(
+                                                    text = stringResource(R.string.history_load_more),
+                                                    style = MaterialTheme.typography.labelLarge,
+                                                    color = MaterialTheme.colorScheme.primary,
+                                                    modifier =
+                                                        Modifier
+                                                            .testTag("load_more_sessions")
+                                                            .clickable(role = Role.Button) {
+                                                                viewModel.loadMore()
+                                                            },
+                                                )
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -594,92 +593,92 @@ fun SessionsScreen(
                 }
             }
         }
-    }
 
-    // ── Bulk action toolbar (animated) ──────────────────────────────────
-    AnimatedVisibility(
-        visible = state.isSelecting && hasSelection,
-        enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
-        exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
-        modifier = Modifier.fillMaxSize(),
-    ) {
-        Box(
+        // ── Bulk action toolbar (animated) ──────────────────────────────────
+        AnimatedVisibility(
+            visible = state.isSelecting && hasSelection,
+            enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
+            exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
             modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.BottomCenter,
         ) {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                shadowElevation = 8.dp,
-                tonalElevation = 4.dp,
-                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.BottomCenter,
             ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = spacing.md, vertical = spacing.sm),
-                    horizontalArrangement = Arrangement.SpaceEvenly,
-                    verticalAlignment = Alignment.CenterVertically,
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shadowElevation = 8.dp,
+                    tonalElevation = 4.dp,
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
                 ) {
-                    // Select all / deselect
-                    OutlinedButton(
-                        onClick = {
-                            if (state.selectedIds.size == state.sessions.size) {
-                                viewModel.clearSelection()
-                            } else {
-                                viewModel.selectAll()
-                            }
-                        },
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = spacing.md, vertical = spacing.sm),
+                        horizontalArrangement = Arrangement.SpaceEvenly,
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Icon(
-                            imageVector =
+                        // Select all / deselect
+                        OutlinedButton(
+                            onClick = {
                                 if (state.selectedIds.size == state.sessions.size) {
-                                    Icons.Filled.Close
+                                    viewModel.clearSelection()
                                 } else {
-                                    Icons.Filled.SelectAll
-                                },
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp),
-                        )
-                        Spacer(modifier = Modifier.width(spacing.xs))
-                        Text(
-                            if (state.selectedIds.size == state.sessions.size) {
-                                stringResource(R.string.sessions_action_deselect_all)
-                            } else {
-                                stringResource(R.string.sessions_action_select_all)
+                                    viewModel.selectAll()
+                                }
                             },
-                        )
-                    }
-
-                    // Delete selected
-                    Button(
-                        onClick = { viewModel.requestBulkDelete() },
-                        enabled = !state.isDeletingBulk,
-                        colors =
-                            ButtonDefaults.buttonColors(
-                                containerColor = statusColors.error,
-                            ),
-                    ) {
-                        if (state.isDeletingBulk) {
-                            CircularProgressIndicator(
-                                modifier = Modifier.size(18.dp),
-                                strokeWidth = 2.dp,
-                                color = statusColors.onError,
-                            )
-                        } else {
+                        ) {
                             Icon(
-                                imageVector = Icons.Filled.Delete,
+                                imageVector =
+                                    if (state.selectedIds.size == state.sessions.size) {
+                                        Icons.Filled.Close
+                                    } else {
+                                        Icons.Filled.SelectAll
+                                    },
                                 contentDescription = null,
                                 modifier = Modifier.size(18.dp),
                             )
+                            Spacer(modifier = Modifier.width(spacing.xs))
+                            Text(
+                                if (state.selectedIds.size == state.sessions.size) {
+                                    stringResource(R.string.sessions_action_deselect_all)
+                                } else {
+                                    stringResource(R.string.sessions_action_select_all)
+                                },
+                            )
                         }
-                        Spacer(modifier = Modifier.width(spacing.xs))
-                        Text(
-                            stringResource(
-                                R.string.sessions_action_delete_n,
-                                state.selectedIds.size,
-                            ),
-                        )
+
+                        // Delete selected
+                        Button(
+                            onClick = { viewModel.requestBulkDelete() },
+                            enabled = !state.isDeletingBulk,
+                            colors =
+                                ButtonDefaults.buttonColors(
+                                    containerColor = statusColors.error,
+                                ),
+                        ) {
+                            if (state.isDeletingBulk) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(18.dp),
+                                    strokeWidth = 2.dp,
+                                    color = Color.White,
+                                )
+                            } else {
+                                Icon(
+                                    imageVector = Icons.Filled.Delete,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                            }
+                            Spacer(modifier = Modifier.width(spacing.xs))
+                            Text(
+                                stringResource(
+                                    R.string.sessions_action_delete_n,
+                                    state.selectedIds.size,
+                                ),
+                            )
+                        }
                     }
                 }
             }
@@ -690,10 +689,7 @@ fun SessionsScreen(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun SessionCard(
-    session: SessionInfo,
-    displayTitle: String,
-    depth: Int,
-    branchStem: String?,
+    session: com.m57.hermescontrol.data.model.SessionInfo,
     query: String,
     isSelecting: Boolean,
     isSelected: Boolean,
@@ -707,6 +703,7 @@ private fun SessionCard(
 ) {
     val spacing = LocalSpacing.current
     val statusColors = LocalHermesStatusColors.current
+    val displayTitle = session.title?.takeIf { it.isNotBlank() } ?: stringResource(R.string.history_untitled)
     val isActive = session.status?.lowercase() == "active" || session.status?.lowercase() == "streaming"
     val srcIcon = sourceIcon(session.source)
 
@@ -714,7 +711,6 @@ private fun SessionCard(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(start = (depth * 16).dp)
                 .testTag("session_card_${session.id}")
                 .combinedClickable(
                     onClick = onCardClick,
@@ -743,16 +739,6 @@ private fun SessionCard(
                     checked = isSelected,
                     onCheckedChange = { onToggleSelection() },
                     modifier = Modifier.testTag("session_checkbox_${session.id}"),
-                )
-                Spacer(modifier = Modifier.width(spacing.sm))
-            }
-
-            // Branch tree stem
-            if (branchStem != null && !isSelecting) {
-                Text(
-                    text = branchStem,
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.outline,
                 )
                 Spacer(modifier = Modifier.width(spacing.sm))
             }

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
@@ -265,8 +265,9 @@ fun SessionsScreen(
         visibleSessionIds.isNotEmpty() && visibleSessionIds.all { it in state.selectedIds }
     val listPadding =
         PaddingValues(
-            horizontal = 12.dp,
-            vertical = 8.dp,
+            start = 12.dp,
+            top = 8.dp,
+            end = 12.dp,
             bottom = if (hasSelection) 72.dp else 8.dp,
         )
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
@@ -904,6 +904,10 @@ private fun SearchResultCard(
     val spacing = LocalSpacing.current
     val statusColors = LocalHermesStatusColors.current
     val snippet = session.preview?.takeIf { it.isNotBlank() } ?: stringResource(R.string.history_untitled)
+    // Backend search snippets carry FTS5 highlight markers (>>>term<<<). The mobile
+    // highlights by the raw query term, so strip those markers before display to avoid
+    // rendering literal ">>>"/"<<<" in the result text.
+    val cleanSnippet = snippet.replace(">>>", "").replace("<<<", "")
     val playedAt = formatPlayedAt(session.started_at)
 
     Card(
@@ -975,7 +979,7 @@ private fun SearchResultCard(
 
                 // The matched snippet, highlighted — shown as the body, NOT as a title.
                 Text(
-                    text = highlightText(snippet, query, highlightBackground, highlightForeground),
+                    text = highlightText(cleanSnippet, query, highlightBackground, highlightForeground),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 4,

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
@@ -80,6 +80,8 @@ import com.m57.hermescontrol.NavigationController
 import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.SessionInfo
 import com.m57.hermescontrol.data.model.SessionSearchResult
+import com.m57.hermescontrol.data.model.SessionTreeItem
+import com.m57.hermescontrol.data.model.flattenSessionTree
 import com.m57.hermescontrol.theme.LocalHermesStatusColors
 import com.m57.hermescontrol.theme.LocalSpacing
 import com.m57.hermescontrol.ui.common.EmptyState
@@ -208,18 +210,22 @@ private fun formatPlayedAt(epochSeconds: Double?): String? {
     }
 }
 
-/**
- * Builds the list of sessions to display. In search mode the backend results are
- * used; otherwise the locally-paginated list is filtered by title/status as before.
- */
-private fun displayedSessions(state: SessionsUiState): List<SessionInfo> =
+private fun displayedSessions(state: SessionsUiState): List<SessionTreeItem> =
     if (state.isSearchMode) {
-        state.searchResults.map { it.toSessionInfo() }
-    } else {
-        state.sessions.filter { session ->
-            session.title?.contains(state.searchQuery, ignoreCase = true) == true ||
-                session.status?.contains(state.searchQuery, ignoreCase = true) == true
+        state.searchResults.map { searchResult ->
+            val session = searchResult.toSessionInfo()
+            SessionTreeItem(
+                session = session,
+                depth = 0,
+                branchStem = null,
+                displayTitle = session.title?.takeIf(String::isNotBlank)
+                    ?: session.display_name?.takeIf(String::isNotBlank)
+                    ?: session.preview?.takeIf(String::isNotBlank)?.take(80)
+                    ?: "Untitled",
+            )
         }
+    } else {
+        flattenSessionTree(state.sessions)
     }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -464,7 +470,8 @@ fun SessionsScreen(
                                             contentPadding = listContentPadding,
                                             verticalArrangement = listItemSpacing,
                                         ) {
-                                            items(sessionsToDisplay, key = { it.id }) { session ->
+                                            items(sessionsToDisplay, key = { it.session.id }) { item ->
+                                                val session = item.session
                                                 SearchResultCard(
                                                     session = session,
                                                     query = state.searchQuery,
@@ -592,9 +599,13 @@ fun SessionsScreen(
                                 contentPadding = listContentPadding,
                                 verticalArrangement = listItemSpacing,
                             ) {
-                                items(sessionsToDisplay, key = { it.id }) { session ->
+                                items(sessionsToDisplay, key = { it.session.id }) { item ->
+                                    val session = item.session
                                     SessionCard(
                                         session = session,
+                                        displayTitle = item.displayTitle,
+                                        depth = item.depth,
+                                        branchStem = item.branchStem,
                                         query = state.searchQuery,
                                         isSelecting = state.isSelecting,
                                         isSelected = session.id in state.selectedIds,
@@ -754,6 +765,9 @@ fun SessionsScreen(
 @Composable
 private fun SessionCard(
     session: com.m57.hermescontrol.data.model.SessionInfo,
+    displayTitle: String,
+    depth: Int,
+    branchStem: String?,
     query: String,
     isSelecting: Boolean,
     isSelected: Boolean,
@@ -767,7 +781,6 @@ private fun SessionCard(
 ) {
     val spacing = LocalSpacing.current
     val statusColors = LocalHermesStatusColors.current
-    val displayTitle = session.title?.takeIf { it.isNotBlank() } ?: stringResource(R.string.history_untitled)
     val isActive = session.status?.lowercase() == "active" || session.status?.lowercase() == "streaming"
     val srcIcon = sourceIcon(session.source)
 
@@ -775,6 +788,7 @@ private fun SessionCard(
         modifier =
             Modifier
                 .fillMaxWidth()
+                .padding(start = (depth * 16).dp)
                 .testTag("session_card_${session.id}")
                 .combinedClickable(
                     onClick = onCardClick,
@@ -803,6 +817,16 @@ private fun SessionCard(
                     checked = isSelected,
                     onCheckedChange = { onToggleSelection() },
                     modifier = Modifier.testTag("session_checkbox_${session.id}"),
+                )
+                Spacer(modifier = Modifier.width(spacing.sm))
+            }
+
+            // Branch tree stem
+            if (branchStem != null && !isSelecting) {
+                Text(
+                    text = branchStem,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.outline,
                 )
                 Spacer(modifier = Modifier.width(spacing.sm))
             }

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsViewModel.kt
@@ -246,9 +246,9 @@ class SessionsViewModel : ViewModel() {
         }
     }
 
-    fun selectAll() {
+    fun selectAll(sessionIds: Set<String> = _uiState.value.sessions.mapTo(linkedSetOf()) { it.id }) {
         _uiState.update {
-            it.copy(selectedIds = it.sessions.map { s -> s.id }.toSet())
+            it.copy(selectedIds = sessionIds.toSet())
         }
     }
 
@@ -358,7 +358,8 @@ class SessionsViewModel : ViewModel() {
                         it.copy(
                             deletingSessionIds = it.deletingSessionIds - sessionId,
                             sessions = it.sessions.filter { s -> s.id != sessionId },
-                            total = it.total - 1,
+                            searchResults = it.searchResults.filter { it.session_id != sessionId },
+                            total = (it.total - 1).coerceAtLeast(0),
                             toastMessage = "Session deleted",
                         )
                     }
@@ -406,7 +407,8 @@ class SessionsViewModel : ViewModel() {
                             isSelecting = false,
                             selectedIds = emptySet(),
                             sessions = it.sessions.filter { s -> s.id !in ids },
-                            total = it.total - ids.size,
+                            searchResults = it.searchResults.filter { it.session_id !in ids },
+                            total = (it.total - ids.size).coerceAtLeast(0),
                             toastMessage = "${ids.size} session(s) deleted",
                         )
                     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsViewModel.kt
@@ -6,11 +6,13 @@ import com.m57.hermescontrol.data.model.BulkDeleteRequest
 import com.m57.hermescontrol.data.model.PruneRequest
 import com.m57.hermescontrol.data.model.SessionInfo
 import com.m57.hermescontrol.data.model.SessionRenameRequest
+import com.m57.hermescontrol.data.model.SessionSearchResult
 import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.NetworkResult
 import com.m57.hermescontrol.data.remote.safeApiCall
 import com.m57.hermescontrol.ui.common.safeLaunchLoad
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -41,8 +43,13 @@ data class SessionsUiState(
     val toastMessage: String? = null,
     val sessionToDeleteConfirm: String? = null,
     val showBulkDeleteConfirm: Boolean = false,
+    val searchQuery: String = "",
+    val isSearching: Boolean = false,
+    val searchResults: List<SessionSearchResult> = emptyList(),
+    val searchError: String? = null,
 ) {
     val hasMore: Boolean get() = total > sessions.size
+    val isSearchMode: Boolean get() = searchQuery.isNotBlank()
 }
 
 class SessionsViewModel : ViewModel() {
@@ -55,6 +62,7 @@ class SessionsViewModel : ViewModel() {
     /** Page size sent to the server — matches the default the gateway uses. */
     private companion object {
         const val PAGE_SIZE = 20
+        const val SEARCH_DEBOUNCE_MS = 300L
     }
 
     /** Load (or reload) sessions from page 0. Used by pull-to-refresh and initial load. */
@@ -132,6 +140,56 @@ class SessionsViewModel : ViewModel() {
                 }
             }
         }
+    }
+
+    // ── Search (server-backed FTS5) ──────────────────────────────────
+
+    private var searchJob: Job? = null
+
+    /**
+     * Debounced server-side session search. A non-blank query schedules a search
+     * call after [SEARCH_DEBOUNCE_MS]; a blank query returns to the normal
+     * paginated list mode.
+     */
+    fun setSearchQuery(query: String) {
+        _uiState.update { it.copy(searchQuery = query) }
+        searchJob?.cancel()
+        if (query.isBlank()) {
+            _uiState.update {
+                it.copy(searchResults = emptyList(), searchError = null, isSearching = false)
+            }
+            return
+        }
+        searchJob =
+            viewModelScope.launch {
+                delay(SEARCH_DEBOUNCE_MS)
+                _uiState.update { it.copy(isSearching = true, searchError = null) }
+                val result =
+                    safeApiCall {
+                        ApiClient.hermesApi.searchSessions(q = query, profile = null)
+                    }
+                when (result) {
+                    is NetworkResult.Success -> {
+                        _uiState.update {
+                            it.copy(
+                                isSearching = false,
+                                searchResults = result.data?.results.orEmpty(),
+                                searchError = null,
+                            )
+                        }
+                    }
+
+                    is NetworkResult.Failure -> {
+                        _uiState.update {
+                            it.copy(
+                                isSearching = false,
+                                searchResults = emptyList(),
+                                searchError = "Search failed: ${result.error.message}",
+                            )
+                        }
+                    }
+                }
+            }
     }
 
     // ── Stats ────────────────────────────────────────────────────────────

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -484,6 +484,13 @@
     <string name="sessions_search_placeholder">Search sessions…</string>
     <string name="sessions_search_empty_title">No results</string>
     <string name="sessions_search_empty_desc">No sessions match “%1$s”</string>
+    <string name="sessions_search_results_header">%1$d result(s) for “%2$s”</string>
+    <string name="sessions_search_played_at">Played %1$s</string>
+    <string name="sessions_search_match_label">Match</string>
+    <string name="sessions_search_model_label">Model</string>
+    <string name="sessions_search_unknown_model">Unknown model</string>
+    <string name="sessions_search_source_label">Source</string>
+    <string name="sessions_search_open_hint">Tap to open this conversation</string>
     <string name="sessions_stat_total">Total</string>
     <string name="sessions_stat_active">Active</string>
     <string name="sessions_action_prune">Prune</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -482,6 +482,8 @@
 
     <!-- Sessions Stats -->
     <string name="sessions_search_placeholder">Search sessions…</string>
+    <string name="sessions_search_empty_title">No results</string>
+    <string name="sessions_search_empty_desc">No sessions match “%1$s”</string>
     <string name="sessions_stat_total">Total</string>
     <string name="sessions_stat_active">Active</string>
     <string name="sessions_action_prune">Prune</string>

--- a/app/src/test/java/com/m57/hermescontrol/data/remote/HermesApiServiceMockWebServerTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/remote/HermesApiServiceMockWebServerTest.kt
@@ -308,6 +308,87 @@ class HermesApiServiceMockWebServerTest {
         }
 
     @Test
+    fun searchSessions_parsesResponse() =
+        runBlocking {
+            mockServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody(
+                        """
+                        {
+                            "results": [
+                                {
+                                    "session_id": "sess-abc",
+                                    "snippet": "…matched text…",
+                                    "role": "user",
+                                    "source": "telegram",
+                                    "model": "gpt-4o",
+                                    "session_started": 1718000000
+                                }
+                            ]
+                        }
+                        """.trimIndent(),
+                    ),
+            )
+
+            val response = api.searchSessions(q = "matched", profile = null)
+            assertTrue(response.isSuccessful)
+
+            val body = response.body()
+            assertNotNull(body)
+            assertEquals(1, body!!.results.size)
+
+            val first = body.results[0]
+            assertEquals("sess-abc", first.session_id)
+            assertEquals("…matched text…", first.snippet)
+            assertEquals("telegram", first.source)
+            assertEquals("gpt-4o", first.model)
+            assertEquals(1718000000.0, first.session_started!!, 0.0)
+        }
+
+    @Test
+    fun searchSessions_encodesQueryAndProfileParams() =
+        runBlocking {
+            mockServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody("""{ "results": [] }"""),
+            )
+
+            api.searchSessions(q = "hello world", profile = "work")
+
+            val request = mockServer.takeRequest()
+            assertTrue(
+                "q must be URL-encoded",
+                request.path!!.contains("q=hello%20world"),
+            )
+            assertTrue(
+                "profile param must be sent",
+                request.path!!.contains("profile=work"),
+            )
+        }
+
+    @Test
+    fun getSessionMessages_encodesSessionIdWithSlashes() =
+        runBlocking {
+            val sessionId = "session/with/slashes"
+            mockServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody("""{ "messages": [] }"""),
+            )
+
+            api.getSessionMessages(sessionId)
+
+            val request = mockServer.takeRequest()
+            assertEquals(
+                "path should contain the session ID properly encoded",
+                "/api/sessions/desktop/session/messages/session%2Fwith%2Fslashes?limit=150&offset=0",
+                request.path,
+            )
+        }
+
+    @Test
     fun getOAuthProviders_parsesList() =
         runBlocking {
             mockServer.enqueue(

--- a/app/src/test/java/com/m57/hermescontrol/data/remote/HermesApiServiceMockWebServerTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/remote/HermesApiServiceMockWebServerTest.kt
@@ -383,7 +383,7 @@ class HermesApiServiceMockWebServerTest {
             val request = mockServer.takeRequest()
             assertEquals(
                 "path should contain the session ID properly encoded",
-                "/api/sessions/desktop/session/messages/session%2Fwith%2Fslashes?limit=150&offset=0",
+                "/api/sessions/session%2Fwith%2Fslashes/messages?offset=0",
                 request.path,
             )
         }

--- a/app/src/test/java/com/m57/hermescontrol/data/remote/HermesApiServiceMockWebServerTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/remote/HermesApiServiceMockWebServerTest.kt
@@ -369,7 +369,7 @@ class HermesApiServiceMockWebServerTest {
         }
 
     @Test
-    fun getSessionMessages_encodesSessionIdWithSlashes() =
+    fun getSessionMessages_preservesSessionIdSlashes() =
         runBlocking {
             val sessionId = "session/with/slashes"
             mockServer.enqueue(
@@ -382,8 +382,8 @@ class HermesApiServiceMockWebServerTest {
 
             val request = mockServer.takeRequest()
             assertEquals(
-                "path should contain the session ID properly encoded",
-                "/api/sessions/session%2Fwith%2Fslashes/messages?offset=0",
+                "path should contain the session ID with slashes preserved",
+                "/api/sessions/session/with/slashes/messages?offset=0",
                 request.path,
             )
         }

--- a/app/src/test/java/com/m57/hermescontrol/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/sessions/SessionsViewModelTest.kt
@@ -1,0 +1,63 @@
+package com.m57.hermescontrol.ui.sessions
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SessionsViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    private fun createViewModel(): SessionsViewModel {
+        val vm = SessionsViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+        return vm
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `blank query resets search mode`() {
+        val vm = createViewModel()
+        vm.setSearchQuery("something")
+        vm.setSearchQuery("")
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("", vm.uiState.value.searchQuery)
+        assertFalse(vm.uiState.value.isSearchMode)
+        assertEquals(0, vm.uiState.value.searchResults.size)
+        assertFalse(vm.uiState.value.isSearching)
+    }
+
+    @Test
+    fun `non-blank query enters search mode and resolves`() {
+        val vm = createViewModel()
+        vm.setSearchQuery("hello")
+        // state is set synchronously
+        assertEquals("hello", vm.uiState.value.searchQuery)
+        assertTrue(vm.uiState.value.isSearchMode)
+        // advance past debounce + (failing, offline) network call
+        testDispatcher.scheduler.advanceTimeBy(500)
+        testDispatcher.scheduler.advanceUntilIdle()
+        // Either way the spinner must stop and the query persists.
+        assertFalse(vm.uiState.value.isSearching)
+        assertEquals("hello", vm.uiState.value.searchQuery)
+    }
+}

--- a/app/src/test/java/com/m57/hermescontrol/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/sessions/SessionsViewModelTest.kt
@@ -82,4 +82,12 @@ class SessionsViewModelTest {
             vm.uiState.value.selectedIds,
         )
     }
+
+    @Test
+    fun `clean search snippet extracts text from JSON payload`() {
+        assertEquals(
+            "Find the deployment logs",
+            cleanSearchSnippet("{\"role\":\"user\",\"content\":\">>>Find<<< the deployment logs\"}"),
+        )
+    }
 }

--- a/app/src/test/java/com/m57/hermescontrol/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/sessions/SessionsViewModelTest.kt
@@ -1,5 +1,11 @@
 package com.m57.hermescontrol.ui.sessions
 
+import com.m57.hermescontrol.data.remote.ApiClient
+import com.m57.hermescontrol.data.remote.HermesApiService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -17,6 +23,7 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class SessionsViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
+    private val mockApi = mockk<HermesApiService>(relaxed = true)
 
     private fun createViewModel(): SessionsViewModel {
         val vm = SessionsViewModel()
@@ -27,11 +34,14 @@ class SessionsViewModelTest {
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        mockkObject(ApiClient)
+        every { ApiClient.hermesApi } returns mockApi
     }
 
     @After
     fun tearDown() {
         Dispatchers.resetMain()
+        unmockkAll()
     }
 
     @Test
@@ -59,5 +69,17 @@ class SessionsViewModelTest {
         // Either way the spinner must stop and the query persists.
         assertFalse(vm.uiState.value.isSearching)
         assertEquals("hello", vm.uiState.value.searchQuery)
+    }
+
+    @Test
+    fun `select all uses the IDs shown in the current view`() {
+        val vm = createViewModel()
+
+        vm.selectAll(setOf("search-session-1", "search-session-2"))
+
+        assertEquals(
+            setOf("search-session-1", "search-session-2"),
+            vm.uiState.value.selectedIds,
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Closes #530. Promotes the existing Sessions search box from a client-side in-memory filter to a real backend FTS5 search via `GET /api/sessions/search`.
- Adds `SessionSearchResponse`/`SessionSearchResult` models mirroring the web contract (`web/src/lib/api.ts`).
- `SessionsViewModel` owns a 300ms-debounced `setSearchQuery`; blank query falls back to the existing paginated list.
- Search results render in the existing `SessionCard` list with loading / empty / error states.

## Notes / scope guards
- The optional `?profile` query param is included in the API signature (default `null`) for Tier-2 #5 parity, but no profile-picker UI is added in this PR (follow-up).
- Snippet highlighting in the card is deferred (search hits have no `title`).

## Verification (local, SDK present)
- ktlint 1.2.1: clean
- `./gradlew compileDebugKotlin`: green
- `./gradlew testDebugUnitTest`: 11 pass (9 API MockWebServer + 2 VM)
- `./gradlew assembleDebug`: real APK produced

CI gates on `ci-summary`.