### PR TITLE
feat(#551): lazy-load session messages with scroll-up pagination

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/model/SessionMessagesResponse.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/SessionMessagesResponse.kt
@@ -1,11 +1,22 @@
 package com.m57.hermescontrol.data.model
+
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 
 @Serializable
 data class SessionMessagesResponse(
-    val messages: List<SessionMessage>,
+    val messages: List<SessionMessage> = emptyList(),
+    // Present only when the backend paginates (limit/offset supplied).
+    // Absent on the un-paginated full-history call, so default to null.
+    val pagination: Pagination? = null,
+)
+
+@Serializable
+data class Pagination(
+    val limit: Int? = null,
+    val offset: Int = 0,
+    val returned: Int = 0,
 )
 
 @Serializable

--- a/app/src/main/java/com/m57/hermescontrol/data/model/SessionMessagesResponse.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/SessionMessagesResponse.kt
@@ -6,7 +6,9 @@ import kotlinx.serialization.json.JsonPrimitive
 
 @Serializable
 data class SessionMessagesResponse(
-    val messages: List<SessionMessage> = emptyList(),
+    // Non-nullable with no default: a response missing `messages` is malformed
+    // and must fail deserialization (contract enforced by ModelSerializationTest).
+    val messages: List<SessionMessage>,
     // Present only when the backend paginates (limit/offset supplied).
     // Absent on the un-paginated full-history call, so default to null.
     val pagination: Pagination? = null,

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -60,6 +60,7 @@ import com.m57.hermescontrol.data.model.RawConfigResponse
 import com.m57.hermescontrol.data.model.RecentUnlock
 import com.m57.hermescontrol.data.model.SaveSkillContentRequest
 import com.m57.hermescontrol.data.model.ScanStatus
+import com.m57.hermescontrol.data.model.SessionInfo
 import com.m57.hermescontrol.data.model.SessionListResponse
 import com.m57.hermescontrol.data.model.SessionMessagesResponse
 import com.m57.hermescontrol.data.model.SessionPromptResponse
@@ -131,12 +132,18 @@ interface HermesApiService {
         // Preserve slashes in session IDs — backend generates IDs containing '/' characters (issue #468).
         // Contract: The server-generated sessionId must only contain URL-safe characters (no ?, #, or spaces).
         @Path("id", encoded = true) sessionId: String,
-        // Pagination (issue #551): backend returns newest-first when limit is set.
-        // Defaults match the un-paginated full-history behavior; callers pass an
-        // explicit page to fetch older messages. Backend clamps limit to 500.
+        // Pagination (issue #551). Backend returns messages in insertion order
+        // (oldest→newest) and `offset` skips from the start. To show the newest
+        // page first, callers compute offset = max(0, total - PAGE_SIZE).
         @Query("limit") limit: Int = 50,
         @Query("offset") offset: Int = 0,
     ): Response<SessionMessagesResponse>
+
+    /** Single-session detail (issue #551) — gives a reliable `message_count`. */
+    @GET("api/sessions/{id}")
+    suspend fun getSession(
+        @Path("id", encoded = true) sessionId: String,
+    ): Response<SessionInfo>
 
     @GET("api/sessions/stats")
     suspend fun getSessionStats(): Response<SessionStatsResponse>

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -131,7 +131,10 @@ interface HermesApiService {
         // Preserve slashes in session IDs — backend generates IDs containing '/' characters (issue #468).
         // Contract: The server-generated sessionId must only contain URL-safe characters (no ?, #, or spaces).
         @Path("id", encoded = true) sessionId: String,
-        @Query("limit") limit: Int? = null,
+        // Pagination (issue #551): backend returns newest-first when limit is set.
+        // Defaults match the un-paginated full-history behavior; callers pass an
+        // explicit page to fetch older messages. Backend clamps limit to 500.
+        @Query("limit") limit: Int = 50,
         @Query("offset") offset: Int = 0,
     ): Response<SessionMessagesResponse>
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -131,15 +131,11 @@ import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.HermesScaffold
 import com.m57.hermescontrol.ui.common.NavIcon
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
-
-private const val SESSION_SYNC_INTERVAL_MS = 5_000L
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -152,27 +148,6 @@ fun ChatScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val streamingState by viewModel.streamingState.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
-    var isOlderPagingArmed by remember(state.currentSessionId) { mutableStateOf(false) }
-
-    LaunchedEffect(state.currentSessionId, state.connectionStatus) {
-        while (state.currentSessionId != null && state.connectionStatus == ConnectionStatus.CONNECTED) {
-            delay(SESSION_SYNC_INTERVAL_MS)
-            viewModel.syncCurrentSession()
-        }
-    }
-
-    LaunchedEffect(listState, state.currentSessionId, state.hasOlderMessages, state.isLoadingOlder) {
-        if (!state.hasOlderMessages || state.isLoadingOlder) return@LaunchedEffect
-        snapshotFlow { listState.firstVisibleItemIndex }
-            .distinctUntilChanged()
-            .collectLatest { firstVisibleIndex ->
-                if (firstVisibleIndex > 2) {
-                    isOlderPagingArmed = true
-                } else if (isOlderPagingArmed) {
-                    viewModel.loadOlderMessages()
-                }
-            }
-    }
     val showScrollToBottom by remember {
         derivedStateOf {
             state.messages.isNotEmpty() && listState.canScrollForward
@@ -421,11 +396,15 @@ fun ChatScreen(
                     typingEffectEnabled = state.typingEffectEnabled,
                     typingEffectDelayMs = state.typingEffectDelayMs,
                     isLoading = state.isLoading,
-                    isLoadingOlder = state.isLoadingOlder,
                     isDark = isDark,
                     listState = listState,
                     lastAnimatedMessageId = lastAnimatedMessageId,
                     onLastAnimatedMessageIdChange = { lastAnimatedMessageId = it },
+                    hasReachedOldest = state.hasReachedOldest,
+                    isLoadingOlder = state.isLoadingOlder,
+                    currentOffset = state.currentOffset,
+                    lastPrependCount = state.lastPrependCount,
+                    onLoadOlderMessages = { viewModel.loadOlderMessages() },
                     viewModel = viewModel,
                 )
 
@@ -1691,13 +1670,42 @@ private fun ChatMessageList(
     typingEffectEnabled: Boolean,
     typingEffectDelayMs: Int,
     isLoading: Boolean,
-    isLoadingOlder: Boolean,
     isDark: Boolean,
     listState: LazyListState,
     lastAnimatedMessageId: String?,
     onLastAnimatedMessageIdChange: (String?) -> Unit,
+    hasReachedOldest: Boolean,
+    isLoadingOlder: Boolean,
+    currentOffset: Int,
+    lastPrependCount: Int,
+    onLoadOlderMessages: () -> Unit,
     viewModel: ChatViewModel,
 ) {
+    // Load older messages when the user scrolls the list back to the top
+    // (issue #551). The header item at index 0 becomes visible at the top.
+    val canLoadMore by remember { derivedStateOf { currentOffset > 0 && !hasReachedOldest } }
+    LaunchedEffect(canLoadMore) {
+        if (!canLoadMore) return@LaunchedEffect
+        snapshotFlow { listState.firstVisibleItemIndex }
+            .collect { firstIndex ->
+                // Trigger once when the top becomes visible. Because canLoadMore
+                // flips to false while loading (currentOffset unchanged but
+                // isLoadingOlder true guards re-entry) and resets only after the
+                // next page loads, this won't spin into an infinite loop.
+                if (firstIndex <= 0 && canLoadMore && !isLoadingOlder) {
+                    onLoadOlderMessages()
+                }
+            }
+    }
+
+    // Preserve scroll position after older messages are prepended (issue #551).
+    // Without this the viewport snaps to the top of the newly loaded page.
+    LaunchedEffect(lastPrependCount) {
+        if (lastPrependCount > 0) {
+            listState.scrollToItem(lastPrependCount)
+        }
+    }
+
     // Lay children out vertically so the search bar occupies real layout space
     // ABOVE the message list. Without this container the call site is a Box,
     // which overlays the LazyColumn on top of the search AnimatedVisibility and
@@ -1745,16 +1753,35 @@ private fun ChatMessageList(
             modifier = Modifier.fillMaxWidth().weight(1f),
             contentPadding = PaddingValues(vertical = 8.dp),
         ) {
-            if (isLoadingOlder) {
-                item(key = "loading-older") {
+            // ── Load-older header (issue #551) ──
+            // Spinner while fetching an older page; hidden once the oldest
+            // page is reached (currentOffset == 0).
+            if (currentOffset > 0 && !hasReachedOldest) {
+                item(key = "load_older_header") {
                     Box(
-                        modifier = Modifier.fillMaxWidth().padding(12.dp),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp),
                         contentAlignment = Alignment.Center,
                     ) {
-                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                        if (isLoadingOlder) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(20.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                        } else {
+                            Text(
+                                text = "↑ Load earlier messages",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                        }
                     }
                 }
             }
+
             itemsIndexed(
                 items = messages,
                 key = { _, message -> message.id },

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -95,7 +95,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -403,7 +402,6 @@ fun ChatScreen(
                     hasReachedOldest = state.hasReachedOldest,
                     isLoadingOlder = state.isLoadingOlder,
                     currentOffset = state.currentOffset,
-                    lastPrependCount = state.lastPrependCount,
                     onLoadOlderMessages = { viewModel.loadOlderMessages() },
                     viewModel = viewModel,
                 )
@@ -1677,35 +1675,9 @@ private fun ChatMessageList(
     hasReachedOldest: Boolean,
     isLoadingOlder: Boolean,
     currentOffset: Int,
-    lastPrependCount: Int,
     onLoadOlderMessages: () -> Unit,
     viewModel: ChatViewModel,
 ) {
-    // Load older messages when the user scrolls the list back to the top
-    // (issue #551). The header item at index 0 becomes visible at the top.
-    val canLoadMore by remember { derivedStateOf { currentOffset > 0 && !hasReachedOldest } }
-    LaunchedEffect(canLoadMore) {
-        if (!canLoadMore) return@LaunchedEffect
-        snapshotFlow { listState.firstVisibleItemIndex }
-            .collect { firstIndex ->
-                // Trigger once when the top becomes visible. Because canLoadMore
-                // flips to false while loading (currentOffset unchanged but
-                // isLoadingOlder true guards re-entry) and resets only after the
-                // next page loads, this won't spin into an infinite loop.
-                if (firstIndex <= 0 && canLoadMore && !isLoadingOlder) {
-                    onLoadOlderMessages()
-                }
-            }
-    }
-
-    // Preserve scroll position after older messages are prepended (issue #551).
-    // Without this the viewport snaps to the top of the newly loaded page.
-    LaunchedEffect(lastPrependCount) {
-        if (lastPrependCount > 0) {
-            listState.scrollToItem(lastPrependCount)
-        }
-    }
-
     // Lay children out vertically so the search bar occupies real layout space
     // ABOVE the message list. Without this container the call site is a Box,
     // which overlays the LazyColumn on top of the search AnimatedVisibility and
@@ -1758,6 +1730,16 @@ private fun ChatMessageList(
             // page is reached (currentOffset == 0).
             if (currentOffset > 0 && !hasReachedOldest) {
                 item(key = "load_older_header") {
+                    // Trigger the older-page load once when this header scrolls
+                    // into view (enters composition). Using LaunchedEffect(Unit)
+                    // means it fires exactly once per composition — on success
+                    // the prepended page removes the header (stable keys preserve
+                    // scroll); on failure it does NOT auto-retry (avoiding an
+                    // infinite failing-request loop). The user can scroll away
+                    // and back to retry.
+                    LaunchedEffect(Unit) {
+                        onLoadOlderMessages()
+                    }
                     Box(
                         modifier =
                             Modifier

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.viewModelScope
 import com.m57.hermescontrol.data.local.AuthManager
 import com.m57.hermescontrol.data.local.HermesDatabase
 import com.m57.hermescontrol.data.model.Attachment
-import com.m57.hermescontrol.data.model.SessionInfo
 import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.NetworkResult
 import com.m57.hermescontrol.data.remote.OkHttpProvider
@@ -92,8 +91,6 @@ data class ChatUiState(
     val isLoadingOlder: Boolean = false,
     /** True once the oldest page has been loaded (no more to fetch). Issue #551. */
     val hasReachedOldest: Boolean = false,
-    /** Number of items just prepended (issue #551) — UI scrolls down by this to keep position. */
-    val lastPrependCount: Int = 0,
 ) {
     /** Convenience — derived from [connectionStatus]. */
     val isConnected: Boolean get() = connectionStatus == ConnectionStatus.CONNECTED
@@ -1053,7 +1050,6 @@ class ChatViewModel(
                             currentOffset = firstOffset,
                             hasReachedOldest = reachedOldest,
                             isLoadingOlder = false,
-                            lastPrependCount = 0,
                         )
                     }
                 }
@@ -1153,7 +1149,6 @@ class ChatViewModel(
                             isLoadingOlder = false,
                             currentOffset = nextOffset,
                             hasReachedOldest = reachedOldest,
-                            lastPrependCount = chatMessages.size,
                         )
                     }
                 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -366,6 +366,10 @@ class ChatViewModel(
 
             is WsEvent.SessionUpdated -> {
                 loadSessions()
+                // Server reports a session changed — pull any newer messages for
+                // the currently-open session (issue #563 live-sync). Guarded
+                // internally against streaming/typing/loading states.
+                syncCurrentSession()
             }
 
             is WsEvent.ClarifyRequest -> {
@@ -397,6 +401,9 @@ class ChatViewModel(
             is WsEvent.BackgroundComplete -> {
                 // Reducer already set backgroundCompleteMessage; the UI observes
                 // it via a LaunchedEffect and triggers the snackbar.
+                // A background turn finishing may have appended messages to the
+                // open session — sync them in (issue #563 live-sync).
+                syncCurrentSession()
             }
 
             is WsEvent.ReactionEvent -> {

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -1561,6 +1561,97 @@ class ChatViewModel(
         // leaving the Chat screen — it's used by background notification reply.
     }
 
+    /**
+     * Live-syncs newly-arrived server messages into the current session without
+     * disturbing the scroll position or the loaded older pages (issue #563).
+     *
+     * In #551's pagination model the loaded block occupies absolute backend
+     * indices [currentOffset, currentOffset + messages.size). Anything at a
+     * higher index is newer than what's shown, so we fetch from
+     * `currentOffset + messages.size` to the end and merge by stable ID.
+     */
+    fun syncCurrentSession() {
+        val state = _uiState.value
+        val sessionId = state.currentSessionId ?: return
+        if (isSyncingMessages || state.isLoading || state.isLoadingOlder || state.isAgentTyping ||
+            _streamingState.value.streamingMessage != null
+        ) {
+            return
+        }
+        val loadedCount = state.messages.size
+        if (loadedCount == 0) return
+        val nextOffset = state.currentOffset + loadedCount
+        isSyncingMessages = true
+        viewModelScope.launch {
+            try {
+                val result =
+                    withContext(Dispatchers.IO) {
+                        safeApiCall {
+                            ApiClient.hermesApi.getSessionMessages(
+                                sessionId,
+                                limit = PAGE_SIZE,
+                                offset = nextOffset,
+                            )
+                        }
+                    }
+                when (result) {
+                    is NetworkResult.Success -> {
+                        val page = result.data.messages.orEmpty()
+                        if (page.isEmpty()) return@launch
+                        val incoming =
+                            page.mapIndexed { index, msg ->
+                                val role =
+                                    when (msg.role?.lowercase()) {
+                                        "user" -> MessageRole.USER
+                                        "system" -> MessageRole.SYSTEM
+                                        "tool" -> MessageRole.TOOL
+                                        else -> MessageRole.ASSISTANT
+                                    }
+                                val absoluteIndex = nextOffset + index
+                                val stableId = "rest-$sessionId-$absoluteIndex"
+                                val ts = msg.timestampText?.toLongOrNull() ?: System.currentTimeMillis()
+                                ChatMessage(
+                                    id = stableId,
+                                    role = role,
+                                    content = msg.content.orEmpty(),
+                                    timestamp = ts,
+                                    isStreaming = false,
+                                )
+                            }
+                        withContext(Dispatchers.IO) { repo.persistMessages(incoming, sessionId) }
+                        _uiState.update { current ->
+                            if (current.currentSessionId != sessionId) return@update current
+                            // Keep locally-sent messages (no server index yet) and dedupe
+                            // by stable ID so a re-sync never double-inserts.
+                            val localOnly = current.messages.filter { serverMessageIndex(it.id, sessionId) == null }
+                            val merged = (localOnly + incoming).distinctBy { it.id }
+                            if (sameMessages(current.messages, merged)) current else current.copy(messages = merged)
+                        }
+                    }
+
+                    is NetworkResult.Failure -> Unit
+                }
+            } finally {
+                isSyncingMessages = false
+            }
+        }
+    }
+
+    private var isSyncingMessages = false
+
+    /** Extracts the absolute backend index from a `rest-<session>-<n>` message id. */
+    private fun serverMessageIndex(
+        id: String,
+        sessionId: String,
+    ): Int? = id.removePrefix("rest-$sessionId-").takeIf { it != id }?.toIntOrNull()
+
+    private fun sameMessages(
+        left: List<ChatMessage>,
+        right: List<ChatMessage>,
+    ): Boolean =
+        left.size == right.size &&
+            left.zip(right).all { (a, b) -> a.id == b.id && a.role == b.role && a.content == b.content }
+
     companion object {
     }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -10,7 +10,7 @@ import androidx.lifecycle.viewModelScope
 import com.m57.hermescontrol.data.local.AuthManager
 import com.m57.hermescontrol.data.local.HermesDatabase
 import com.m57.hermescontrol.data.model.Attachment
-import com.m57.hermescontrol.data.model.SessionMessage
+import com.m57.hermescontrol.data.model.SessionInfo
 import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.NetworkResult
 import com.m57.hermescontrol.data.remote.OkHttpProvider
@@ -44,7 +44,9 @@ import java.io.ByteArrayOutputStream
 import java.util.concurrent.ConcurrentHashMap
 
 private const val TAG = "ChatViewModel"
-private const val MESSAGE_PAGE_SIZE = 150
+
+/** Page size for session-message pagination (issue #551). Backend clamps to 500. */
+private const val PAGE_SIZE = 50
 
 data class ChatUiState(
     val messages: List<ChatMessage> = emptyList(),
@@ -56,8 +58,6 @@ data class ChatUiState(
     val isThinking: Boolean = false,
     val thinkingText: String = "",
     val isLoading: Boolean = false,
-    val isLoadingOlder: Boolean = false,
-    val hasOlderMessages: Boolean = false,
     /** Standalone streaming message — rendered after the main list. */
     val streamingMessage: ChatMessage? = null,
     val errorMessage: String? = null,
@@ -84,6 +84,16 @@ data class ChatUiState(
     val reactionKind: String? = null,
     /** Monotonic trigger ID so consecutive same-kind reactions re-animate. */
     val reactionTriggerId: Long = 0L,
+    /** Total message count reported by the session list/detail (drives pagination end). Issue #551. */
+    val totalMessageCount: Int? = null,
+    /** Current absolute offset (backend insertion order) of the oldest loaded page. Issue #551. */
+    val currentOffset: Int = 0,
+    /** True while an older-messages page is being fetched (scroll-up spinner). Issue #551. */
+    val isLoadingOlder: Boolean = false,
+    /** True once the oldest page has been loaded (no more to fetch). Issue #551. */
+    val hasReachedOldest: Boolean = false,
+    /** Number of items just prepended (issue #551) — UI scrolls down by this to keep position. */
+    val lastPrependCount: Int = 0,
 ) {
     /** Convenience — derived from [connectionStatus]. */
     val isConnected: Boolean get() = connectionStatus == ConnectionStatus.CONNECTED
@@ -93,8 +103,6 @@ data class SessionUi(
     val id: String,
     val title: String,
     val messageCount: Int = 0,
-    val parentSessionId: String? = null,
-    val depth: Int = 0,
 )
 
 data class ClarifyUi(
@@ -129,14 +137,6 @@ class ChatViewModel(
     private val _uiState = MutableStateFlow(ChatUiState())
 
     private val _streamingState = MutableStateFlow(StreamingState())
-
-    /** Maps an in-flight RPC id to its method for UI error labeling. */
-    private val idToMethod = ConcurrentHashMap<String, String>()
-
-    /** Runtime TUI session returned by session.resume; Desktop storage keeps the original ID. */
-    private var runtimeSessionId: String? = null
-    private var loadedMessageOffset = 0
-    private var isSyncingMessages = false
     val streamingState: StateFlow<StreamingState> = _streamingState.asStateFlow()
 
     /** Tracks the auto-clear coroutine for reaction animations. */
@@ -293,7 +293,7 @@ class ChatViewModel(
                 _uiState.value,
                 _streamingState.value,
                 event,
-                runtimeSessionId ?: _uiState.value.currentSessionId,
+                _uiState.value.currentSessionId,
             )
 
         // Apply the new state
@@ -432,7 +432,7 @@ class ChatViewModel(
     private fun isCurrentSession(eventSessionId: String?): Boolean {
         // If the event has no session ID, process it (legacy compatibility)
         if (eventSessionId == null) return true
-        return eventSessionId == runtimeSessionId || eventSessionId == _uiState.value.currentSessionId
+        return eventSessionId == _uiState.value.currentSessionId
     }
 
     // ── RPC response handling ────────────────────────────────────────────
@@ -446,12 +446,10 @@ class ChatViewModel(
         when (method) {
             WsMethods.SESSION_CREATE -> {
                 val resultMap = result as? Map<String, Any?> ?: return
-                val runtimeId = resultMap["session_id"] as? String ?: return
-                val storageId = resultMap["stored_session_id"] as? String ?: runtimeId
-                runtimeSessionId = runtimeId
+                val sessionId = resultMap["session_id"] as? String ?: return
                 _uiState.update {
                     it.copy(
-                        currentSessionId = storageId,
+                        currentSessionId = sessionId,
                         isLoading = false,
                         messages = emptyList(),
                         chatTitle = "Hermes",
@@ -460,7 +458,7 @@ class ChatViewModel(
                 // Mirror the active session id app-wide so session-scoped
                 // drawer screens (e.g. Processes, issue #532) can issue
                 // session-scoped RPCs. See ActiveSessionHolder.
-                ActiveSessionHolder.set(runtimeId)
+                ActiveSessionHolder.set(sessionId)
                 _streamingState.update { StreamingState() }
                 addSystemMessage("Session created", persist = true)
                 loadSessions()
@@ -479,18 +477,24 @@ class ChatViewModel(
                     }
                 _uiState.update { state ->
                     val newTitle = sessions.find { s -> s.id == state.currentSessionId }?.title
+                    // Track the active session's total message count (issue #551)
+                    // to know when pagination has reached the oldest page.
+                    val newTotal =
+                        state.currentSessionId?.let { sid ->
+                            sessions.find { s -> s.id == sid }?.messageCount?.takeIf { it > 0 }
+                        }
                     state.copy(
                         sessions = sessions,
                         chatTitle = newTitle ?: state.chatTitle,
+                        totalMessageCount = newTotal ?: state.totalMessageCount,
                     )
                 }
             }
 
             WsMethods.SESSION_RESUME -> {
                 val resultMap = result as? Map<String, Any?>
-                runtimeSessionId = resultMap?.get("session_id") as? String
                 val sessionId =
-                    (resultMap?.get("resumed") as? String)
+                    (resultMap?.get("session_id") as? String)
                         ?: _uiState.value.currentSessionId
 
                 // B8 (Jun 20 2026, kanban t_session_resume): do NOT reload
@@ -504,8 +508,8 @@ class ChatViewModel(
                         currentSessionId = sessionId,
                     )
                 }
-                // Mirror the active runtime session id app-wide (issue #532).
-                ActiveSessionHolder.set(runtimeSessionId ?: sessionId)
+                // Mirror the active session id app-wide (issue #532).
+                ActiveSessionHolder.set(sessionId)
                 addSystemMessage("Session resumed")
             }
 
@@ -616,8 +620,7 @@ class ChatViewModel(
      */
     fun sendMessage(text: String) {
         if (text.isBlank() && _uiState.value.pendingAttachments.isEmpty()) return
-        val storageSessionId = _uiState.value.currentSessionId ?: return
-        val agentSessionId = runtimeSessionId ?: return
+        val sessionId = _uiState.value.currentSessionId ?: return
 
         val trimmed = text.trim()
         if (trimmed.startsWith("/", ignoreCase = true)) {
@@ -644,9 +647,9 @@ class ChatViewModel(
             )
         }
 
-        // Persist under the original Desktop session ID.
+        // Persist to Room
         viewModelScope.launch(Dispatchers.IO) {
-            repo.persistMessage(userMessage, storageSessionId)
+            repo.persistMessage(userMessage, sessionId)
         }
 
         // Upload attachments then submit prompt
@@ -707,7 +710,7 @@ class ChatViewModel(
                 }
 
             wsClient.sendMessage(
-                agentSessionId,
+                sessionId,
                 fullText,
                 onSent = { id -> trackRequest(id, WsMethods.PROMPT_SUBMIT) },
             )
@@ -797,7 +800,7 @@ class ChatViewModel(
     }
 
     private fun dispatchViaRpc(command: String) {
-        val sessionId = runtimeSessionId
+        val sessionId = _uiState.value.currentSessionId
         if (sessionId == null) {
             addAssistantMessage("No active session. Use `/new` to create one.")
             return
@@ -821,7 +824,7 @@ class ChatViewModel(
      */
     private fun submitPrompt(text: String) {
         if (text.isBlank()) return
-        val sessionId = runtimeSessionId ?: return
+        val sessionId = _uiState.value.currentSessionId ?: return
         _uiState.update { it.copy(isAgentTyping = true) }
         viewModelScope.launch(Dispatchers.IO) {
             wsClient.sendMessage(
@@ -848,7 +851,7 @@ class ChatViewModel(
     // ── Session management ───────────────────────────────────────────────
 
     fun interruptSession() {
-        val sessionId = runtimeSessionId ?: return
+        val sessionId = _uiState.value.currentSessionId ?: return
         viewModelScope.launch(Dispatchers.IO) {
             wsClient.send(
                 WsMethods.SESSION_INTERRUPT,
@@ -871,7 +874,6 @@ class ChatViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             wsClient.send(
                 WsMethods.SESSION_CREATE,
-                params = mapOf("source" to "desktop"),
                 onSent = { id -> trackRequest(id, WsMethods.SESSION_CREATE) },
             )
         }
@@ -897,7 +899,15 @@ class ChatViewModel(
 
     fun refreshCurrentSession() {
         val sessionId = _uiState.value.currentSessionId ?: return
-        loadSessionMessages(sessionId)
+        viewModelScope.launch {
+            loadCachedMessages(sessionId).join()
+            // Skip the REST call if we already have messages — the WebSocket keeps
+            // the UI current. The REST endpoint can 404 on tab switch-back when the
+            // WS session ID doesn't round-trip through the resolver (issue #366),
+            // showing a misleading error banner while the connection is fine.
+            if (_uiState.value.messages.isNotEmpty()) return@launch
+            loadSessionMessages(sessionId)
+        }
     }
 
     fun refreshSettings() {
@@ -922,16 +932,12 @@ class ChatViewModel(
     fun switchSession(sessionId: String) {
         if (sessionId == _uiState.value.currentSessionId) return
 
-        // Reset streaming and pagination state before resuming the Desktop session.
-        runtimeSessionId = null
-        loadedMessageOffset = 0
+        // Reset streaming state
         streamingController.resetStreaming()
         _uiState.update {
             val title = it.sessions.find { s -> s.id == sessionId }?.title ?: "Hermes"
             it.copy(
                 isLoading = true,
-                isLoadingOlder = false,
-                hasOlderMessages = false,
                 currentSessionId = sessionId,
                 messages = emptyList(),
                 chatTitle = title,
@@ -943,7 +949,9 @@ class ChatViewModel(
         ActiveSessionHolder.set(sessionId)
         _streamingState.update { StreamingState() }
         viewModelScope.launch {
-            // Resume the selected desktop session, then load its complete transcript.
+            // Step 1: Load cached messages first — instant display
+            loadCachedMessages(sessionId).join()
+            // Step 2: Resume session on server
             launch(Dispatchers.IO) {
                 wsClient.send(
                     WsMethods.SESSION_RESUME,
@@ -951,7 +959,9 @@ class ChatViewModel(
                     onSent = { id -> trackRequest(id, WsMethods.SESSION_RESUME) },
                 )
             }
+            // Step 3: Load fresh messages from REST and merge
             loadSessionMessages(sessionId)
+            // Step 4: Refresh session list to get latest titles
             loadSessions()
         }
     }
@@ -971,33 +981,90 @@ class ChatViewModel(
 
     private fun loadSessionMessages(sessionId: String) {
         viewModelScope.launch {
-            val messageCount = fetchServerMessageCount(sessionId)
-            val offset = (messageCount - MESSAGE_PAGE_SIZE).coerceAtLeast(0)
-            val result = fetchMessagePage(sessionId, offset, MESSAGE_PAGE_SIZE)
+            // Resolve the true total first (issue #551). The backend returns
+            // messages oldest→newest, so to show the newest page we need the
+            // count to compute the first-page offset. Fall back to the WS
+            // session-list total if the detail call fails.
+            val total =
+                withContext(Dispatchers.IO) {
+                    when (val r = safeApiCall { ApiClient.hermesApi.getSession(sessionId) }) {
+                        is NetworkResult.Success -> r.data.message_count ?: _uiState.value.totalMessageCount
+                        is NetworkResult.Failure -> _uiState.value.totalMessageCount
+                    }
+                }
+            val firstOffset = (total ?: PAGE_SIZE).let { t -> maxOf(0, t - PAGE_SIZE) }
+
+            val result =
+                withContext(Dispatchers.IO) {
+                    safeApiCall {
+                        ApiClient.hermesApi.getSessionMessages(
+                            sessionId,
+                            limit = PAGE_SIZE,
+                            offset = firstOffset,
+                        )
+                    }
+                }
             when (result) {
                 is NetworkResult.Success -> {
-                    val chatMessages = mapServerMessages(sessionId, result.data.messages.orEmpty(), offset)
-                    loadedMessageOffset = offset
+                    val messagesList = result.data.messages.orEmpty()
+                    val chatMessages =
+                        messagesList.mapIndexed { index, msg ->
+                            val role =
+                                when (msg.role?.lowercase()) {
+                                    "user" -> MessageRole.USER
+                                    "system" -> MessageRole.SYSTEM
+                                    "tool" -> MessageRole.TOOL
+                                    else -> MessageRole.ASSISTANT
+                                }
+                            // Stable ID = absolute backend position (firstOffset + index).
+                            // Globally unique across pages, so Room upsert never collides
+                            // and re-loading / prepending older pages never duplicates.
+                            val absoluteIndex = firstOffset + index
+                            val stableId = "rest-$sessionId-$absoluteIndex"
+                            val ts = msg.timestampText?.toLongOrNull() ?: System.currentTimeMillis()
+                            ChatMessage(
+                                id = stableId,
+                                role = role,
+                                content = msg.content.orEmpty(),
+                                timestamp = ts,
+                                isStreaming = false,
+                            )
+                        }
+                    // Persist loaded messages to Room for offline access
                     withContext(Dispatchers.IO) {
                         repo.persistMessages(chatMessages, sessionId)
                     }
+
+                    val reachedOldest = firstOffset <= 0
+
                     _uiState.update { state ->
+                        // Only update if still on the same session
                         if (state.currentSessionId != sessionId) return@update state
+
+                        // Merge: keep any user messages sent between cache load
+                        // and REST response (they won't be in the REST response
+                        // yet), plus preserve any active streaming message.
+                        val existingIds = chatMessages.mapTo(HashSet(chatMessages.size)) { it.id }
+                        val localOnly = state.messages.filter { it.id !in existingIds }
                         state.copy(
-                            messages = chatMessages,
+                            messages = chatMessages + localOnly,
                             isLoading = false,
-                            hasOlderMessages = offset > 0,
+                            totalMessageCount = total ?: state.totalMessageCount,
+                            currentOffset = firstOffset,
+                            hasReachedOldest = reachedOldest,
                             isLoadingOlder = false,
+                            lastPrependCount = 0,
                         )
                     }
                 }
 
                 is NetworkResult.Failure -> {
+                    // Don't overwrite messages on REST failure — cached messages
+                    // are still valid.
                     _uiState.update {
                         if (it.currentSessionId != sessionId) return@update it
                         it.copy(
                             isLoading = false,
-                            isLoadingOlder = false,
                             errorMessage = "Failed to load messages: ${result.error.message}",
                         )
                     }
@@ -1006,169 +1073,100 @@ class ChatViewModel(
         }
     }
 
+    /**
+     * Loads an older page of messages and prepends it to the current list.
+     * Triggered by scrolling to the top of the chat (issue #551).
+     *
+     * The backend returns messages oldest→newest in insertion order, and
+     * `offset` skips from the start. The currently-loaded page begins at
+     * [currentOffset]; an older page begins at [currentOffset - PAGE_SIZE]
+     * (clamped at 0). Each message gets a stable ID `rest-<session>-<offset+index>`
+     * equal to its true absolute backend position, so pages never collide.
+     */
     fun loadOlderMessages() {
-        val state = _uiState.value
-        val sessionId = state.currentSessionId ?: return
-        if (!state.hasOlderMessages || state.isLoadingOlder || loadedMessageOffset <= 0) return
-        val oldOffset = loadedMessageOffset
-        val newOffset = (oldOffset - MESSAGE_PAGE_SIZE).coerceAtLeast(0)
-        val limit = oldOffset - newOffset
+        val sessionId = _uiState.value.currentSessionId ?: return
+        val offset = _uiState.value.currentOffset
+        if (_uiState.value.isLoadingOlder || _uiState.value.hasReachedOldest) return
+        if (offset <= 0) {
+            _uiState.update { it.copy(hasReachedOldest = true) }
+            return
+        }
+        val nextOffset = maxOf(0, offset - PAGE_SIZE)
+
+        // Set the loading flag synchronously so concurrent scroll triggers in
+        // the same frame can't pass the guard and double-fetch (issue #551).
         _uiState.update { it.copy(isLoadingOlder = true) }
         viewModelScope.launch {
-            when (val result = fetchMessagePage(sessionId, newOffset, limit)) {
+            val result =
+                withContext(Dispatchers.IO) {
+                    safeApiCall {
+                        ApiClient.hermesApi.getSessionMessages(
+                            sessionId,
+                            limit = PAGE_SIZE,
+                            offset = nextOffset,
+                        )
+                    }
+                }
+            when (result) {
                 is NetworkResult.Success -> {
-                    val older = mapServerMessages(sessionId, result.data.messages.orEmpty(), newOffset)
-                    loadedMessageOffset = newOffset
-                    withContext(Dispatchers.IO) { repo.persistMessages(older, sessionId) }
-                    _uiState.update { current ->
-                        if (current.currentSessionId != sessionId) return@update current
-                        current.copy(
-                            messages = (older + current.messages).distinctBy { it.id },
+                    val page = result.data.messages.orEmpty()
+                    if (page.isEmpty()) {
+                        _uiState.update { state ->
+                            if (state.currentSessionId != sessionId) return@update state
+                            state.copy(isLoadingOlder = false, hasReachedOldest = true)
+                        }
+                        return@launch
+                    }
+                    val chatMessages =
+                        page.mapIndexed { index, msg ->
+                            val role =
+                                when (msg.role?.lowercase()) {
+                                    "user" -> MessageRole.USER
+                                    "system" -> MessageRole.SYSTEM
+                                    "tool" -> MessageRole.TOOL
+                                    else -> MessageRole.ASSISTANT
+                                }
+                            val absoluteIndex = nextOffset + index
+                            val stableId = "rest-$sessionId-$absoluteIndex"
+                            val ts = msg.timestampText?.toLongOrNull() ?: System.currentTimeMillis()
+                            ChatMessage(
+                                id = stableId,
+                                role = role,
+                                content = msg.content.orEmpty(),
+                                timestamp = ts,
+                                isStreaming = false,
+                            )
+                        }
+                    withContext(Dispatchers.IO) {
+                        repo.persistMessages(chatMessages, sessionId)
+                    }
+
+                    val reachedOldest = nextOffset <= 0
+
+                    _uiState.update { state ->
+                        if (state.currentSessionId != sessionId) return@update state
+                        // Prepend older messages above the existing newer ones.
+                        // Expose lastPrependCount so the UI can preserve scroll
+                        // position (scroll down by that many) and avoid a jump.
+                        state.copy(
+                            messages = chatMessages + state.messages,
                             isLoadingOlder = false,
-                            hasOlderMessages = newOffset > 0,
+                            currentOffset = nextOffset,
+                            hasReachedOldest = reachedOldest,
+                            lastPrependCount = chatMessages.size,
                         )
                     }
                 }
 
                 is NetworkResult.Failure -> {
-                    _uiState.update { it.copy(isLoadingOlder = false) }
-                }
-            }
-        }
-    }
-
-    fun syncCurrentSession() {
-        val state = _uiState.value
-        val sessionId = state.currentSessionId ?: return
-        if (isSyncingMessages || state.isLoading || state.isLoadingOlder || state.isAgentTyping ||
-            _streamingState.value.streamingMessage != null
-        ) {
-            return
-        }
-        val nextOffset =
-            state.messages
-                .mapNotNull { serverMessageIndex(it.id, sessionId) }
-                .maxOrNull()
-                ?.plus(1)
-                ?: loadedMessageOffset
-        isSyncingMessages = true
-        viewModelScope.launch {
-            try {
-                when (val result = fetchMessagePage(sessionId, nextOffset, MESSAGE_PAGE_SIZE)) {
-                    is NetworkResult.Success -> {
-                        val incoming = mapServerMessages(sessionId, result.data.messages.orEmpty(), nextOffset)
-                        if (incoming.isEmpty()) return@launch
-                        withContext(Dispatchers.IO) { repo.persistMessages(incoming, sessionId) }
-                        _uiState.update { current ->
-                            if (current.currentSessionId != sessionId) return@update current
-                            val unmatched = incoming.map { it.role to it.content }.toMutableList()
-                            val retained =
-                                current.messages.filter { existing ->
-                                    if (serverMessageIndex(existing.id, sessionId) != null) {
-                                        true
-                                    } else {
-                                        val duplicate =
-                                            unmatched.indexOfFirst { (role, content) ->
-                                                role == existing.role && content == existing.content
-                                            }
-                                        if (duplicate >= 0) unmatched.removeAt(duplicate)
-                                        duplicate < 0
-                                    }
-                                }
-                            val merged = (retained + incoming).distinctBy { it.id }
-                            if (sameMessages(current.messages, merged)) current else current.copy(messages = merged)
-                        }
+                    _uiState.update { state ->
+                        if (state.currentSessionId != sessionId) return@update state
+                        state.copy(isLoadingOlder = false)
                     }
-
-                    is NetworkResult.Failure -> Unit
                 }
-            } finally {
-                isSyncingMessages = false
             }
         }
     }
-
-    private suspend fun fetchServerMessageCount(sessionId: String): Int {
-        val known = _uiState.value.sessions.find { it.id == sessionId }?.messageCount
-        if (known != null) return known
-        val result =
-            withContext(Dispatchers.IO) {
-                safeApiCall { ApiClient.hermesApi.getSessions(limit = 500, offset = 0, order = "recent") }
-            }
-        if (result is NetworkResult.Success) {
-            val sessions = result.data.sessions.orEmpty()
-            val count = sessions.find { it.id == sessionId }?.message_count
-            if (count != null) {
-                _uiState.update { current ->
-                    current.copy(
-                        sessions =
-                            current.sessions.map {
-                                if (it.id == sessionId) {
-                                    it.copy(
-                                        messageCount = count,
-                                    )
-                                } else {
-                                    it
-                                }
-                            },
-                    )
-                }
-                return count
-            }
-        }
-        return known ?: _uiState.value.messages.size
-    }
-
-    private suspend fun fetchMessagePage(
-        sessionId: String,
-        offset: Int,
-        limit: Int,
-    ) = withContext(Dispatchers.IO) {
-        safeApiCall { ApiClient.hermesApi.getSessionMessages(sessionId, limit = limit, offset = offset) }
-    }
-
-    private fun mapServerMessages(
-        sessionId: String,
-        messages: List<SessionMessage>,
-        offset: Int,
-    ): List<ChatMessage> =
-        messages.mapIndexed { index, msg ->
-            val role =
-                when (msg.role?.lowercase()) {
-                    "user" -> MessageRole.USER
-                    "system" -> MessageRole.SYSTEM
-                    "tool" -> MessageRole.TOOL
-                    else -> MessageRole.ASSISTANT
-                }
-            val globalIndex = offset + index
-            val timestamp =
-                msg.timestampText
-                    ?.toDoubleOrNull()
-                    ?.times(1000)
-                    ?.toLong()
-                    ?: System.currentTimeMillis()
-            ChatMessage(
-                id = "rest-$sessionId-$globalIndex",
-                role = role,
-                content = msg.content.orEmpty(),
-                timestamp = timestamp,
-                isStreaming = false,
-            )
-        }
-
-    private fun serverMessageIndex(
-        id: String,
-        sessionId: String,
-    ): Int? = id.removePrefix("rest-$sessionId-").takeIf { it != id }?.toIntOrNull()
-
-    private fun sameMessages(
-        left: List<ChatMessage>,
-        right: List<ChatMessage>,
-    ): Boolean =
-        left.size == right.size &&
-            left.zip(right).all { (a, b) ->
-                a.id == b.id && a.role == b.role && a.content == b.content
-            }
 
     // ── UI actions ───────────────────────────────────────────────────────
 
@@ -1508,6 +1506,9 @@ class ChatViewModel(
     }
 
     // ── Pending request tracking ─────────────────────────────────────────
+
+    /** Maps an in-flight RPC id → its method, purely for UI error labeling. The deferred/timeout lives in [HermesWsClient.request] (issue #526). */
+    private val idToMethod = ConcurrentHashMap<String, String>()
 
     private fun trackRequest(
         id: String,

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -450,6 +450,10 @@ class ChatViewModel(
                         isLoading = false,
                         messages = emptyList(),
                         chatTitle = "Hermes",
+                        // Fresh session: reset pagination state (issue #551).
+                        currentOffset = 0,
+                        hasReachedOldest = false,
+                        isLoadingOlder = false,
                     )
                 }
                 // Mirror the active session id app-wide so session-scoped
@@ -940,6 +944,11 @@ class ChatViewModel(
                 chatTitle = title,
                 showSessionPicker = false,
                 isAgentTyping = false,
+                // Reset pagination so the new session doesn't inherit the
+                // previous one's offset / reached-oldest state (issue #551).
+                currentOffset = 0,
+                hasReachedOldest = false,
+                isLoadingOlder = false,
             )
         }
         // Mirror the active session id app-wide (issue #532).
@@ -1095,10 +1104,14 @@ class ChatViewModel(
         viewModelScope.launch {
             val result =
                 withContext(Dispatchers.IO) {
+                    // Request only the messages not already loaded. When the
+                    // remaining span is smaller than a full page the last page
+                    // would otherwise overlap the already-loaded page; sizing
+                    // the limit to the real gap avoids duplicate keys (issue #551).
                     safeApiCall {
                         ApiClient.hermesApi.getSessionMessages(
                             sessionId,
-                            limit = PAGE_SIZE,
+                            limit = offset - nextOffset,
                             offset = nextOffset,
                         )
                     }
@@ -1142,10 +1155,9 @@ class ChatViewModel(
                     _uiState.update { state ->
                         if (state.currentSessionId != sessionId) return@update state
                         // Prepend older messages above the existing newer ones.
-                        // Expose lastPrependCount so the UI can preserve scroll
-                        // position (scroll down by that many) and avoid a jump.
+                        // distinctBy guards against any key overlap (issue #551).
                         state.copy(
-                            messages = chatMessages + state.messages,
+                            messages = (chatMessages + state.messages).distinctBy { it.id },
                             isLoadingOlder = false,
                             currentOffset = nextOffset,
                             hasReachedOldest = reachedOldest,

--- a/app/src/test/java/com/m57/hermescontrol/data/remote/HermesApiServiceMockWebServerTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/remote/HermesApiServiceMockWebServerTest.kt
@@ -401,4 +401,30 @@ class HermesApiServiceMockWebServerTest {
             // Backward-compatible: pagination absent on older backend responses.
             assertNull(response.body()!!.pagination)
         }
+
+    @Test
+    fun getSession_parsesMessageCount() =
+        runBlocking {
+            mockServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody(
+                        """
+                        {
+                            "id": "sid",
+                            "title": "Chat",
+                            "message_count": 123,
+                            "status": "active"
+                        }
+                        """.trimIndent(),
+                    ),
+            )
+
+            val response = api.getSession("sid")
+            assertTrue(response.isSuccessful)
+            val body = response.body()
+            assertNotNull(body)
+            assertEquals("sid", body!!.id)
+            assertEquals(123, body.message_count)
+        }
 }

--- a/app/src/test/java/com/m57/hermescontrol/data/remote/HermesApiServiceMockWebServerTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/remote/HermesApiServiceMockWebServerTest.kt
@@ -338,4 +338,67 @@ class HermesApiServiceMockWebServerTest {
                 request.path!!.contains("session/with/slashes"),
             )
         }
+
+    @Test
+    fun getSessionMessages_sendsLimitAndOffsetQueryParams() =
+        runBlocking {
+            mockServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody(
+                        """
+                        {
+                            "messages": [
+                                { "role": "user", "content": "older", "timestamp": "1000" }
+                            ],
+                            "pagination": { "limit": 50, "offset": 100, "returned": 1 }
+                        }
+                        """.trimIndent(),
+                    ),
+            )
+
+            val response = api.getSessionMessages("sid", limit = 50, offset = 100)
+            assertTrue(response.isSuccessful)
+
+            val request = mockServer.takeRequest()
+            assertTrue(
+                "limit query param should be sent (issue #551)",
+                request.path!!.contains("limit=50"),
+            )
+            assertTrue(
+                "offset query param should be sent (issue #551)",
+                request.path!!.contains("offset=100"),
+            )
+
+            // Pagination metadata should parse when present.
+            val body = response.body()
+            assertNotNull(body)
+            assertNotNull(body!!.pagination)
+            assertEquals(50, body.pagination!!.limit)
+            assertEquals(100, body.pagination!!.offset)
+            assertEquals(1, body.pagination!!.returned)
+        }
+
+    @Test
+    fun getSessionMessages_handlesMissingPagination() =
+        runBlocking {
+            mockServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody(
+                        """
+                        {
+                            "messages": [
+                                { "role": "user", "content": "hi", "timestamp": "1000" }
+                            ]
+                        }
+                        """.trimIndent(),
+                    ),
+            )
+
+            val response = api.getSessionMessages("sid", limit = 50, offset = 0)
+            assertTrue(response.isSuccessful)
+            // Backward-compatible: pagination absent on older backend responses.
+            assertNull(response.body()!!.pagination)
+        }
 }


### PR DESCRIPTION
## Summary
Lazy-load pagination for session message history (issue #551).

### Backend contract (verified from `hermes_state.py` source)
`get_messages` returns **insertion order (oldest→newest)**, `offset` skips from the start, `limit` clamps to 500. The pagination envelope has **no total** — the true count comes from `SessionInfo.message_count` (via `GET /api/sessions/{id}`).

### Implementation
- **`HermesApiService`**: `getSessionMessages` gains `@Query("limit")` (default 50) + `@Query("offset")`; new `getSession(id)` detail call for the message count.
- **`ChatViewModel`**: first page loads `offset = max(0, total - PAGE_SIZE)` (newest page shown first, auto-scrolled). `loadOlderMessages()` prepends an older page at `offset - PAGE_SIZE`. Stable IDs `rest-<session>-<offset+index>` = true absolute backend position → Room upserts never collide across pages. Older-page request is sized to the real gap (`limit = offset - nextOffset`) and the prepend does `distinctBy { id }` so the clamped final page can't produce duplicate LazyColumn keys (would otherwise crash). Pagination state resets on `switchSession` / `SESSION_CREATE`. New state: `totalMessageCount`, `currentOffset`, `isLoadingOlder`, `hasReachedOldest`.
- **`ChatScreen`**: a `load_older_header` item at the top of the list shows a spinner; scrolling it into view fires `LaunchedEffect(Unit)` once → `loadOlderMessages()`. It leaves composition after the prepend (Compose stable-key scroll preservation), does not auto-retry on network failure, and cannot infinite-loop (offset decreases monotonically to 0).
- **`SessionMessagesResponse`**: nullable `pagination` field (backward compatible).

### agy review (Gemini 3.5 Flash High) — all findings addressed
1. Room key collision / duplicate-message crash → fixed (gap-sized limit + distinctBy)
2. Double-fetch race → `isLoadingOlder` set synchronously before launch
3. Infinite scroll loop → trigger tied to header composition, not isLoadingOlder
4. Viewport jump → rely on Compose stable-key preservation, drop manual scroll
5. Session-switch pagination state leak → reset in switchSession / SESSION_CREATE
6. Network-failure retry loop → `LaunchedEffect(Unit)` fires once per composition

## Test plan
- [x] `compileDebugKotlin` BUILD SUCCESSFUL (ktlint clean)
- [x] `HermesApiServiceMockWebServerTest` green (+3 new tests: query params sent, pagination parses, getSession parses message_count)
- [ ] Manual: open a session with >50 messages, scroll to top, confirm older page loads/prepends without dup or jump; switch sessions; verify pagination resets