### PR TITLE
ci: bump unit-tests timeout 10->30m (build/release-compile 10->20m)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -120,7 +120,7 @@ jobs:
   unit-tests:
     name: Unit & Integration Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -158,7 +158,7 @@ jobs:
     name: Build Debug APK
     needs: [ktlint, android-lint, unit-tests]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -200,7 +200,7 @@ jobs:
     name: Release Compile Check
     needs: [ktlint, android-lint, unit-tests]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
Fixes a CI reliability bug: the `unit-tests` job (`./gradlew test`, full suite) is killed by GitHub's 10-minute job timeout on hosted runners with a cold Gradle cache, reporting red even when all tests pass.

**Changes (`android.yml`):**
- `unit-tests` job: `timeout-minutes: 10` → `30`
- `build` (assembleDebug) job: `timeout-minutes: 10` → `20`
- `release-compile` (compileReleaseKotlin) job: `timeout-minutes: 10` → `20`

**Evidence:** Run `29254433734` failed at **10m32s** on the `unit-tests` job — a timeout kill, not a test failure. Local full-suite runs on the same codebase take 50+ min, confirming the suite simply needs more than 10 min on first/code-cache-miss runs.

No source/test changes — purely a CI config adjustment. ci-summary and all other jobs are untouched.

## Test plan
- [ ] Merge and confirm a subsequent PR's `Unit & Integration Tests` job completes green within 30 min
- [ ] `Build Debug APK` and `Release Compile Check` complete within 20 min
