### PR TITLE
fix: shorten chat banner status text + prevent relogin button squish

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
@@ -1615,7 +1616,10 @@ private fun ChatTopBanner(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
+                Row(
+                    modifier = Modifier.weight(1f),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
                     if (connectionStatus == ConnectionStatus.RECONNECTING) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(16.dp).padding(end = 8.dp),
@@ -1624,6 +1628,9 @@ private fun ChatTopBanner(
                         )
                     }
                     Text(
+                        modifier = Modifier.weight(1f, fill = false),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
                         text =
                             when (connectionStatus) {
                                 ConnectionStatus.RECONNECTING -> stringResource(R.string.chat_status_reconnecting)

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,10 +101,10 @@
     <string name="chat_empty_title">Ready to chat</string>
     <string name="chat_empty_subtitle">Send a message to start a conversation</string>
     <string name="chat_status_connecting">Connecting to Hermes\u2026</string>
-    <string name="chat_status_reconnecting">Reconnecting to Hermes\u2026</string>
-    <string name="chat_status_disconnected">Disconnected from Hermes</string>
-    <string name="chat_status_no_network">No network connection</string>
-    <string name="chat_status_auth_expired">Session expired \u2014 please sign in again</string>
+    <string name="chat_status_reconnecting">Reconnecting\u2026</string>
+    <string name="chat_status_disconnected">Disconnected</string>
+    <string name="chat_status_no_network">No network</string>
+    <string name="chat_status_auth_expired">Session expired</string>
     <string name="chat_thinking">Thinking\u2026</string>
     <string name="chat_thinking_param">Thinking: %1$s\u2026</string>
     <string name="chat_reasoning">Reasoning</string>


### PR DESCRIPTION
## Summary
- Shorten the four `ChatTopBanner` status strings so the right-aligned action buttons (Re-login / Reconnect) no longer get pushed off-screen on narrow widths:
  - `chat_status_disconnected`: "Disconnected from Hermes" -> "Disconnected"
  - `chat_status_reconnecting`: "Reconnecting to Hermes…" -> "Reconnecting…"
  - `chat_status_no_network`: "No network connection" -> "No network"
  - `chat_status_auth_expired`: "Session expired — please sign in again" -> "Session expired"
- Layout hardening in `ChatTopBanner` (`ChatScreen.kt`):
  - Left status row now `Modifier.weight(1f)` so it takes only its fair share of the row.
  - Status `Text` gets `weight(1f, fill = false)` + `maxLines = 1` + `TextOverflow.Ellipsis`, so any future long string ellipsizes instead of squishing the buttons.

## Why
The AUTH_EXPIRED / DISCONNECTED variants previously rendered long copy next to the Relogin button, compressing it at the row's end on smaller screens.

## Verification
- `./ktlint app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt` -> clean (exit 0, import order OK).

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)