### PR TITLE
fix(#548): stop System tab button text truncation + fix two wrong labels

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/system/SystemScreen.kt
@@ -389,7 +389,7 @@ private fun LazyListScope.hostSection(
                                 Icon(Icons.Filled.Update, contentDescription = null, modifier = Modifier.size(18.dp))
                                 Spacer(modifier = Modifier.size(spacing.xs))
                             }
-                            Text(stringResource(R.string.system_action_check_updates), maxLines = 1)
+                            Text(stringResource(R.string.system_action_check_updates), maxLines = 1, softWrap = false)
                         }
                         state.updateInfo?.let { info ->
                             if (info.update_available == true && info.can_apply == true) {
@@ -403,7 +403,11 @@ private fun LazyListScope.hostSection(
                                         modifier = Modifier.size(18.dp),
                                     )
                                     Spacer(modifier = Modifier.size(spacing.xs))
-                                    Text(stringResource(R.string.system_action_update_now), maxLines = 1)
+                                    Text(
+                                        stringResource(R.string.system_action_update_now),
+                                        maxLines = 1,
+                                        softWrap = false,
+                                    )
                                 }
                             }
                         }
@@ -571,7 +575,11 @@ private fun LazyListScope.portalSection(
                         ) {
                             Icon(Icons.Filled.Link, contentDescription = null, modifier = Modifier.size(16.dp))
                             Spacer(modifier = Modifier.size(spacing.xs))
-                            Text(stringResource(R.string.system_portal_manage_subscription))
+                            Text(
+                                stringResource(R.string.system_portal_manage_subscription),
+                                maxLines = 1,
+                                softWrap = false,
+                            )
                         }
                     }
 
@@ -676,11 +684,11 @@ private fun LazyListScope.curatorSection(
                                         modifier = Modifier.size(18.dp),
                                     )
                                     Spacer(modifier = Modifier.size(spacing.xs))
-                                    Text(stringResource(R.string.system_curator_resume), maxLines = 1)
+                                    Text(stringResource(R.string.system_curator_resume), maxLines = 1, softWrap = false)
                                 } else {
                                     Icon(Icons.Filled.Pause, contentDescription = null, modifier = Modifier.size(18.dp))
                                     Spacer(modifier = Modifier.size(spacing.xs))
-                                    Text(stringResource(R.string.system_curator_pause), maxLines = 1)
+                                    Text(stringResource(R.string.system_curator_pause), maxLines = 1, softWrap = false)
                                 }
                             }
                             Button(
@@ -689,7 +697,7 @@ private fun LazyListScope.curatorSection(
                             ) {
                                 Icon(Icons.Filled.Refresh, contentDescription = null, modifier = Modifier.size(18.dp))
                                 Spacer(modifier = Modifier.size(spacing.xs))
-                                Text(stringResource(R.string.system_curator_run_now), maxLines = 1)
+                                Text(stringResource(R.string.system_curator_run_now), maxLines = 1, softWrap = false)
                             }
                         }
                     }
@@ -815,7 +823,7 @@ private fun LazyListScope.gatewaySection(
                             ) {
                                 Icon(Icons.Filled.PlayArrow, contentDescription = null, modifier = Modifier.size(18.dp))
                                 Spacer(modifier = Modifier.size(spacing.xs))
-                                Text(stringResource(R.string.system_gateway_start), maxLines = 1)
+                                Text(stringResource(R.string.system_gateway_start), maxLines = 1, softWrap = false)
                             }
                         }
                         if (isRunning) {
@@ -829,7 +837,7 @@ private fun LazyListScope.gatewaySection(
                                     modifier = Modifier.size(18.dp),
                                 )
                                 Spacer(modifier = Modifier.size(spacing.xs))
-                                Text(stringResource(R.string.system_gateway_restart), maxLines = 1)
+                                Text(stringResource(R.string.system_gateway_restart), maxLines = 1, softWrap = false)
                             }
                             OutlinedButton(
                                 onClick = { viewModel.stopGateway() },
@@ -918,7 +926,11 @@ private fun LazyListScope.memorySection(
                             ) {
                                 Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(14.dp))
                                 Spacer(modifier = Modifier.size(spacing.xs))
-                                Text(stringResource(R.string.system_memory_reset_memory), maxLines = 1)
+                                Text(
+                                    stringResource(R.string.system_memory_reset_memory),
+                                    maxLines = 1,
+                                    softWrap = false,
+                                )
                             }
                             FilledTonalButton(
                                 onClick = { onResetRequest("user") },
@@ -926,7 +938,7 @@ private fun LazyListScope.memorySection(
                             ) {
                                 Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(14.dp))
                                 Spacer(modifier = Modifier.size(spacing.xs))
-                                Text(stringResource(R.string.system_memory_reset_user), maxLines = 1)
+                                Text(stringResource(R.string.system_memory_reset_user), maxLines = 1, softWrap = false)
                             }
                             FilledTonalButton(
                                 onClick = { onResetRequest("all") },
@@ -938,7 +950,7 @@ private fun LazyListScope.memorySection(
                                     modifier = Modifier.size(14.dp),
                                 )
                                 Spacer(modifier = Modifier.size(spacing.xs))
-                                Text(stringResource(R.string.system_memory_reset_all), maxLines = 1)
+                                Text(stringResource(R.string.system_memory_reset_all), maxLines = 1, softWrap = false)
                             }
                         }
                     }
@@ -1032,7 +1044,7 @@ private fun LazyListScope.credentialsSection(
                         Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(18.dp))
                         Spacer(modifier = Modifier.size(spacing.xs))
                     }
-                    Text(stringResource(R.string.system_credentials_add_key))
+                    Text(stringResource(R.string.system_credentials_add_key), maxLines = 1, softWrap = false)
                 }
 
                 HorizontalDivider(modifier = Modifier.padding(vertical = spacing.sm))
@@ -1101,7 +1113,7 @@ private fun LazyListScope.operationsSection(
                     ) {
                         Icon(Icons.Filled.HealthAndSafety, contentDescription = null, modifier = Modifier.size(16.dp))
                         Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_doctor), maxLines = 1)
+                        Text(stringResource(R.string.system_op_doctor), maxLines = 1, softWrap = false)
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runSecurityAudit() },
@@ -1109,7 +1121,7 @@ private fun LazyListScope.operationsSection(
                     ) {
                         Icon(Icons.Filled.VerifiedUser, contentDescription = null, modifier = Modifier.size(16.dp))
                         Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_security_audit), maxLines = 1)
+                        Text(stringResource(R.string.system_op_security_audit), maxLines = 1, softWrap = false)
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runUpdateSkills() },
@@ -1117,7 +1129,7 @@ private fun LazyListScope.operationsSection(
                     ) {
                         Icon(Icons.Filled.Refresh, contentDescription = null, modifier = Modifier.size(16.dp))
                         Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_update_skills), maxLines = 1)
+                        Text(stringResource(R.string.system_op_update_skills), maxLines = 1, softWrap = false)
                     }
                 }
 
@@ -1134,7 +1146,7 @@ private fun LazyListScope.operationsSection(
                     ) {
                         Icon(Icons.Filled.HealthAndSafety, contentDescription = null, modifier = Modifier.size(16.dp))
                         Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_prompt_size), maxLines = 1)
+                        Text(stringResource(R.string.system_op_prompt_size), maxLines = 1, softWrap = false)
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runDump() },
@@ -1142,7 +1154,7 @@ private fun LazyListScope.operationsSection(
                     ) {
                         Icon(Icons.Filled.Build, contentDescription = null, modifier = Modifier.size(16.dp))
                         Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_dump), maxLines = 1)
+                        Text(stringResource(R.string.system_op_dump), maxLines = 1, softWrap = false)
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runConfigMigrate() },
@@ -1150,7 +1162,7 @@ private fun LazyListScope.operationsSection(
                     ) {
                         Icon(Icons.Filled.Build, contentDescription = null, modifier = Modifier.size(16.dp))
                         Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_config_migrate), maxLines = 1)
+                        Text(stringResource(R.string.system_op_config_migrate), maxLines = 1, softWrap = false)
                     }
                 }
 
@@ -1158,7 +1170,7 @@ private fun LazyListScope.operationsSection(
 
                 // Backup section
                 Text(
-                    text = stringResource(R.string.system_op_backup_create),
+                    text = stringResource(R.string.system_sec_backup),
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.SemiBold,
                 )
@@ -1174,7 +1186,7 @@ private fun LazyListScope.operationsSection(
                     ) {
                         Icon(Icons.Filled.Backup, contentDescription = null, modifier = Modifier.size(18.dp))
                         Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_backup_create), maxLines = 1)
+                        Text(stringResource(R.string.system_op_backup_create), maxLines = 1, softWrap = false)
                     }
                     OutlinedButton(
                         onClick = { viewModel.downloadBackup() },
@@ -1183,14 +1195,14 @@ private fun LazyListScope.operationsSection(
                     ) {
                         Icon(Icons.Filled.CloudDownload, contentDescription = null, modifier = Modifier.size(18.dp))
                         Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_backup_download), maxLines = 1)
+                        Text(stringResource(R.string.system_op_backup_download), maxLines = 1, softWrap = false)
                     }
                 }
 
                 // Restore from uploaded zip
                 Spacer(modifier = Modifier.height(spacing.sm))
                 Text(
-                    text = stringResource(R.string.system_op_backup_restore_upload),
+                    text = stringResource(R.string.system_sec_restore),
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.SemiBold,
                 )
@@ -1219,7 +1231,7 @@ private fun LazyListScope.operationsSection(
                 ) {
                     Icon(Icons.Filled.RestartAlt, contentDescription = null, modifier = Modifier.size(18.dp))
                     Spacer(modifier = Modifier.size(spacing.xs))
-                    Text(stringResource(R.string.system_op_restore_upload))
+                    Text(stringResource(R.string.system_op_restore_upload), maxLines = 1, softWrap = false)
                 }
 
                 HorizontalDivider(modifier = Modifier.padding(vertical = spacing.sm))
@@ -1270,6 +1282,8 @@ private fun LazyListScope.operationsSection(
                         } else {
                             stringResource(R.string.system_debug_share_generate)
                         },
+                        maxLines = 1,
+                        softWrap = false,
                     )
                 }
 
@@ -1288,7 +1302,7 @@ private fun LazyListScope.operationsSection(
                                 if (share.ok == true) {
                                     stringResource(R.string.system_debug_share_uploaded)
                                 } else {
-                                    stringResource(R.string.system_status_stopped)
+                                    stringResource(R.string.system_debug_share_failed)
                                 },
                             status = if (share.ok == true) StatusBadgeType.SUCCESS else StatusBadgeType.ERROR,
                         )
@@ -1384,7 +1398,7 @@ private fun LazyListScope.checkpointsSection(
                     ) {
                         Icon(Icons.Filled.DeleteForever, contentDescription = null, modifier = Modifier.size(18.dp))
                         Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_checkpoints_prune))
+                        Text(stringResource(R.string.system_checkpoints_prune), maxLines = 1, softWrap = false)
                     }
                 }
             }
@@ -1406,7 +1420,7 @@ private fun LazyListScope.shellHooksSection(
                 FilledTonalButton(onClick = { viewModel.toggleHookModal() }) {
                     Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.size(16.dp))
                     Spacer(modifier = Modifier.size(spacing.xs))
-                    Text(stringResource(R.string.system_hooks_new))
+                    Text(stringResource(R.string.system_hooks_new), maxLines = 1, softWrap = false)
                 }
             },
         )

--- a/app/src/main/java/com/m57/hermescontrol/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/system/SystemScreen.kt
@@ -65,9 +65,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.m57.hermescontrol.R
@@ -380,32 +380,32 @@ private fun LazyListScope.hostSection(
                             onClick = { viewModel.checkForUpdate(false) },
                             enabled = !state.checkingUpdate,
                             modifier = Modifier.weight(1f),
+                            contentPadding = actionButtonPadding,
                         ) {
                             if (state.checkingUpdate) {
-                                androidx.compose.material3.CircularProgressIndicator(
-                                    modifier = Modifier.size(16.dp),
-                                    strokeWidth = 2.dp,
+                                ActionButtonContent(
+                                    icon = null,
+                                    text = stringResource(R.string.system_action_check_updates),
+                                    loading = true,
                                 )
-                                Spacer(modifier = Modifier.size(spacing.sm))
                             } else {
-                                Icon(Icons.Filled.Update, contentDescription = null, modifier = Modifier.size(16.dp))
-                                Spacer(modifier = Modifier.size(spacing.xs))
+                                ActionButtonContent(
+                                    icon = Icons.Filled.Update,
+                                    text = stringResource(R.string.system_action_check_updates),
+                                )
                             }
-                            AutoScaleButtonText(stringResource(R.string.system_action_check_updates))
                         }
                         state.updateInfo?.let { info ->
                             if (info.update_available == true && info.can_apply == true) {
                                 Button(
                                     onClick = { viewModel.openUpdateConfirm() },
                                     modifier = Modifier.weight(1f),
+                                    contentPadding = actionButtonPadding,
                                 ) {
-                                    Icon(
-                                        Icons.Filled.PlayArrow,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(16.dp),
+                                    ActionButtonContent(
+                                        icon = Icons.Filled.PlayArrow,
+                                        text = stringResource(R.string.system_action_update_now),
                                     )
-                                    Spacer(modifier = Modifier.size(spacing.xs))
-                                    AutoScaleButtonText(stringResource(R.string.system_action_update_now))
                                 }
                             }
                         }
@@ -674,28 +674,29 @@ private fun LazyListScope.curatorSection(
                             OutlinedButton(
                                 onClick = { viewModel.toggleCuratorPaused() },
                                 modifier = Modifier.weight(1f),
+                                contentPadding = actionButtonPadding,
                             ) {
                                 if (curator.paused == true) {
-                                    Icon(
-                                        Icons.Filled.PlayArrow,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(16.dp),
+                                    ActionButtonContent(
+                                        icon = Icons.Filled.PlayArrow,
+                                        text = stringResource(R.string.system_curator_resume),
                                     )
-                                    Spacer(modifier = Modifier.size(spacing.xs))
-                                    AutoScaleButtonText(stringResource(R.string.system_curator_resume))
                                 } else {
-                                    Icon(Icons.Filled.Pause, contentDescription = null, modifier = Modifier.size(16.dp))
-                                    Spacer(modifier = Modifier.size(spacing.xs))
-                                    AutoScaleButtonText(stringResource(R.string.system_curator_pause))
+                                    ActionButtonContent(
+                                        icon = Icons.Filled.Pause,
+                                        text = stringResource(R.string.system_curator_pause),
+                                    )
                                 }
                             }
                             Button(
                                 onClick = { viewModel.runCuratorNow() },
                                 modifier = Modifier.weight(1f),
+                                contentPadding = actionButtonPadding,
                             ) {
-                                Icon(Icons.Filled.Refresh, contentDescription = null, modifier = Modifier.size(16.dp))
-                                Spacer(modifier = Modifier.size(spacing.xs))
-                                AutoScaleButtonText(stringResource(R.string.system_curator_run_now))
+                                ActionButtonContent(
+                                    icon = Icons.Filled.Refresh,
+                                    text = stringResource(R.string.system_curator_run_now),
+                                )
                             }
                         }
                     }
@@ -818,39 +819,35 @@ private fun LazyListScope.gatewaySection(
                             Button(
                                 onClick = { viewModel.startGateway() },
                                 modifier = Modifier.weight(1f),
+                                contentPadding = actionButtonPadding,
                             ) {
-                                Icon(Icons.Filled.PlayArrow, contentDescription = null, modifier = Modifier.size(16.dp))
-                                Spacer(modifier = Modifier.size(spacing.xs))
-                                AutoScaleButtonText(stringResource(R.string.system_gateway_start))
+                                ActionButtonContent(
+                                    icon = Icons.Filled.PlayArrow,
+                                    text = stringResource(R.string.system_gateway_start),
+                                )
                             }
                         }
                         if (isRunning) {
                             Button(
                                 onClick = { viewModel.restartGateway() },
                                 modifier = Modifier.weight(1f),
+                                contentPadding = actionButtonPadding,
                             ) {
-                                Icon(
-                                    Icons.Filled.RestartAlt,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(16.dp),
+                                ActionButtonContent(
+                                    icon = Icons.Filled.RestartAlt,
+                                    text = stringResource(R.string.system_gateway_restart),
                                 )
-                                Spacer(modifier = Modifier.size(spacing.xs))
-                                AutoScaleButtonText(stringResource(R.string.system_gateway_restart))
                             }
                             OutlinedButton(
                                 onClick = { viewModel.stopGateway() },
                                 modifier = Modifier.weight(1f),
+                                contentPadding = actionButtonPadding,
                             ) {
-                                Icon(
-                                    Icons.Filled.Stop,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(16.dp),
-                                    tint = MaterialTheme.colorScheme.error,
-                                )
-                                Spacer(modifier = Modifier.size(spacing.xs))
-                                AutoScaleButtonText(
-                                    stringResource(R.string.system_gateway_stop),
-                                    color = MaterialTheme.colorScheme.error,
+                                ActionButtonContent(
+                                    icon = Icons.Filled.Stop,
+                                    text = stringResource(R.string.system_gateway_stop),
+                                    iconTint = MaterialTheme.colorScheme.error,
+                                    textColor = MaterialTheme.colorScheme.error,
                                 )
                             }
                         }
@@ -920,30 +917,32 @@ private fun LazyListScope.memorySection(
                             FilledTonalButton(
                                 onClick = { onResetRequest("memory") },
                                 modifier = Modifier.weight(1f),
+                                contentPadding = actionButtonPadding,
                             ) {
-                                Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(14.dp))
-                                Spacer(modifier = Modifier.size(spacing.xs))
-                                AutoScaleButtonText(stringResource(R.string.system_memory_reset_memory))
+                                ActionButtonContent(
+                                    icon = Icons.Filled.Delete,
+                                    text = stringResource(R.string.system_memory_reset_memory),
+                                )
                             }
                             FilledTonalButton(
                                 onClick = { onResetRequest("user") },
                                 modifier = Modifier.weight(1f),
+                                contentPadding = actionButtonPadding,
                             ) {
-                                Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(14.dp))
-                                Spacer(modifier = Modifier.size(spacing.xs))
-                                AutoScaleButtonText(stringResource(R.string.system_memory_reset_user))
+                                ActionButtonContent(
+                                    icon = Icons.Filled.Delete,
+                                    text = stringResource(R.string.system_memory_reset_user),
+                                )
                             }
                             FilledTonalButton(
                                 onClick = { onResetRequest("all") },
                                 modifier = Modifier.weight(1f),
+                                contentPadding = actionButtonPadding,
                             ) {
-                                Icon(
-                                    Icons.Filled.DeleteForever,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(14.dp),
+                                ActionButtonContent(
+                                    icon = Icons.Filled.DeleteForever,
+                                    text = stringResource(R.string.system_memory_reset_all),
                                 )
-                                Spacer(modifier = Modifier.size(spacing.xs))
-                                AutoScaleButtonText(stringResource(R.string.system_memory_reset_all))
                             }
                         }
                     }
@@ -1103,26 +1102,32 @@ private fun LazyListScope.operationsSection(
                             viewModel.loadAll()
                         },
                         modifier = Modifier.weight(1f),
+                        contentPadding = actionButtonPadding,
                     ) {
-                        Icon(Icons.Filled.HealthAndSafety, contentDescription = null, modifier = Modifier.size(16.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        AutoScaleButtonText(stringResource(R.string.system_op_doctor))
+                        ActionButtonContent(
+                            icon = Icons.Filled.HealthAndSafety,
+                            text = stringResource(R.string.system_op_doctor),
+                        )
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runSecurityAudit() },
                         modifier = Modifier.weight(1f),
+                        contentPadding = actionButtonPadding,
                     ) {
-                        Icon(Icons.Filled.VerifiedUser, contentDescription = null, modifier = Modifier.size(16.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        AutoScaleButtonText(stringResource(R.string.system_op_security_audit))
+                        ActionButtonContent(
+                            icon = Icons.Filled.VerifiedUser,
+                            text = stringResource(R.string.system_op_security_audit),
+                        )
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runUpdateSkills() },
                         modifier = Modifier.weight(1f),
+                        contentPadding = actionButtonPadding,
                     ) {
-                        Icon(Icons.Filled.Refresh, contentDescription = null, modifier = Modifier.size(16.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        AutoScaleButtonText(stringResource(R.string.system_op_update_skills))
+                        ActionButtonContent(
+                            icon = Icons.Filled.Refresh,
+                            text = stringResource(R.string.system_op_update_skills),
+                        )
                     }
                 }
 
@@ -1136,26 +1141,32 @@ private fun LazyListScope.operationsSection(
                     FilledTonalButton(
                         onClick = { viewModel.runPromptSize() },
                         modifier = Modifier.weight(1f),
+                        contentPadding = actionButtonPadding,
                     ) {
-                        Icon(Icons.Filled.HealthAndSafety, contentDescription = null, modifier = Modifier.size(16.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        AutoScaleButtonText(stringResource(R.string.system_op_prompt_size))
+                        ActionButtonContent(
+                            icon = Icons.Filled.HealthAndSafety,
+                            text = stringResource(R.string.system_op_prompt_size),
+                        )
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runDump() },
                         modifier = Modifier.weight(1f),
+                        contentPadding = actionButtonPadding,
                     ) {
-                        Icon(Icons.Filled.Build, contentDescription = null, modifier = Modifier.size(16.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        AutoScaleButtonText(stringResource(R.string.system_op_dump))
+                        ActionButtonContent(
+                            icon = Icons.Filled.Build,
+                            text = stringResource(R.string.system_op_dump),
+                        )
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runConfigMigrate() },
                         modifier = Modifier.weight(1f),
+                        contentPadding = actionButtonPadding,
                     ) {
-                        Icon(Icons.Filled.Build, contentDescription = null, modifier = Modifier.size(16.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        AutoScaleButtonText(stringResource(R.string.system_op_config_migrate))
+                        ActionButtonContent(
+                            icon = Icons.Filled.Build,
+                            text = stringResource(R.string.system_op_config_migrate),
+                        )
                     }
                 }
 
@@ -1176,19 +1187,23 @@ private fun LazyListScope.operationsSection(
                     Button(
                         onClick = { viewModel.triggerBackup() },
                         modifier = Modifier.weight(1f),
+                        contentPadding = actionButtonPadding,
                     ) {
-                        Icon(Icons.Filled.Backup, contentDescription = null, modifier = Modifier.size(16.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        AutoScaleButtonText(stringResource(R.string.system_op_backup_create))
+                        ActionButtonContent(
+                            icon = Icons.Filled.Backup,
+                            text = stringResource(R.string.system_op_backup_create),
+                        )
                     }
                     OutlinedButton(
                         onClick = { viewModel.downloadBackup() },
                         enabled = state.backupArchive != null,
                         modifier = Modifier.weight(1f),
+                        contentPadding = actionButtonPadding,
                     ) {
-                        Icon(Icons.Filled.CloudDownload, contentDescription = null, modifier = Modifier.size(16.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        AutoScaleButtonText(stringResource(R.string.system_op_backup_download))
+                        ActionButtonContent(
+                            icon = Icons.Filled.CloudDownload,
+                            text = stringResource(R.string.system_op_backup_download),
+                        )
                     }
                 }
 
@@ -1620,32 +1635,37 @@ private fun LazyListScope.actionLogSection(
     }
 }
 
+private val actionButtonPadding =
+    androidx.compose.foundation.layout.PaddingValues(horizontal = 8.dp, vertical = 8.dp)
+
 @Composable
-private fun AutoScaleButtonText(
+private fun ActionButtonContent(
+    icon: ImageVector?,
     text: String,
-    modifier: Modifier = Modifier,
-    color: androidx.compose.ui.graphics.Color = androidx.compose.ui.graphics.Color.Unspecified,
+    iconTint: androidx.compose.ui.graphics.Color = androidx.compose.material3.LocalContentColor.current,
+    textColor: androidx.compose.ui.graphics.Color = androidx.compose.ui.graphics.Color.Unspecified,
+    loading: Boolean = false,
 ) {
-    val style =
-        when {
-            text.length >= 15 ->
-                MaterialTheme.typography.labelSmall.copy(
-                    fontSize = 10.sp,
-                    fontWeight = FontWeight.SemiBold,
-                )
-            text.length >= 11 ->
-                MaterialTheme.typography.labelSmall.copy(
-                    fontSize = 11.sp,
-                    fontWeight = FontWeight.SemiBold,
-                )
-            else -> MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.SemiBold)
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        if (loading) {
+            androidx.compose.material3.CircularProgressIndicator(
+                modifier = Modifier.size(18.dp),
+                strokeWidth = 2.dp,
+            )
+        } else if (icon != null) {
+            Icon(icon, contentDescription = null, modifier = Modifier.size(18.dp), tint = iconTint)
         }
-    Text(
-        text = text,
-        style = style,
-        color = color,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
-        modifier = modifier,
-    )
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            color = textColor,
+            textAlign = TextAlign.Center,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/system/SystemScreen.kt
@@ -16,27 +16,16 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Backup
-import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.ContentCopy
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.Devices
-import androidx.compose.material.icons.filled.HealthAndSafety
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.Memory
-import androidx.compose.material.icons.filled.Pause
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.RestartAlt
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Speed
-import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.Storage
-import androidx.compose.material.icons.filled.Update
-import androidx.compose.material.icons.filled.VerifiedUser
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -385,11 +374,8 @@ private fun LazyListScope.hostSection(
                                     strokeWidth = 2.dp,
                                 )
                                 Spacer(modifier = Modifier.size(spacing.sm))
-                            } else {
-                                Icon(Icons.Filled.Update, contentDescription = null, modifier = Modifier.size(18.dp))
-                                Spacer(modifier = Modifier.size(spacing.xs))
                             }
-                            Text(stringResource(R.string.system_action_check_updates), maxLines = 1, softWrap = false)
+                            Text(stringResource(R.string.system_action_check_updates))
                         }
                         state.updateInfo?.let { info ->
                             if (info.update_available == true && info.can_apply == true) {
@@ -397,17 +383,7 @@ private fun LazyListScope.hostSection(
                                     onClick = { viewModel.openUpdateConfirm() },
                                     modifier = Modifier.weight(1f),
                                 ) {
-                                    Icon(
-                                        Icons.Filled.PlayArrow,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(18.dp),
-                                    )
-                                    Spacer(modifier = Modifier.size(spacing.xs))
-                                    Text(
-                                        stringResource(R.string.system_action_update_now),
-                                        maxLines = 1,
-                                        softWrap = false,
-                                    )
+                                    Text(stringResource(R.string.system_action_update_now))
                                 }
                             }
                         }
@@ -678,26 +654,16 @@ private fun LazyListScope.curatorSection(
                                 modifier = Modifier.weight(1f),
                             ) {
                                 if (curator.paused == true) {
-                                    Icon(
-                                        Icons.Filled.PlayArrow,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(18.dp),
-                                    )
-                                    Spacer(modifier = Modifier.size(spacing.xs))
-                                    Text(stringResource(R.string.system_curator_resume), maxLines = 1, softWrap = false)
+                                    Text(stringResource(R.string.system_curator_resume))
                                 } else {
-                                    Icon(Icons.Filled.Pause, contentDescription = null, modifier = Modifier.size(18.dp))
-                                    Spacer(modifier = Modifier.size(spacing.xs))
-                                    Text(stringResource(R.string.system_curator_pause), maxLines = 1, softWrap = false)
+                                    Text(stringResource(R.string.system_curator_pause))
                                 }
                             }
                             Button(
                                 onClick = { viewModel.runCuratorNow() },
                                 modifier = Modifier.weight(1f),
                             ) {
-                                Icon(Icons.Filled.Refresh, contentDescription = null, modifier = Modifier.size(18.dp))
-                                Spacer(modifier = Modifier.size(spacing.xs))
-                                Text(stringResource(R.string.system_curator_run_now), maxLines = 1, softWrap = false)
+                                Text(stringResource(R.string.system_curator_run_now))
                             }
                         }
                     }
@@ -821,9 +787,7 @@ private fun LazyListScope.gatewaySection(
                                 onClick = { viewModel.startGateway() },
                                 modifier = Modifier.weight(1f),
                             ) {
-                                Icon(Icons.Filled.PlayArrow, contentDescription = null, modifier = Modifier.size(18.dp))
-                                Spacer(modifier = Modifier.size(spacing.xs))
-                                Text(stringResource(R.string.system_gateway_start), maxLines = 1, softWrap = false)
+                                Text(stringResource(R.string.system_gateway_start))
                             }
                         }
                         if (isRunning) {
@@ -831,29 +795,15 @@ private fun LazyListScope.gatewaySection(
                                 onClick = { viewModel.restartGateway() },
                                 modifier = Modifier.weight(1f),
                             ) {
-                                Icon(
-                                    Icons.Filled.RestartAlt,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(18.dp),
-                                )
-                                Spacer(modifier = Modifier.size(spacing.xs))
-                                Text(stringResource(R.string.system_gateway_restart), maxLines = 1, softWrap = false)
+                                Text(stringResource(R.string.system_gateway_restart))
                             }
                             OutlinedButton(
                                 onClick = { viewModel.stopGateway() },
                                 modifier = Modifier.weight(1f),
                             ) {
-                                Icon(
-                                    Icons.Filled.Stop,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(18.dp),
-                                    tint = MaterialTheme.colorScheme.error,
-                                )
-                                Spacer(modifier = Modifier.size(spacing.xs))
                                 Text(
                                     stringResource(R.string.system_gateway_stop),
                                     color = MaterialTheme.colorScheme.error,
-                                    maxLines = 1,
                                 )
                             }
                         }
@@ -924,33 +874,19 @@ private fun LazyListScope.memorySection(
                                 onClick = { onResetRequest("memory") },
                                 modifier = Modifier.weight(1f),
                             ) {
-                                Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(14.dp))
-                                Spacer(modifier = Modifier.size(spacing.xs))
-                                Text(
-                                    stringResource(R.string.system_memory_reset_memory),
-                                    maxLines = 1,
-                                    softWrap = false,
-                                )
+                                Text(stringResource(R.string.system_memory_reset_memory))
                             }
                             FilledTonalButton(
                                 onClick = { onResetRequest("user") },
                                 modifier = Modifier.weight(1f),
                             ) {
-                                Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(14.dp))
-                                Spacer(modifier = Modifier.size(spacing.xs))
-                                Text(stringResource(R.string.system_memory_reset_user), maxLines = 1, softWrap = false)
+                                Text(stringResource(R.string.system_memory_reset_user))
                             }
                             FilledTonalButton(
                                 onClick = { onResetRequest("all") },
                                 modifier = Modifier.weight(1f),
                             ) {
-                                Icon(
-                                    Icons.Filled.DeleteForever,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(14.dp),
-                                )
-                                Spacer(modifier = Modifier.size(spacing.xs))
-                                Text(stringResource(R.string.system_memory_reset_all), maxLines = 1, softWrap = false)
+                                Text(stringResource(R.string.system_memory_reset_all))
                             }
                         }
                     }
@@ -1111,25 +1047,19 @@ private fun LazyListScope.operationsSection(
                         },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Icon(Icons.Filled.HealthAndSafety, contentDescription = null, modifier = Modifier.size(16.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_doctor), maxLines = 1, softWrap = false)
+                        Text(stringResource(R.string.system_op_doctor))
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runSecurityAudit() },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Icon(Icons.Filled.VerifiedUser, contentDescription = null, modifier = Modifier.size(16.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_security_audit), maxLines = 1, softWrap = false)
+                        Text(stringResource(R.string.system_op_security_audit))
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runUpdateSkills() },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Icon(Icons.Filled.Refresh, contentDescription = null, modifier = Modifier.size(16.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_update_skills), maxLines = 1, softWrap = false)
+                        Text(stringResource(R.string.system_op_update_skills))
                     }
                 }
 
@@ -1144,25 +1074,19 @@ private fun LazyListScope.operationsSection(
                         onClick = { viewModel.runPromptSize() },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Icon(Icons.Filled.HealthAndSafety, contentDescription = null, modifier = Modifier.size(16.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_prompt_size), maxLines = 1, softWrap = false)
+                        Text(stringResource(R.string.system_op_prompt_size))
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runDump() },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Icon(Icons.Filled.Build, contentDescription = null, modifier = Modifier.size(16.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_dump), maxLines = 1, softWrap = false)
+                        Text(stringResource(R.string.system_op_dump))
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runConfigMigrate() },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Icon(Icons.Filled.Build, contentDescription = null, modifier = Modifier.size(16.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_config_migrate), maxLines = 1, softWrap = false)
+                        Text(stringResource(R.string.system_op_config_migrate))
                     }
                 }
 
@@ -1184,18 +1108,14 @@ private fun LazyListScope.operationsSection(
                         onClick = { viewModel.triggerBackup() },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Icon(Icons.Filled.Backup, contentDescription = null, modifier = Modifier.size(18.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_backup_create), maxLines = 1, softWrap = false)
+                        Text(stringResource(R.string.system_op_backup_create))
                     }
                     OutlinedButton(
                         onClick = { viewModel.downloadBackup() },
                         enabled = state.backupArchive != null,
                         modifier = Modifier.weight(1f),
                     ) {
-                        Icon(Icons.Filled.CloudDownload, contentDescription = null, modifier = Modifier.size(18.dp))
-                        Spacer(modifier = Modifier.size(spacing.xs))
-                        Text(stringResource(R.string.system_op_backup_download), maxLines = 1, softWrap = false)
+                        Text(stringResource(R.string.system_op_backup_download))
                     }
                 }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/system/SystemScreen.kt
@@ -16,16 +16,27 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Backup
+import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.Devices
+import androidx.compose.material.icons.filled.HealthAndSafety
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.Memory
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.RestartAlt
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.Storage
+import androidx.compose.material.icons.filled.Update
+import androidx.compose.material.icons.filled.VerifiedUser
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -54,7 +65,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.m57.hermescontrol.R
@@ -374,8 +387,11 @@ private fun LazyListScope.hostSection(
                                     strokeWidth = 2.dp,
                                 )
                                 Spacer(modifier = Modifier.size(spacing.sm))
+                            } else {
+                                Icon(Icons.Filled.Update, contentDescription = null, modifier = Modifier.size(16.dp))
+                                Spacer(modifier = Modifier.size(spacing.xs))
                             }
-                            Text(stringResource(R.string.system_action_check_updates))
+                            AutoScaleButtonText(stringResource(R.string.system_action_check_updates))
                         }
                         state.updateInfo?.let { info ->
                             if (info.update_available == true && info.can_apply == true) {
@@ -383,7 +399,13 @@ private fun LazyListScope.hostSection(
                                     onClick = { viewModel.openUpdateConfirm() },
                                     modifier = Modifier.weight(1f),
                                 ) {
-                                    Text(stringResource(R.string.system_action_update_now))
+                                    Icon(
+                                        Icons.Filled.PlayArrow,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(16.dp),
+                                    )
+                                    Spacer(modifier = Modifier.size(spacing.xs))
+                                    AutoScaleButtonText(stringResource(R.string.system_action_update_now))
                                 }
                             }
                         }
@@ -654,16 +676,26 @@ private fun LazyListScope.curatorSection(
                                 modifier = Modifier.weight(1f),
                             ) {
                                 if (curator.paused == true) {
-                                    Text(stringResource(R.string.system_curator_resume))
+                                    Icon(
+                                        Icons.Filled.PlayArrow,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(16.dp),
+                                    )
+                                    Spacer(modifier = Modifier.size(spacing.xs))
+                                    AutoScaleButtonText(stringResource(R.string.system_curator_resume))
                                 } else {
-                                    Text(stringResource(R.string.system_curator_pause))
+                                    Icon(Icons.Filled.Pause, contentDescription = null, modifier = Modifier.size(16.dp))
+                                    Spacer(modifier = Modifier.size(spacing.xs))
+                                    AutoScaleButtonText(stringResource(R.string.system_curator_pause))
                                 }
                             }
                             Button(
                                 onClick = { viewModel.runCuratorNow() },
                                 modifier = Modifier.weight(1f),
                             ) {
-                                Text(stringResource(R.string.system_curator_run_now))
+                                Icon(Icons.Filled.Refresh, contentDescription = null, modifier = Modifier.size(16.dp))
+                                Spacer(modifier = Modifier.size(spacing.xs))
+                                AutoScaleButtonText(stringResource(R.string.system_curator_run_now))
                             }
                         }
                     }
@@ -787,7 +819,9 @@ private fun LazyListScope.gatewaySection(
                                 onClick = { viewModel.startGateway() },
                                 modifier = Modifier.weight(1f),
                             ) {
-                                Text(stringResource(R.string.system_gateway_start))
+                                Icon(Icons.Filled.PlayArrow, contentDescription = null, modifier = Modifier.size(16.dp))
+                                Spacer(modifier = Modifier.size(spacing.xs))
+                                AutoScaleButtonText(stringResource(R.string.system_gateway_start))
                             }
                         }
                         if (isRunning) {
@@ -795,13 +829,26 @@ private fun LazyListScope.gatewaySection(
                                 onClick = { viewModel.restartGateway() },
                                 modifier = Modifier.weight(1f),
                             ) {
-                                Text(stringResource(R.string.system_gateway_restart))
+                                Icon(
+                                    Icons.Filled.RestartAlt,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(16.dp),
+                                )
+                                Spacer(modifier = Modifier.size(spacing.xs))
+                                AutoScaleButtonText(stringResource(R.string.system_gateway_restart))
                             }
                             OutlinedButton(
                                 onClick = { viewModel.stopGateway() },
                                 modifier = Modifier.weight(1f),
                             ) {
-                                Text(
+                                Icon(
+                                    Icons.Filled.Stop,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(16.dp),
+                                    tint = MaterialTheme.colorScheme.error,
+                                )
+                                Spacer(modifier = Modifier.size(spacing.xs))
+                                AutoScaleButtonText(
                                     stringResource(R.string.system_gateway_stop),
                                     color = MaterialTheme.colorScheme.error,
                                 )
@@ -874,19 +921,29 @@ private fun LazyListScope.memorySection(
                                 onClick = { onResetRequest("memory") },
                                 modifier = Modifier.weight(1f),
                             ) {
-                                Text(stringResource(R.string.system_memory_reset_memory))
+                                Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(14.dp))
+                                Spacer(modifier = Modifier.size(spacing.xs))
+                                AutoScaleButtonText(stringResource(R.string.system_memory_reset_memory))
                             }
                             FilledTonalButton(
                                 onClick = { onResetRequest("user") },
                                 modifier = Modifier.weight(1f),
                             ) {
-                                Text(stringResource(R.string.system_memory_reset_user))
+                                Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(14.dp))
+                                Spacer(modifier = Modifier.size(spacing.xs))
+                                AutoScaleButtonText(stringResource(R.string.system_memory_reset_user))
                             }
                             FilledTonalButton(
                                 onClick = { onResetRequest("all") },
                                 modifier = Modifier.weight(1f),
                             ) {
-                                Text(stringResource(R.string.system_memory_reset_all))
+                                Icon(
+                                    Icons.Filled.DeleteForever,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(14.dp),
+                                )
+                                Spacer(modifier = Modifier.size(spacing.xs))
+                                AutoScaleButtonText(stringResource(R.string.system_memory_reset_all))
                             }
                         }
                     }
@@ -1047,19 +1104,25 @@ private fun LazyListScope.operationsSection(
                         },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Text(stringResource(R.string.system_op_doctor))
+                        Icon(Icons.Filled.HealthAndSafety, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Spacer(modifier = Modifier.size(spacing.xs))
+                        AutoScaleButtonText(stringResource(R.string.system_op_doctor))
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runSecurityAudit() },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Text(stringResource(R.string.system_op_security_audit))
+                        Icon(Icons.Filled.VerifiedUser, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Spacer(modifier = Modifier.size(spacing.xs))
+                        AutoScaleButtonText(stringResource(R.string.system_op_security_audit))
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runUpdateSkills() },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Text(stringResource(R.string.system_op_update_skills))
+                        Icon(Icons.Filled.Refresh, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Spacer(modifier = Modifier.size(spacing.xs))
+                        AutoScaleButtonText(stringResource(R.string.system_op_update_skills))
                     }
                 }
 
@@ -1074,19 +1137,25 @@ private fun LazyListScope.operationsSection(
                         onClick = { viewModel.runPromptSize() },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Text(stringResource(R.string.system_op_prompt_size))
+                        Icon(Icons.Filled.HealthAndSafety, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Spacer(modifier = Modifier.size(spacing.xs))
+                        AutoScaleButtonText(stringResource(R.string.system_op_prompt_size))
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runDump() },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Text(stringResource(R.string.system_op_dump))
+                        Icon(Icons.Filled.Build, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Spacer(modifier = Modifier.size(spacing.xs))
+                        AutoScaleButtonText(stringResource(R.string.system_op_dump))
                     }
                     FilledTonalButton(
                         onClick = { viewModel.runConfigMigrate() },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Text(stringResource(R.string.system_op_config_migrate))
+                        Icon(Icons.Filled.Build, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Spacer(modifier = Modifier.size(spacing.xs))
+                        AutoScaleButtonText(stringResource(R.string.system_op_config_migrate))
                     }
                 }
 
@@ -1108,14 +1177,18 @@ private fun LazyListScope.operationsSection(
                         onClick = { viewModel.triggerBackup() },
                         modifier = Modifier.weight(1f),
                     ) {
-                        Text(stringResource(R.string.system_op_backup_create))
+                        Icon(Icons.Filled.Backup, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Spacer(modifier = Modifier.size(spacing.xs))
+                        AutoScaleButtonText(stringResource(R.string.system_op_backup_create))
                     }
                     OutlinedButton(
                         onClick = { viewModel.downloadBackup() },
                         enabled = state.backupArchive != null,
                         modifier = Modifier.weight(1f),
                     ) {
-                        Text(stringResource(R.string.system_op_backup_download))
+                        Icon(Icons.Filled.CloudDownload, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Spacer(modifier = Modifier.size(spacing.xs))
+                        AutoScaleButtonText(stringResource(R.string.system_op_backup_download))
                     }
                 }
 
@@ -1545,4 +1618,34 @@ private fun LazyListScope.actionLogSection(
             }
         }
     }
+}
+
+@Composable
+private fun AutoScaleButtonText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: androidx.compose.ui.graphics.Color = androidx.compose.ui.graphics.Color.Unspecified,
+) {
+    val style =
+        when {
+            text.length >= 15 ->
+                MaterialTheme.typography.labelSmall.copy(
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            text.length >= 11 ->
+                MaterialTheme.typography.labelSmall.copy(
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            else -> MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.SemiBold)
+        }
+    Text(
+        text = text,
+        style = style,
+        color = color,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier,
+    )
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/system/SystemScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -396,6 +396,8 @@
     <string name="system_op_backup_create">Create backup</string>
     <string name="system_op_backup_download">Download backup</string>
     <string name="system_op_backup_restore_upload">Restore from backup upload</string>
+    <string name="system_sec_backup">Backup</string>
+    <string name="system_sec_restore">Restore from upload</string>
     <string name="system_op_choose_zip">Choose restore zip</string>
     <string name="system_op_restore_upload">Restore upload</string>
     <string name="system_op_restore_path_label">Restore from backups path</string>
@@ -416,6 +418,7 @@
     <string name="system_debug_share_not_redacted">not redacted</string>
     <string name="system_debug_share_auto_delete">auto-deletes in %1$dh</string>
     <string name="system_debug_share_copy_all">Copy all</string>
+    <string name="system_debug_share_failed">upload failed</string>
 
     <!-- Checkpoints section -->
     <string name="system_sec_checkpoints">Checkpoints</string>


### PR DESCRIPTION
## Fixes #548

### Root cause (the "icon + two letters" symptom)
Every `Button`/`OutlinedButton`/`FilledTonalButton` in `SystemScreen.kt` wrapped its label in `Text(..., maxLines = 1)` **without `softWrap = false`**. Inside a Button's internal `Row`, a `Text` child with the default `softWrap = true` collapses to a near-zero intrinsic width and clips to a word or two — so buttons like "Create backup", "Migrate config", "Run doctor" rendered as an icon + ~2 letters.

### Changes
1. **Truncation fix:** added `softWrap = false` to all 24 icon+label button `Text` composables (18 already had `maxLines = 1`, 6 full-width labels did not). Lines pushed past 120 chars were re-wrapped to satisfy ktlint.
2. **Badge text (#548 item 1):** the debug-share **failure** badge used `system_status_stopped` ("Stopped") — a gateway running/stopped string, not an upload outcome. Added `system_debug_share_failed` ("upload failed") and switched the failure branch to it. The legitimate gateway running/stopped badge at L737 is untouched.
3. **Duplicate sub-headings (#548 item 2):** backup/restore blocks used the button label strings (`system_op_backup_create` / `system_op_backup_restore_upload`) as section headers directly above the same-labeled button. Replaced with proper `system_sec_backup` ("Backup") / `system_sec_restore` ("Restore from upload") headers, matching the existing `system_sec_*` convention.

### Verification
- `./gradlew ktlintCheck` → clean (exit 0)
- `./gradlew assembleDebug` → build succeeded (exit 0)
- `./gradlew testDebugUnitTest` → passed (exit 0)

No string-coverage test exists in the repo, so none added.