### PR TITLE
fix(#574): hide desktop/CLI-only slash commands from mobile suggestions

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -717,11 +717,8 @@ private fun ChatInputBar(
             elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
         ) {
             Column {
-                // Build command list from dynamic catalog (pairs = [name, description])
-                val allCommands = commandCatalog.pairs.associate { (name, desc) -> name to desc }
-                // Commands hidden from suggestion menu (still work when manually typed)
-                val hiddenSlashDisplay = setOf("/stop", "/interrupt")
-                val commandNames = allCommands.keys.filter { it !in hiddenSlashDisplay }
+                // All catalog commands are offered in the suggestion menu
+                val commandNames = commandCatalog.pairs.map { it[0] }
 
                 androidx.compose.animation.AnimatedVisibility(
                     visible = inputText.startsWith("/") && !inputText.contains(" "),

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -717,8 +717,47 @@ private fun ChatInputBar(
             elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
         ) {
             Column {
-                // All catalog commands are offered in the suggestion menu
-                val commandNames = commandCatalog.pairs.map { it[0] }
+                // Commands hidden from the suggestion menu — desktop/CLI-only and
+                // TUI-only commands that don't function on mobile (issue #574).
+                // Source of truth: backend `cli_only` / TUI-only flags in the catalog.
+                val hiddenSlashDisplay =
+                    setOf(
+                        "/clear",
+                        "/redraw",
+                        "/history",
+                        "/save",
+                        "/prompt",
+                        "/snapshot",
+                        "/handoff",
+                        "/journey",
+                        "/config",
+                        "/statusbar",
+                        "/timestamps",
+                        "/verbose",
+                        "/skin",
+                        "/indicator",
+                        "/busy",
+                        "/tools",
+                        "/toolsets",
+                        "/skills",
+                        "/pet",
+                        "/hatch",
+                        "/cron",
+                        "/reload",
+                        "/browser",
+                        "/plugins",
+                        "/billing",
+                        "/platforms",
+                        "/copy",
+                        "/paste",
+                        "/image",
+                        "/quit",
+                        // TUI-only extras (meaningless outside the TUI)
+                        "/compact",
+                        "/logs",
+                        "/mouse",
+                    )
+                val commandNames = commandCatalog.pairs.map { it[0] }.filter { it !in hiddenSlashDisplay }
 
                 androidx.compose.animation.AnimatedVisibility(
                     visible = inputText.startsWith("/") && !inputText.contains(" "),

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -747,24 +747,13 @@ private fun ChatInputBar(
                                 modifier = Modifier.heightIn(max = 200.dp),
                             ) {
                                 items(filteredCommands, key = { it }) { cmd ->
-                                    val description = allCommands[cmd] ?: ""
                                     DropdownMenuItem(
                                         text = {
-                                            Row(
-                                                modifier = Modifier.fillMaxWidth(),
-                                                horizontalArrangement = Arrangement.SpaceBetween,
-                                            ) {
-                                                Text(
-                                                    cmd,
-                                                    fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
-                                                    color = MaterialTheme.colorScheme.primary,
-                                                )
-                                                Text(
-                                                    description,
-                                                    style = MaterialTheme.typography.bodySmall,
-                                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                )
-                                            }
+                                            Text(
+                                                cmd,
+                                                fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+                                                color = MaterialTheme.colorScheme.primary,
+                                            )
                                         },
                                         onClick = { onInputChange(cmd) },
                                     )


### PR DESCRIPTION
## Summary
- Recreates the `hiddenSlashDisplay` blocklist (removed in `1f322e3` / #575) on the chat input suggestion dropdown.
- Populates it with the **33** commands that are `cli_only` or TUI-only in the backend `COMMAND_REGISTRY` and therefore do not function on mobile (issue #574).
- Deliberately does **not** re-hide `/stop` and `/interrupt` — those work on mobile and were intentionally un-hidden by #575.
- `ktlintCheck` clean; `compileDebugKotlin` BUILD SUCCESSFUL (no new errors).

## Blocklist source
Derived directly from the backend catalog (`hermes_cli/commands.py` `cli_only=True` + `tui_gateway/server.py` `_TUI_EXTRA`):
```
/clear /redraw /history /save /prompt /snapshot /handoff /journey /config
/statusbar /timestamps /verbose /skin /indicator /busy /tools /toolsets /skills
/pet /hatch /cron /reload /browser /plugins /billing /platforms /copy /paste
/image /quit /compact /logs /mouse
```

## Caveat (follow-up)
This is the stopgap the issue proposed. It **rots** whenever the backend adds a new `cli_only` command — it will not auto-appear here. The durable fix is to have `commands.catalog` emit a `cli_only` / `mobile_unsupported` flag per entry so the client filters data-driven. A companion change to the hermes-agent backend is being prepared separately.

Closes #574