### PR TITLE
fix(#583): scroll-to-bottom aligns last message bottom to viewport

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -479,7 +480,7 @@ fun ChatScreen(
                                 (if (streamingState.streamingMessage != null) 1 else 0) +
                                 (if (streamingState.isThinking) 1 else 0)
                         if (totalItems > 0) {
-                            listState.animateScrollToItem(totalItems - 1)
+                            listState.scrollToBottom(animated = true)
                         }
                     }
                 },
@@ -1469,6 +1470,36 @@ private fun LazyListState.isAtBottom(threshold: Int = 3): Boolean {
     return lastVisibleItem.index >= layoutInfo.totalItemsCount - threshold
 }
 
+/**
+ * Scroll so the bottom edge of the last item is aligned to the bottom of the
+ * viewport (issue #583).
+ *
+ * `animateScrollToItem(lastIndex)` only top-aligns the last item, so when the
+ * last item is taller than the viewport its bottom is clipped below the fold.
+ * We first top-align (instant), then scroll the exact remaining gap so the
+ * bottom is visible. Using the remaining delta (not `scrollOffset = Int.MAX_VALUE`)
+ * avoids integer overflow in the internal scroll-position clamp, which would
+ * otherwise wrap the offset to 0 and scroll back to the top.
+ */
+private suspend fun LazyListState.scrollToBottom(animated: Boolean) {
+    val layoutInfo = this.layoutInfo
+    if (layoutInfo.totalItemsCount == 0) return
+    val lastIndex = layoutInfo.totalItemsCount - 1
+    // Top-align the last item first so layoutInfo reflects the last item's offset.
+    scrollToItem(lastIndex)
+    val info = this.layoutInfo
+    val lastItem = info.visibleItemsInfo.lastOrNull { it.index == lastIndex } ?: return
+    val remaining =
+        (lastItem.offset + lastItem.size + info.afterContentPadding) - info.viewportEndOffset
+    if (remaining > 0) {
+        if (animated) {
+            animateScrollBy(remaining.toFloat())
+        } else {
+            scroll { scrollBy(remaining.toFloat()) }
+        }
+    }
+}
+
 @Composable
 private fun ChatLifecycleEffects(
     sessionId: String?,
@@ -1561,9 +1592,9 @@ private fun ChatLifecycleEffects(
             val isSessionSwitch = currentSessionId != lastSessionId
             if (isSessionSwitch) {
                 lastSessionId = currentSessionId
-                listState.scrollToItem(totalItems - 1)
+                listState.scrollToBottom(animated = false)
             } else if (listState.isAtBottom()) {
-                listState.animateScrollToItem(totalItems - 1)
+                listState.scrollToBottom(animated = true)
             }
         }
     }
@@ -1957,7 +1988,7 @@ private fun BoxScope.ChatScrollToBottomFab(
                             (if (streamingMessage != null) 1 else 0) +
                             (if (isThinking) 1 else 0)
                     if (totalItems > 0) {
-                        listState.animateScrollToItem(totalItems - 1)
+                        listState.scrollToBottom(animated = true)
                     }
                 }
             },

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -1486,7 +1486,13 @@ private suspend fun LazyListState.scrollToBottom(animated: Boolean) {
     if (layoutInfo.totalItemsCount == 0) return
     val lastIndex = layoutInfo.totalItemsCount - 1
     // Top-align the last item first so layoutInfo reflects the last item's offset.
-    scrollToItem(lastIndex)
+    // When animated, use the animated variant so the FAB / send clicks keep a
+    // smooth scroll instead of an instant jump followed by a tiny animation.
+    if (animated) {
+        animateScrollToItem(lastIndex)
+    } else {
+        scrollToItem(lastIndex)
+    }
     val info = this.layoutInfo
     val lastItem = info.visibleItemsInfo.lastOrNull { it.index == lastIndex } ?: return
     val remaining =


### PR DESCRIPTION
## Summary

Fixes #583 — the scroll-to-bottom FAB (and send-message auto-scroll + session-switch) used `animateScrollToItem(totalItems - 1)`, which only **top-aligns** the last item. When the last message is taller than the viewport (long assistant answer, streaming message, code block), its bottom was clipped below the fold — it looked like it "jumped to the top of the last message" instead of scrolling all the way down.

## Fix

Added a `LazyListState.scrollToBottom(animated)` helper that:
1. top-aligns the last item instantly (`scrollToItem(lastIndex)`), then
2. computes the exact remaining delta from `layoutInfo` and scrolls it via `animateScrollBy` (animated) or `scroll { scrollBy(...) }` (instant), so the **bottom edge** of the last item is aligned to the viewport bottom.

Applied to all 3 reported call sites (+ the FAB):
- `ChatScreen.kt:482` send-button auto-scroll → `scrollToBottom(animated = true)`
- `ChatScreen.kt:1564-1566` auto-scroll-on-new-message / session-switch → `scrollToBottom`
- `ChatScreen.kt:1960` FAB → `scrollToBottom(animated = true)`

## Why not `scrollOffset = Int.MAX_VALUE`?

The issue's first suggested option overflows. `snapToItemIndexInternal` only *stores* the offset (`requestPositionAndForgetLastKnownKey(index, Int.MAX_VALUE)`); the real clamp runs at measurement as `itemOffset + Int.MAX_VALUE`, which wraps `Int` to a negative value, clamps to 0, and scrolls back to the **top**. The remaining-delta approach has no overflow path, so it's correct for arbitrarily tall last items.

## Verification

- `./gradlew ktlintCheck` — PASS
- `./gradlew compileDebugKotlin` — PASS
- `./gradlew testDebugUnitTest` — PASS (28 tasks, BUILD SUCCESSFUL)

Note: a full Compose behavioral regression test (tall last item → bottom visible) would require Robolectric, which is not in the `test` source-set deps — out of scope for this fix. The math is verified against the actual Compose `LazyListState`/`LazyListLayoutInfo` source for BOM 2026.03.01.