### PR TITLE
fix: add spacing between rendered markdown paragraphs

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/MarkdownText.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/MarkdownText.kt
@@ -346,7 +346,7 @@ fun MarkdownText(
                             },
                         color = textColor,
                         style = MaterialTheme.typography.bodyMedium,
-                        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
                     )
                 }
             }


### PR DESCRIPTION
## Summary
Assistant chat messages render each markdown paragraph as its own `Text` with only `padding(vertical = 2.dp)`, stacked in a `Column` with no vertical arrangement. Net gap between paragraphs was ~4dp — reads as one cramped block.

Bumped the paragraph padding to `vertical = 6.dp` (~12dp between paragraphs). User messages are unaffected (plain `Text`, newlines preserved).

## Verification
- `./gradlew ktlintCheck` — BUILD SUCCESSFUL
- `./gradlew assembleDebug` — BUILD SUCCESSFUL (app-debug.apk produced)

## Test plan
- [ ] Open a multi-paragraph assistant reply in the chat — paragraphs should have visible separation
- [ ] Single-paragraph replies look unchanged
- [ ] Lists/headings/code blocks unaffected