### PR TITLE
feat(#536): composer @file/@folder path autocomplete via complete.path RPC

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/model/PathSuggestion.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/PathSuggestion.kt
@@ -1,0 +1,37 @@
+package com.m57.hermescontrol.data.model
+
+/**
+ * A single path completion returned by the gateway's `complete.path` RPC
+ * (issue #536). Mirrors the desktop `ContextSuggestion` shape.
+ *
+ * @param text The token to insert into the composer (e.g. `@file:src/main.kt`).
+ * @param display Short label shown in the dropdown (basename or keyword).
+ * @param meta Optional secondary text (parent dir, "dir", or a keyword hint).
+ * @param isDirectory Whether the entry is a directory (used to render a hint).
+ */
+data class PathSuggestion(
+    val text: String,
+    val display: String,
+    val meta: String? = null,
+    val isDirectory: Boolean = false,
+) {
+    companion object {
+        /**
+         * Build a [PathSuggestion] from a raw `complete.path` item map.
+         * Returns `null` when the item is missing a usable `text` field.
+         */
+        fun fromMap(map: Map<*, *>): PathSuggestion? {
+            val text = map["text"] as? String ?: return null
+            if (text.isBlank()) return null
+            val display = (map["display"] as? String).orEmpty()
+            val meta = map["meta"] as? String
+            val isDirectory = text.endsWith("/") || meta == "dir"
+            return PathSuggestion(
+                text = text,
+                display = display.ifBlank { text },
+                meta = meta,
+                isDirectory = isDirectory,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/WsMethods.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/WsMethods.kt
@@ -40,4 +40,13 @@ object WsMethods {
 
     /** Kill a single background process (scoped to the active session). */
     const val PROCESS_KILL = "process.kill"
+
+    // ── Composer path autocomplete (issue #536) ─────────────────────────
+
+    /**
+     * Resolve `@`-tagged path completions (e.g. `@file:`, `@folder:`, `@diff`)
+     * against the gateway's session working directory. Mirrors the desktop
+     * composer (`apps/desktop/.../use-context-suggestions.ts`).
+     */
+    const val COMPLETE_PATH = "complete.path"
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -107,6 +107,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -150,7 +151,7 @@ fun ChatScreen(
         }
     }
     val scrollScope = rememberCoroutineScope()
-    var inputText by rememberSaveable { mutableStateOf("") }
+    var inputText by rememberSaveable { mutableStateOf(TextFieldValue("")) }
     var isListening by rememberSaveable { mutableStateOf(false) }
     var lastAnimatedMessageId by rememberSaveable { mutableStateOf<String?>(null) }
     var showReloginDialog by rememberSaveable { mutableStateOf(false) }
@@ -176,10 +177,10 @@ fun ChatScreen(
                         .orEmpty()
                 if (spokenText.isNotBlank()) {
                     inputText =
-                        if (inputText.isBlank()) {
-                            spokenText
+                        if (inputText.text.isBlank()) {
+                            TextFieldValue(spokenText)
                         } else {
-                            "$inputText $spokenText"
+                            TextFieldValue("${inputText.text} $spokenText")
                         }
                 }
             }
@@ -417,8 +418,8 @@ fun ChatScreen(
                 inputText = inputText,
                 onInputChange = { inputText = it },
                 onSend = {
-                    viewModel.sendMessage(inputText)
-                    inputText = ""
+                    viewModel.sendMessage(inputText.text)
+                    inputText = TextFieldValue("")
                     scrollScope.launch {
                         val totalItems =
                             state.messages.size +
@@ -465,6 +466,7 @@ fun ChatScreen(
                 isAgentTyping = state.isAgentTyping,
                 isConnected = state.isConnected,
                 commandCatalog = state.commandCatalog,
+                currentSessionId = state.currentSessionId,
                 pendingAttachments = state.pendingAttachments,
                 onCameraTap = {
                     try {
@@ -617,24 +619,33 @@ private fun ReasoningIndicator(reasoningText: String) {
 
 @Composable
 private fun ChatInputBar(
-    inputText: String,
-    onInputChange: (String) -> Unit,
+    inputText: TextFieldValue,
+    onInputChange: (TextFieldValue) -> Unit,
     onSend: () -> Unit,
     onMicTap: () -> Unit,
     isListening: Boolean,
     isAgentTyping: Boolean,
     isConnected: Boolean,
     commandCatalog: CommandCatalog,
+    currentSessionId: String?,
     pendingAttachments: List<Attachment> = emptyList(),
     onCameraTap: () -> Unit = {},
     onImageTap: () -> Unit = {},
     onFileTap: () -> Unit = {},
     onRemoveAttachment: (Int) -> Unit = {},
 ) {
+    // Path autocomplete (`@file:`, `@folder:`, `@name`) — issue #536.
+    val pathCompletion =
+        rememberPathCompletions(
+            input = inputText,
+            sessionId = currentSessionId,
+            onTokenInserted = onInputChange,
+        )
+
     // Allow sending slash commands even while agent is typing
-    val isSlashCommand = inputText.startsWith("/")
+    val isSlashCommand = inputText.text.startsWith("/")
     val canSend =
-        (inputText.isNotBlank() || pendingAttachments.isNotEmpty()) &&
+        (inputText.text.isNotBlank() || pendingAttachments.isNotEmpty()) &&
             isConnected && (!isAgentTyping || isSlashCommand)
 
     // Attachment menu state
@@ -670,11 +681,11 @@ private fun ChatInputBar(
                 val commandNames = allCommands.keys.filter { it !in hiddenSlashDisplay }
 
                 androidx.compose.animation.AnimatedVisibility(
-                    visible = inputText.startsWith("/") && !inputText.contains(" "),
+                    visible = inputText.text.startsWith("/") && !inputText.text.contains(" "),
                     enter = androidx.compose.animation.fadeIn() + androidx.compose.animation.expandVertically(),
                     exit = androidx.compose.animation.fadeOut() + androidx.compose.animation.shrinkVertically(),
                 ) {
-                    val filteredCommands = commandNames.filter { it.startsWith(inputText, ignoreCase = true) }
+                    val filteredCommands = commandNames.filter { it.startsWith(inputText.text, ignoreCase = true) }
                     if (filteredCommands.isNotEmpty()) {
                         androidx.compose.material3.Surface(
                             modifier =
@@ -712,13 +723,17 @@ private fun ChatInputBar(
                                                 )
                                             }
                                         },
-                                        onClick = { onInputChange(cmd) },
+                                        onClick = { onInputChange(TextFieldValue(cmd)) },
                                     )
                                 }
                             }
                         }
                     }
                 }
+
+                // Path autocomplete dropdown (`@file:`, `@folder:`, `@diff`) — issue #536.
+                // Shown above the attachment chips when the gateway returns suggestions.
+                PathCompletionDropdown(state = pathCompletion)
 
                 // Attachment preview chips
                 AnimatedVisibility(
@@ -849,7 +864,7 @@ private fun ChatInputBar(
                         targetState =
                             when {
                                 isListening -> "listening"
-                                inputText.isBlank() && pendingAttachments.isEmpty() -> "mic"
+                                inputText.text.isBlank() && pendingAttachments.isEmpty() -> "mic"
                                 else -> "send"
                             },
                         transitionSpec = {

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -151,7 +151,7 @@ fun ChatScreen(
         }
     }
     val scrollScope = rememberCoroutineScope()
-    var inputText by rememberSaveable { mutableStateOf(TextFieldValue("")) }
+    var inputText by rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue("")) }
     var isListening by rememberSaveable { mutableStateOf(false) }
     var lastAnimatedMessageId by rememberSaveable { mutableStateOf<String?>(null) }
     var showReloginDialog by rememberSaveable { mutableStateOf(false) }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/PathCompletion.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/PathCompletion.kt
@@ -1,0 +1,246 @@
+package com.m57.hermescontrol.ui.chat
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import com.m57.hermescontrol.data.model.PathSuggestion
+import com.m57.hermescontrol.data.ws.HermesWsClient
+import com.m57.hermescontrol.data.ws.WsMethods
+import kotlinx.coroutines.delay
+
+/**
+ * Composer `@`-path autocomplete for issue #536.
+ *
+ * Mirrors the desktop composer (`apps/desktop/.../use-context-suggestions.ts`):
+ * when the user types an `@`-tagged token — `@`, `@file:`, `@file:src/`,
+ * `@folder:`, or a bare `@name` fuzzy match — we fire the gateway's
+ * `complete.path` RPC with the current token as `word` and surface a dropdown
+ * of [PathSuggestion]s. Selecting one replaces the token in the composer with
+ * the completion `text` (e.g. `@file:src/main.kt`).
+ *
+ * Mobile has no local `cwd`; we send only `session_id` + `word` and let the
+ * gateway resolve the working directory from its session record.
+ *
+ * [PATH_TOKEN_RE] matches a trailing `@`-token being typed (the context
+ * completion trigger).
+ */
+
+private val PATH_TOKEN_RE = Regex("""@[\w./:\-~]*$""")
+
+/**
+ * Find the `@`-tagged token at the end of [text], or `null` if the caret is
+ * not inside one. A token is "active" from the `@` up to the first whitespace.
+ */
+fun findPathToken(text: String): String? {
+    val m = PATH_TOKEN_RE.find(text) ?: return null
+    return m.value
+}
+
+/**
+ * Replace the active trailing `@`-token in [text] with [replacement].
+ * If no token is present, returns [text] unchanged. Pure helper so the
+ * insertion logic is unit-testable without composition.
+ */
+fun replaceActivePathToken(
+    text: String,
+    replacement: String,
+): String {
+    val match = PATH_TOKEN_RE.find(text) ?: return text
+    return text.replaceRange(match.range.first, match.range.last + 1, replacement)
+}
+
+/**
+ * Call the gateway's `complete.path` RPC and return parsed suggestions.
+ *
+ * Suspends for the RPC result (delegated to [HermesWsClient.request], which
+ * carries its own 120s timeout + disconnect rejection). Returns an empty list
+ * on any failure (RPC error, timeout, parse error) so the UI simply hides.
+ */
+suspend fun fetchPathSuggestions(
+    sessionId: String,
+    word: String,
+): List<PathSuggestion> {
+    return try {
+        val result =
+            HermesWsClient
+                .request(
+                    method = WsMethods.COMPLETE_PATH,
+                    params =
+                        mapOf(
+                            "session_id" to sessionId,
+                            "word" to word,
+                        ),
+                ).await()
+        val items =
+            (result as? Map<*, *>)
+                ?.get("items")
+                ?.let { it as? List<*> }
+                .orEmpty()
+        items.mapNotNull { item ->
+            val map = item as? Map<*, *> ?: return@mapNotNull null
+            PathSuggestion.fromMap(map)
+        }
+    } catch (e: Exception) {
+        emptyList()
+    }
+}
+
+/**
+ * Drives path-completion state from the composer [TextFieldValue] and exposes
+ * a [select] callback that replaces the active `@`-token with the chosen text.
+ *
+ * Debounces (250ms) so we don't spam `complete.path` on every keystroke, and
+ * ignores results that arrive after the token has changed (race guard),
+ * matching desktop's `stillCurrent()` guard.
+ */
+@Composable
+fun rememberPathCompletions(
+    input: TextFieldValue,
+    sessionId: String?,
+    onTokenInserted: (TextFieldValue) -> Unit,
+): PathCompletionState {
+    var suggestions by remember { mutableStateOf<List<PathSuggestion>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(false) }
+    val token by remember {
+        derivedStateOf { if (sessionId != null) findPathToken(input.text) else null }
+    }
+
+    LaunchedEffect(token, sessionId) {
+        if (token == null || sessionId == null) {
+            suggestions = emptyList()
+            isLoading = false
+            return@LaunchedEffect
+        }
+        isLoading = true
+        delay(250L)
+        val tokenText: String = token ?: return@LaunchedEffect
+        val fetched = fetchPathSuggestions(sessionId, tokenText)
+        // Race guard: only commit if the token hasn't changed meanwhile.
+        if (findPathToken(input.text) == tokenText) {
+            suggestions = fetched
+        }
+        isLoading = false
+    }
+
+    val select: (PathSuggestion) -> Unit = { suggestion ->
+        val replaced = replaceActivePathToken(input.text, suggestion.text)
+        val newSelection = replaced.length
+        onTokenInserted(
+            input.copy(
+                text = replaced,
+                selection = androidx.compose.ui.text.TextRange(newSelection),
+            ),
+        )
+        suggestions = emptyList()
+        isLoading = false
+    }
+
+    return PathCompletionState(
+        suggestions = suggestions,
+        isLoading = isLoading,
+        token = token,
+        select = select,
+    )
+}
+
+/** Immutable snapshot exposed by [rememberPathCompletions]. */
+data class PathCompletionState(
+    val suggestions: List<PathSuggestion>,
+    val isLoading: Boolean,
+    val token: String?,
+    val select: (PathSuggestion) -> Unit,
+)
+
+/**
+ * Dropdown listing [PathCompletionState.suggestions]. Renders nothing when
+ * there are no suggestions. Mirrors the slash-command suggestion styling.
+ */
+@Composable
+fun PathCompletionDropdown(state: PathCompletionState) {
+    AnimatedVisibility(
+        visible = state.suggestions.isNotEmpty(),
+        enter = fadeIn(),
+        exit = shrinkVertically(),
+    ) {
+        Surface(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 4.dp),
+            shape = MaterialTheme.shapes.medium,
+            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+            border =
+                androidx.compose.foundation.BorderStroke(
+                    1.dp,
+                    MaterialTheme.colorScheme.outline.copy(alpha = 0.2f),
+                ),
+        ) {
+            LazyColumn(modifier = Modifier.heightIn(max = 200.dp)) {
+                items(state.suggestions, key = { it.text }) { suggestion ->
+                    val isDir = suggestion.isDirectory
+                    DropdownMenuItem(
+                        text = {
+                            Box(
+                                modifier = Modifier.fillMaxWidth(),
+                                contentAlignment = Alignment.CenterStart,
+                            ) {
+                                Text(
+                                    text = suggestion.display,
+                                    fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                                    color = MaterialTheme.colorScheme.primary,
+                                )
+                                suggestion.meta?.let { meta ->
+                                    Text(
+                                        text = "  $meta",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            }
+                        },
+                        leadingIcon = {
+                            Icon(
+                                imageVector =
+                                    if (isDir) {
+                                        Icons.Filled.Folder
+                                    } else {
+                                        Icons.AutoMirrored.Filled.InsertDriveFile
+                                    },
+                                contentDescription = null,
+                                modifier = androidx.compose.ui.Modifier.size(18.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        },
+                        onClick = { state.select(suggestion) },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/PathCompletion.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/PathCompletion.kt
@@ -51,7 +51,7 @@ import kotlinx.coroutines.delay
  * completion trigger).
  */
 
-private val PATH_TOKEN_RE = Regex("""@[\w./:\-~]*$""")
+private val PATH_TOKEN_RE = Regex("""(?<!\S)@[\w./:\-~]*$""")
 
 /**
  * Find the `@`-tagged token at the end of [text], or `null` if the caret is
@@ -131,7 +131,7 @@ fun rememberPathCompletions(
         derivedStateOf { if (sessionId != null) findPathToken(input.text) else null }
     }
 
-    LaunchedEffect(token, sessionId) {
+    LaunchedEffect(input.text, sessionId) {
         if (token == null || sessionId == null) {
             suggestions = emptyList()
             isLoading = false
@@ -233,7 +233,7 @@ fun PathCompletionDropdown(state: PathCompletionState) {
                                         Icons.AutoMirrored.Filled.InsertDriveFile
                                     },
                                 contentDescription = null,
-                                modifier = androidx.compose.ui.Modifier.size(18.dp),
+                                modifier = Modifier.size(18.dp),
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         },

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/PathCompletionTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/PathCompletionTest.kt
@@ -1,0 +1,137 @@
+package com.m57.hermescontrol.ui.chat
+
+import com.m57.hermescontrol.data.model.PathSuggestion
+import com.m57.hermescontrol.data.ws.HermesWsClient
+import com.m57.hermescontrol.data.ws.WsMethods
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class PathCompletionTest {
+    @Before
+    fun setUp() {
+        mockkObject(HermesWsClient)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // ── findPathToken ──────────────────────────────────────────────────────
+
+    @Test
+    fun `findPathToken returns trailing @-token`() {
+        assertEquals("@file:", findPathToken("attach @file:"))
+        assertEquals("@file:src/", findPathToken("check @file:src/"))
+        assertEquals("@", findPathToken("type @"))
+        assertEquals("@folder:", findPathToken("with @folder:"))
+    }
+
+    @Test
+    fun `findPathToken returns null when no @ token or @ followed by space`() {
+        assertNull(findPathToken("no token here"))
+        assertNull(findPathToken("type @ done"))
+        // A space after the `@` run ends the token, so it's not active
+        assertNull(findPathToken("ping @ and then text"))
+    }
+
+    // ── replaceActivePathToken ──────────────────────────────────────────────
+
+    @Test
+    fun `replaceActivePathToken swaps the trailing token`() {
+        assertEquals(
+            "attach @file:src/main.kt",
+            replaceActivePathToken("attach @file:", "@file:src/main.kt"),
+        )
+        assertEquals(
+            "check @folder:docs",
+            replaceActivePathToken("check @folder:", "@folder:docs"),
+        )
+        // A token in the middle of the text (caret not at a trailing token) is
+        // replaced at its own position; only the trailing @-run is the trigger.
+        assertEquals(
+            "use @file:a.kt",
+            replaceActivePathToken("use @file:", "@file:a.kt"),
+        )
+    }
+
+    @Test
+    fun `replaceActivePathToken leaves text unchanged with no token`() {
+        assertEquals("plain text", replaceActivePathToken("plain text", "@file:x"))
+    }
+
+    // ── PathSuggestion.fromMap ──────────────────────────────────────────────
+
+    @Test
+    fun `fromMap builds suggestion with dir flag from trailing slash`() {
+        val s = PathSuggestion.fromMap(mapOf("text" to "@folder:src/", "display" to "src", "meta" to "dir"))
+        assertEquals("@folder:src/", s?.text)
+        assertEquals("src", s?.display)
+        assertEquals(true, s?.isDirectory)
+    }
+
+    @Test
+    fun `fromMap builds file suggestion and infers dir from meta`() {
+        val s = PathSuggestion.fromMap(mapOf("text" to "@file:README.md", "display" to "README.md"))
+        assertEquals("@file:README.md", s?.text)
+        assertEquals("README.md", s?.display)
+        assertEquals(false, s?.isDirectory)
+    }
+
+    @Test
+    fun `fromMap returns null without text`() {
+        assertNull(PathSuggestion.fromMap(mapOf("display" to "x")))
+        assertNull(PathSuggestion.fromMap(mapOf("text" to "")))
+    }
+
+    // ── fetchPathSuggestions (RPC wiring) ───────────────────────────────────
+
+    @Test
+    fun `fetchPathSuggestions calls complete_path with session_id and word`() =
+        runTest {
+            val captured = mutableListOf<Map<String, Any>>()
+            every {
+                HermesWsClient.request(WsMethods.COMPLETE_PATH, capture(captured))
+            } answers {
+                CompletableDeferred(
+                    mapOf(
+                        "items" to
+                            listOf(
+                                mapOf("text" to "@file:src/main.kt", "display" to "main.kt"),
+                                mapOf("text" to "@file:src/util.kt", "display" to "util.kt"),
+                            ),
+                    ),
+                )
+            }
+
+            val result = fetchPathSuggestions("session-1", "@file:src/")
+
+            assertEquals(1, captured.size)
+            assertEquals("session-1", captured[0]["session_id"])
+            assertEquals("@file:src/", captured[0]["word"])
+            assertEquals(2, result.size)
+            assertEquals("@file:src/main.kt", result[0].text)
+            assertEquals("@file:src/util.kt", result[1].text)
+        }
+
+    @Test
+    fun `fetchPathSuggestions returns empty list on RPC failure`() =
+        runTest {
+            every {
+                HermesWsClient.request(WsMethods.COMPLETE_PATH, any())
+            } answers {
+                CompletableDeferred<Any?>(null).also { it.completeExceptionally(RuntimeException("boom")) }
+            }
+
+            val result = fetchPathSuggestions("session-1", "@file:")
+            assertEquals(emptyList<PathSuggestion>(), result)
+        }
+}

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/PathCompletionTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/PathCompletionTest.kt
@@ -41,6 +41,9 @@ class PathCompletionTest {
         assertNull(findPathToken("type @ done"))
         // A space after the `@` run ends the token, so it's not active
         assertNull(findPathToken("ping @ and then text"))
+        // An `@` glued to a preceding word (email, annotation) is NOT a trigger
+        assertNull(findPathToken("email me@host.com"))
+        assertNull(findPathToken("call foo@bar now"))
     }
 
     // ── replaceActivePathToken ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Implements issue #536 — composer `@file`/`@folder` path autocomplete on mobile, mirroring the desktop composer's `complete.path` usage.

- **`WsMethods.COMPLETE_PATH`** — new `complete.path` RPC constant.
- **`PathSuggestion`** model — parses gateway completion items (`text`/`display`/`meta`, dir flag).
- **`PathCompletion.kt`** — `findPathToken` (detects a trailing `@`-token), `fetchPathSuggestions` (awaits `complete.path` via `HermesWsClient.request`, 120s timeout + disconnect rejection), `rememberPathCompletions` (250ms debounce + race guard) and `PathCompletionDropdown` UI.
- **`ChatScreen`** — composer now holds a `TextFieldValue`; on `@` trigger the dropdown shows suggestions and selecting one inserts the `@file:`/`@folder:` token. `cwd` is intentionally omitted (mobile has no local cwd) — the gateway resolves it from the session record, exactly as desktop does when `cwd` is empty.
- **Tests** — `PathCompletionTest` covers token detection, replacement, model parsing, and the RPC wiring/failure path (MockK).

The inserted `@file:`/`@folder:` token flows through the existing `sendMessage` path, so it reaches the agent unchanged — no attach-flow change required (consistent with desktop).

## Test plan
- [x] `./ktlint` clean on all changed files
- [x] `./gradlew testDebugUnitTest --tests PathCompletionTest --tests ChatViewModelTest` — green (no regression)
- [x] `./gradlew compileReleaseKotlin` — green

Closes #536