### PR TITLE
fix(#587): forward session_id on image.attach_bytes and await the RPC

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -694,17 +694,29 @@ class ChatViewModel(
 
                 try {
                     if (attachment.isImage) {
-                        // Fire-and-forget — backend queues into session["attached_images"],
-                        // auto-picked by the subsequent prompt.submit
-                        wsClient.send(
-                            method = WsMethods.IMAGE_ATTACH_BYTES,
-                            params =
-                                mapOf(
-                                    "content_base64" to "data:${attachment.mimeType};base64,$b64",
-                                    "filename" to attachment.name,
-                                    "ext" to attachment.fileExtension,
-                                ),
-                        )
+                        // Await so the backend stages the image into
+                        // session["attached_images"] BEFORE prompt.submit runs
+                        // (a fire-and-forget send raced prompt.submit and the
+                        // image was dropped). Requires session_id or the gateway
+                        // 4001s "session not found" (desktop passes it too).
+                        val result =
+                            sendRpcAndAwait(
+                                method = WsMethods.IMAGE_ATTACH_BYTES,
+                                params =
+                                    mapOf(
+                                        "session_id" to agentSessionId,
+                                        "content_base64" to "data:${attachment.mimeType};base64,$b64",
+                                        "filename" to attachment.name,
+                                        "ext" to attachment.fileExtension,
+                                    ),
+                            )
+                        if (result != null) {
+                            @Suppress("UNCHECKED_CAST")
+                            val ok = (result as? Map<String, Any?>)?.get("attached") as? Boolean
+                            if (ok != true) {
+                                Log.w(TAG, "Image attach for ${attachment.name} returned non-ok: $result")
+                            }
+                        }
                     } else {
                         // Await the @file: ref text so we can embed it in the prompt
                         sendRpcAndAwait(

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -642,8 +642,8 @@ class ChatViewModel(
      * Flow:
      * 1. Snapshot pending attachments (then clear them from UI)
      * 2. Add user message to UI + DB immediately (optimistic UX)
-     * 3. For each image → fire-and-forget `image.attach_bytes` (queues into session)
-     * 4. For each file → await `file.attach`, collect @file: refs
+     * 3. For each image → await `image.attach_bytes` (requires session_id)
+     * 4. For each file → await `file.attach` (requires session_id), collect @file: refs
      * 5. Send `prompt.submit` with text + @file: refs — images auto-picked up by backend
      */
     fun sendMessage(text: String) {
@@ -718,11 +718,14 @@ class ChatViewModel(
                             }
                         }
                     } else {
-                        // Await the @file: ref text so we can embed it in the prompt
+                        // Await the @file: ref text so we can embed it in the prompt.
+                        // file.attach also requires session_id or the gateway 4001s
+                        // "session not found" (same resolver as image.attach_bytes).
                         sendRpcAndAwait(
                             method = WsMethods.FILE_ATTACH,
                             params =
                                 mapOf(
+                                    "session_id" to agentSessionId,
                                     "data_url" to "data:${attachment.mimeType};base64,$b64",
                                     "name" to attachment.name,
                                 ),

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -17,8 +17,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -1394,6 +1396,71 @@ class ChatViewModelTest {
                     viewModel.uiState.value.messages
                         .any { it.content == "Here is an image" }
             assertTrue("Message should still be sent despite attachment read failure", sent)
+        }
+
+    /**
+     * Regression for the "session not found" (code 4001) error when sending an
+     * image: the mobile image-attach path must pass `session_id` to
+     * `image.attach_bytes` (the gateway resolves the session from it; desktop
+     * does the same). Without it the backend 4001s and the image is dropped.
+     * Also asserts the image attach is AWAITED (staged before prompt.submit),
+     * not fire-and-forget.
+     */
+    @Test
+    fun testSendMessage_imageAttachment_sendsSessionId() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+
+            // sendRpcAndAwait calls HermesWsClient.request(method, params) — the
+            // 2-arg form (Kotlin synthesizes request(String, Map)). Stub that
+            // exact signature, capture params, and return a completed deferred
+            // so the await resolves without hanging.
+            val paramsSlot = slot<Map<String, Any>>()
+            every {
+                HermesWsClient.request(any(), capture(paramsSlot), any())
+            } returns CompletableDeferred<Any?>(mapOf("attached" to true))
+
+            // Mock Android's Base64OutputStream constructor to avoid "Stub!" exception in JVM tests
+            io.mockk.mockkConstructor(android.util.Base64OutputStream::class)
+            every {
+                anyConstructed<android.util.Base64OutputStream>().write(
+                    any<ByteArray>(),
+                    any(),
+                    any(),
+                )
+            } returns Unit
+            every { anyConstructed<android.util.Base64OutputStream>().close() } returns Unit
+
+            // The image bytes read via ContentResolver must succeed.
+            mockkStatic(Uri::class)
+            val mockUri = mockk<Uri>()
+            every { Uri.parse("content://dummy") } returns mockUri
+            val contentResolver = mockk<ContentResolver>()
+            every { app.contentResolver } returns contentResolver
+            every { contentResolver.openInputStream(any()) } returns
+                java.io.ByteArrayInputStream(byteArrayOf(1, 2, 3, 4))
+
+            viewModel.addAttachment("content://dummy", "test.png", "image/png", 1000)
+            advanceUntilIdle()
+            assertTrue(
+                "pendingAttachments must contain the image before send",
+                viewModel.uiState.value.pendingAttachments.isNotEmpty(),
+            )
+            assertTrue(
+                "attached png must have isImage=true",
+                viewModel.uiState.value.pendingAttachments.first().isImage,
+            )
+
+            viewModel.sendMessage("Here is an image")
+            advanceUntilIdle()
+
+            // Verify the image attach RPC was issued with session_id.
+            verify { HermesWsClient.request(WsMethods.IMAGE_ATTACH_BYTES, any()) }
+            assertEquals(
+                "session_id must be forwarded to image.attach_bytes",
+                sessionId,
+                paramsSlot.captured["session_id"],
+            )
         }
 
     // ── Pending request timeout + rejectAllPending (issue #526) ───────────


### PR DESCRIPTION
## Problem
Sending an image OR a non-image file in chat failed with `JsonRpcError(code=4001, message=session not found)`.

## Root cause
`ChatViewModel.sendMessage` called `image.attach_bytes` and `file.attach` **without** the required `session_id` param. Both backend handlers resolve the session via `_sess(params, rid)` (`tui_gateway/server.py`), which returns 4001 when `session_id` is absent. The desktop client (`use-prompt-actions/index.ts`) already passes `session_id` — mobile was the outlier.

Camera capture is **unaffected**: it produces an `image/jpeg` attachment, which routes through the (fixed) `image.attach_bytes` branch.

## Fix (in `app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt`)
- Add `"session_id" to agentSessionId` to both the `image.attach_bytes` and `file.attach` params.
- Switch both attachment branches from fire-and-forget `wsClient.send` to the **awaited** `sendRpcAndAwait(...)` layer (same awaited-RPC path used for slash commands, #526). This also closes two related defects per branch:
  - **Race**: `prompt.submit` could previously fire before the attachment was staged on the backend.
  - **Silent failure**: fire-and-forget `send` swallowed RPC errors; the awaited path surfaces them.

## Test (in `app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt`)
- `testSendMessage_imageAttachment_sendsSessionId` — regression proving the `image.attach_bytes` RPC carries `session_id`. (The MockK blocker proved to be `android.util.Base64OutputStream`'s constructor throwing "Stub!" on the JVM test; mocking the ctor lets `readContentUriBase64` succeed so the request stub captures the params.)
- Full `ChatViewModelTest` suite passes; ktlint-clean.

## Verification
- Root cause confirmed against backend source (`_sess`) and the desktop reference client.
- Both `ChatViewModel.kt` and `ChatViewModelTest.kt` pass `ktlintCheck`.
- `./gradlew testDebugUnitTest` green for the whole `ChatViewModelTest` class.

Closes #587. Related: #573 (inline render, receive side), #526 (awaited RPC layer).

## Note for maintainers
CI is the build/test truth engine — I have **not** merged or force-pushed. Once CI is green on this PR I will confirm before any merge, and will not merge without explicit go-ahead.