### PR TITLE
fix: clarify Dismiss now informs the agent instead of silently dropping

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -105,6 +105,14 @@ data class ClarifyUi(
     val clarifyId: String? = null,
 )
 
+/**
+ * String sent to the agent when a clarify prompt is dismissed (the Dismiss
+ * button). Mirrors the CLI's interrupt-cancel sentinel (cli.py:12036) so the
+ * agent reads a dismiss identically across CLI / desktop / mobile and proceeds
+ * on its own judgement instead of re-prompting.
+ */
+private const val CLARIFY_DISMISS_RESPONSE = "The user cancelled. Use your best judgement to proceed."
+
 /** Transient — not persisted. Holds a pending sudo.password request. */
 data class SudoPromptUi(
     val requestId: String?,
@@ -1225,8 +1233,44 @@ class ChatViewModel(
         _uiState.update { it.copy(showSessionPicker = !it.showSessionPicker) }
     }
 
+    /**
+     * Dismiss the active clarify prompt and tell the agent it was cancelled.
+     *
+     * The backend's clarify tool blocks the agent thread waiting for a response
+     * (CLI timeout is 120s). A silent dismiss would leave the agent hanging
+     * until that timeout, so we send the same cancel sentinel the CLI pushes on
+     * interrupt (cli.py:12036): "The user cancelled. Use your best judgement to
+     * proceed." — the agent reads it as "decide on your own" and continues.
+     *
+     * Unlike [respondToClarify] we do NOT append a user chat bubble: a dismiss
+     * is not something the user typed, so faking a USER message would be
+     * dishonest. We instead surface a short SYSTEM note so the dismissal is
+     * visible in the transcript.
+     */
     fun dismissClarify() {
+        val sessionId = _uiState.value.currentSessionId ?: return
+        val clarifyId = _uiState.value.clarifyRequest?.clarifyId
         _uiState.update { it.copy(clarifyRequest = null) }
+
+        addSystemMessage("Clarify dismissed — agent will decide on its own", persist = true)
+
+        viewModelScope.launch(Dispatchers.IO) {
+            val params =
+                mutableMapOf<String, Any>(
+                    "session_id" to sessionId,
+                    "response" to CLARIFY_DISMISS_RESPONSE,
+                    "answer" to CLARIFY_DISMISS_RESPONSE,
+                )
+            if (clarifyId != null) {
+                params["clarify_id"] = clarifyId
+                params["request_id"] = clarifyId
+            }
+            wsClient.send(
+                method = WsMethods.CLARIFY_RESPOND,
+                params = params,
+                onSent = { id -> trackRequest(id, WsMethods.CLARIFY_RESPOND) },
+            )
+        }
     }
 
     fun respondToClarify(option: String) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -107,11 +107,14 @@ data class ClarifyUi(
 
 /**
  * String sent to the agent when a clarify prompt is dismissed (the Dismiss
- * button). Mirrors the CLI's interrupt-cancel sentinel (cli.py:12036) so the
- * agent reads a dismiss identically across CLI / desktop / mobile and proceeds
- * on its own judgement instead of re-prompting.
+ * button). This is a *reject* — "I'm not answering this question" — NOT an
+ * instruction to proceed. Deliberately NOT the CLI's interrupt sentinel
+ * ("...Use your best judgement to proceed."): a mobile Dismiss is a
+ * skip-the-question gesture, not an interrupt of the whole turn. The agent is
+ * unblocked but told no answer was given, so it re-asks or backs off rather
+ * than charging ahead.
  */
-private const val CLARIFY_DISMISS_RESPONSE = "The user cancelled. Use your best judgement to proceed."
+private const val CLARIFY_DISMISS_RESPONSE = "The user cancelled — no answer provided."
 
 /** Transient — not persisted. Holds a pending sudo.password request. */
 data class SudoPromptUi(
@@ -1234,13 +1237,16 @@ class ChatViewModel(
     }
 
     /**
-     * Dismiss the active clarify prompt and tell the agent it was cancelled.
+     * Dismiss the active clarify prompt and reject it (tell the agent no answer
+     * was given).
      *
      * The backend's clarify tool blocks the agent thread waiting for a response
      * (CLI timeout is 120s). A silent dismiss would leave the agent hanging
-     * until that timeout, so we send the same cancel sentinel the CLI pushes on
-     * interrupt (cli.py:12036): "The user cancelled. Use your best judgement to
-     * proceed." — the agent reads it as "decide on your own" and continues.
+     * until that timeout, so we send a cancel sentinel
+     * ([CLARIFY_DISMISS_RESPONSE]) over `clarify.respond` to unblock it.
+     *
+     * This is a *reject*, not an instruction to proceed — the agent is told no
+     * answer was provided and should re-ask or back off, NOT charge ahead.
      *
      * Unlike [respondToClarify] we do NOT append a user chat bubble: a dismiss
      * is not something the user typed, so faking a USER message would be
@@ -1252,7 +1258,7 @@ class ChatViewModel(
         val clarifyId = _uiState.value.clarifyRequest?.clarifyId
         _uiState.update { it.copy(clarifyRequest = null) }
 
-        addSystemMessage("Clarify dismissed — agent will decide on its own", persist = true)
+        addSystemMessage("Clarify dismissed — no answer sent", persist = true)
 
         viewModelScope.launch(Dispatchers.IO) {
             val params =

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -800,8 +800,8 @@ class ChatViewModelTest {
                     params =
                         mapOf(
                             "session_id" to sessionId,
-                            "response" to "The user cancelled. Use your best judgement to proceed.",
-                            "answer" to "The user cancelled. Use your best judgement to proceed.",
+                            "response" to "The user cancelled — no answer provided.",
+                            "answer" to "The user cancelled — no answer provided.",
                             "clarify_id" to "clarify-789",
                             "request_id" to "clarify-789",
                         ),

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -766,6 +766,50 @@ class ChatViewModelTest {
             }
         }
 
+    @Test
+    fun testClarifyDismissInformsAgent() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+
+            mockEventsFlow.emit(
+                WsEvent.ClarifyRequest(
+                    "Please choose:",
+                    listOf("Yes", "No"),
+                    "clarify-789",
+                ),
+            )
+            advanceUntilIdle()
+            assertEquals("clarify-789", viewModel.uiState.value.clarifyRequest?.clarifyId)
+
+            viewModel.dismissClarify()
+            advanceUntilIdle()
+
+            // Dialog dismissed locally
+            assertNull(viewModel.uiState.value.clarifyRequest)
+            // Baseline has 1 "Connected" system message; dismiss adds exactly
+            // ONE system note and must NOT fake a user bubble.
+            val messages = viewModel.uiState.value.messages
+            assertEquals(2, messages.size)
+            assertEquals(MessageRole.SYSTEM, messages[0].role) // pre-existing "Connected"
+            assertEquals(MessageRole.SYSTEM, messages[1].role) // dismiss trace
+            assertTrue(messages[1].content.contains("dismissed", ignoreCase = true))
+
+            verify {
+                HermesWsClient.send(
+                    WsMethods.CLARIFY_RESPOND,
+                    params =
+                        mapOf(
+                            "session_id" to sessionId,
+                            "response" to "The user cancelled. Use your best judgement to proceed.",
+                            "answer" to "The user cancelled. Use your best judgement to proceed.",
+                            "clarify_id" to "clarify-789",
+                            "request_id" to "clarify-789",
+                        ),
+                    onSent = any(),
+                )
+            }
+        }
+
     // ── Attachments ──────────────────────────────────────────────────────────
 
     /** Add [count] dummy attachments so a test starts with a populated list. */


### PR DESCRIPTION
## Problem
The clarify dialog's **Dismiss** button called `dismissClarify()`, which only nulled `clarifyRequest` in UI state and sent **nothing** to the backend. The agent's clarify tool blocks its worker thread waiting for a response (CLI timeout is 120s), so dismissing left the agent hanging until that timeout — the same foot-gun already fixed for sudo/secret (#524).

## Fix
`ChatViewModel.dismissClarify()` now:
- Sends `clarify.respond` with a **reject sentinel**: `"The user cancelled — no answer provided."` — a *skip-the-question* gesture, NOT an instruction to proceed. The agent is unblocked but told no answer was given, so it re-asks or backs off rather than charging ahead. (Deliberately NOT the CLI's interrupt string `"...Use your best judgement to proceed."` — a mobile Dismiss rejects the question; it does not interrupt the whole turn.)
- Sends the full param map (`session_id`, `response`, `answer`, `clarify_id`, `request_id`) — matching `respondToClarify` — so the backend's `_respond` bridge actually unblocks the waiter.
- Does **not** fake a USER chat bubble (a dismiss isn't typed input); instead appends a short SYSTEM note ("Clarify dismissed — no answer sent") so the dismissal is visible in the transcript.

The `ChatScreen` wiring (`onDismiss = viewModel::dismissClarify`) needed no change — it now transparently gains the new behavior.

## Verification
- `./ktlint` → clean
- `./gradlew testDebugUnitTest` (ChatViewModelTest) → **51 tests, 0 failures**, including `testClarifyDismissInformsAgent` which asserts the dismiss fires `clarify.respond` with the exact reject sentinel + clears state + adds no user bubble.

## Notes
- Commit references `#572` as a placeholder — update if a real issue exists.
- Split out from the clarify-dialog scroll fix (#579) so each PR is single-purpose.