### PR TITLE
fix(#584): keep scroll free during streaming (no auto-follow)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -1588,39 +1588,32 @@ private fun ChatLifecycleEffects(
         }
     }
 
-    // Auto-scroll to bottom on new messages + follow the stream (issue #584)
+    // Auto-scroll to bottom on new messages + session switch (issues #584/#583)
     //
-    // This used to be a LaunchedEffect keyed on
-    // (messages.size, streamingMessage?.content?.length, isThinking). Those
-    // keys change on EVERY streamed token, so the effect restarted per token
-    // and cancelled the in-flight animateScrollToItem — leaving the view
-    // stuck/frozen mid-stream. A single persistent snapshotFlow now reacts to
-    // the same signals WITHOUT restarting the effect, and the streaming follow
-    // uses an instant (non-cancellable-animation) scroll so rapid tokens don't
-    // thrash.
+    // IMPORTANT (m57, #584 follow-up): while an assistant message is STREAMING
+    // the scroll is left completely FREE — no auto-follow of the streaming
+    // message — so the user can scroll up/down to read while it generates.
+    // Auto-scroll only happens on explicit actions (send / FAB / session
+    // switch, handled elsewhere) and when a discrete non-streaming message
+    // lands while the user is already pinned to the bottom.
     //
     // The effect runs once (Unit), so we mirror the params through
-    // rememberUpdatedState and read them via getValue() inside the flow — that
-    // keeps the lambda bound to the latest propagated values (live snapshot
-    // reads) instead of the first-composition closure captures.
+    // rememberUpdatedState and read them live inside the flow/collect — that
+    // keeps the lambda bound to the latest values instead of first-composition
+    // closure captures. streamingMessage is intentionally NOT a flow key, so
+    // the flow doesn't churn per token; we just read it live to gate scrolling.
     val latestMessages by rememberUpdatedState(messages)
     val latestStreaming by rememberUpdatedState(streamingMessage)
     val latestIsThinking by rememberUpdatedState(isThinking)
     val latestSessionId by rememberUpdatedState(currentSessionId)
     LaunchedEffect(Unit) {
         snapshotFlow {
-            Triple(
-                latestMessages.size,
-                latestStreaming?.content?.length ?: -1,
-                latestIsThinking,
-            )
-        }.collectLatest { (msgCount, _, thinking) ->
-            val streamMsg = latestStreaming
-            val totalItems =
-                msgCount +
-                    (if (streamMsg != null) 1 else 0) +
-                    (if (thinking) 1 else 0)
+            Pair(latestMessages.size, latestIsThinking)
+        }.collectLatest { (msgCount, thinking) ->
+            val totalItems = msgCount + (if (thinking) 1 else 0)
             if (totalItems <= 0) return@collectLatest
+            // While a message is streaming, leave scrolling free (no auto-follow).
+            if (latestStreaming != null) return@collectLatest
             val isSessionSwitch = latestSessionId != lastSessionId
             if (isSessionSwitch) {
                 lastSessionId = latestSessionId
@@ -1628,9 +1621,8 @@ private fun ChatLifecycleEffects(
                 return@collectLatest
             }
             if (!listState.isAtBottom()) return@collectLatest
-            // Instant when streaming (no animation to cancel per token);
-            // animated when a discrete new message lands while at the bottom.
-            listState.scrollToBottom(animated = streamMsg == null)
+            // Discrete new message while pinned to the bottom — follow it.
+            listState.scrollToBottom(animated = true)
         }
     }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -1588,20 +1588,49 @@ private fun ChatLifecycleEffects(
         }
     }
 
-    // Auto-scroll to bottom on new messages
-    LaunchedEffect(messages.size, streamingMessage?.content?.length, isThinking) {
-        val totalItems =
-            messages.size +
-                (if (streamingMessage != null) 1 else 0) +
-                (if (isThinking) 1 else 0)
-        if (totalItems > 0) {
-            val isSessionSwitch = currentSessionId != lastSessionId
+    // Auto-scroll to bottom on new messages + follow the stream (issue #584)
+    //
+    // This used to be a LaunchedEffect keyed on
+    // (messages.size, streamingMessage?.content?.length, isThinking). Those
+    // keys change on EVERY streamed token, so the effect restarted per token
+    // and cancelled the in-flight animateScrollToItem — leaving the view
+    // stuck/frozen mid-stream. A single persistent snapshotFlow now reacts to
+    // the same signals WITHOUT restarting the effect, and the streaming follow
+    // uses an instant (non-cancellable-animation) scroll so rapid tokens don't
+    // thrash.
+    //
+    // The effect runs once (Unit), so we mirror the params through
+    // rememberUpdatedState and read them via getValue() inside the flow — that
+    // keeps the lambda bound to the latest propagated values (live snapshot
+    // reads) instead of the first-composition closure captures.
+    val latestMessages by rememberUpdatedState(messages)
+    val latestStreaming by rememberUpdatedState(streamingMessage)
+    val latestIsThinking by rememberUpdatedState(isThinking)
+    val latestSessionId by rememberUpdatedState(currentSessionId)
+    LaunchedEffect(Unit) {
+        snapshotFlow {
+            Triple(
+                latestMessages.size,
+                latestStreaming?.content?.length ?: -1,
+                latestIsThinking,
+            )
+        }.collectLatest { (msgCount, _, thinking) ->
+            val streamMsg = latestStreaming
+            val totalItems =
+                msgCount +
+                    (if (streamMsg != null) 1 else 0) +
+                    (if (thinking) 1 else 0)
+            if (totalItems <= 0) return@collectLatest
+            val isSessionSwitch = latestSessionId != lastSessionId
             if (isSessionSwitch) {
-                lastSessionId = currentSessionId
+                lastSessionId = latestSessionId
                 listState.scrollToBottom(animated = false)
-            } else if (listState.isAtBottom()) {
-                listState.scrollToBottom(animated = true)
+                return@collectLatest
             }
+            if (!listState.isAtBottom()) return@collectLatest
+            // Instant when streaming (no animation to cancel per token);
+            // animated when a discrete new message lands while at the bottom.
+            listState.scrollToBottom(animated = streamMsg == null)
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #584 — while an assistant message streams, the list was supposed to stay pinned to the bottom, but it visibly lagged / froze partway. The first pass stopped the freeze but still force-followed the bottom; per m57's follow-up the scroll must be **completely free** during streaming — no auto-follow at all — so the user can scroll up/down to read while a message generates.

## Behavior

- **Streaming:** scroll is left entirely to the user (free up/down). The auto-scroll effect bails out while `streamingMessage != null`.
- **Explicit actions** (send / FAB / session switch): still scroll to bottom (animated / instant as before).
- **Discrete non-streaming message** arrives while already pinned to the bottom: auto-follow (animated). If the user has scrolled up, it is *not* yanked down.
- `streamingMessage` is dropped from the `snapshotFlow` keys, so the flow no longer churns on every token.

## Root cause (original freeze)

The auto-scroll `LaunchedEffect` was keyed on `(messages.size, streamingMessage?.content?.length, isThinking)` — those change on **every streamed token**, so the effect restarted per token and cancelled the in-flight `animateScrollToItem`.

## Implementation

Single persistent `LaunchedEffect(Unit) + snapshotFlow + collectLatest`. Params mirrored through `rememberUpdatedState` and read live (otherwise the effect captures first-composition values and the flow is deaf to updates / session-switch uses a stale id).

## Verification

- `./gradlew ktlintCheck` — PASS
- `./gradlew compileDebugKotlin` — PASS
- `./gradlew testDebugUnitTest` — PASS