### PR TITLE
[enhancement] fix(#575): drop description text from slash-command suggestions

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -717,11 +717,8 @@ private fun ChatInputBar(
             elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
         ) {
             Column {
-                // Build command list from dynamic catalog (pairs = [name, description])
-                val allCommands = commandCatalog.pairs.associate { (name, desc) -> name to desc }
-                // Commands hidden from suggestion menu (still work when manually typed)
-                val hiddenSlashDisplay = setOf("/stop", "/interrupt")
-                val commandNames = allCommands.keys.filter { it !in hiddenSlashDisplay }
+                // All catalog commands are offered in the suggestion menu
+                val commandNames = commandCatalog.pairs.map { it[0] }
 
                 androidx.compose.animation.AnimatedVisibility(
                     visible = inputText.startsWith("/") && !inputText.contains(" "),

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -747,24 +747,13 @@ private fun ChatInputBar(
                                 modifier = Modifier.heightIn(max = 200.dp),
                             ) {
                                 items(filteredCommands, key = { it }) { cmd ->
-                                    val description = allCommands[cmd] ?: ""
                                     DropdownMenuItem(
                                         text = {
-                                            Row(
-                                                modifier = Modifier.fillMaxWidth(),
-                                                horizontalArrangement = Arrangement.SpaceBetween,
-                                            ) {
-                                                Text(
-                                                    cmd,
-                                                    fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-                                                    color = MaterialTheme.colorScheme.primary,
-                                                )
-                                                Text(
-                                                    description,
-                                                    style = MaterialTheme.typography.bodySmall,
-                                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                )
-                                            }
+                                            Text(
+                                                cmd,
+                                                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                                                color = MaterialTheme.colorScheme.primary,
+                                            )
                                         },
                                         onClick = { onInputChange(cmd) },
                                     )


### PR DESCRIPTION
Closes #575.

Two changes to the slash-command suggestion dropdown in ChatScreen:
1. Drop the description text — each suggestion row now renders only the command name (bold, primary color).
2. Show `/stop` and `/interrupt` in the menu again. They were previously filtered out by a `hiddenSlashDisplay` set; that filter is removed so all catalog commands appear in the suggestion list (they still worked when typed manually).

`commandCatalog.pairs` is `List<List<String>>` (not `List<Pair>`), so names are extracted via `it[0]`.

Note: per m57's direction this push skipped the local ktlint/test gate run — CI is the verification engine. Prior local run of `ktlintCheck testDebugUnitTest` was green before the `/stop`/`/interrupt` change.