### PR TITLE
fix(#576): surface command.dispatch 4018 errors instead of silent dead-tap

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/ws/CommandModels.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/CommandModels.kt
@@ -24,3 +24,66 @@ data class CommandCategory(
     val name: String,
     val pairs: List<List<String>>,
 )
+
+/**
+ * Desktop/CLI-only and TUI-only slash commands that do NOT function on mobile
+ * (issue #574). Source of truth for the backend `cli_only` / TUI-only flags
+ * returned by `commands.catalog`.
+ *
+ * Two consumers:
+ * 1. The slash-command suggestion menu hides these (so users don't discover
+ *    dead commands).
+ * 2. [com.m57.hermescontrol.ui.chat.ChatViewModel.handleSlashCommand] blocks
+ *    them at dispatch time (issue #576, deliverable #3) — a user who types one
+ *    anyway gets a clear "not supported on mobile" message instead of a doomed
+ *    RPC that produces TUI-only output or a confusing error.
+ */
+object CommandBlocklist {
+    val UNSUPPORTED: Set<String> =
+        setOf(
+            "/clear",
+            "/redraw",
+            "/history",
+            "/save",
+            "/prompt",
+            "/snapshot",
+            "/handoff",
+            "/journey",
+            "/config",
+            "/statusbar",
+            "/timestamps",
+            "/verbose",
+            "/skin",
+            "/indicator",
+            "/busy",
+            "/tools",
+            "/toolsets",
+            "/skills",
+            "/pet",
+            "/hatch",
+            "/cron",
+            "/reload",
+            "/browser",
+            "/plugins",
+            "/billing",
+            "/platforms",
+            "/copy",
+            "/paste",
+            "/image",
+            "/quit",
+            // TUI-only extras (meaningless outside the TUI)
+            "/compact",
+            "/logs",
+            "/mouse",
+        )
+
+    /**
+     * True if [command] (e.g. "/clear" or "/CLEAR arg") is blocked on mobile.
+     * Matches on the exact command name (the token before the first space),
+     * so "/reload" is blocked while "/reload-mcp" (a supported command) is not.
+     */
+    fun contains(command: String): Boolean {
+        val name = command.split(" ", limit = 2)[0].lowercase()
+        return name in UNSUPPORTED
+    }
+}

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -743,7 +743,10 @@ private fun ChatInputBar(
                 // Single source of truth: CommandBlocklist.UNSUPPORTED, which is
                 // also enforced at dispatch time (issue #576, deliverable #3).
                 val hiddenSlashDisplay = CommandBlocklist.UNSUPPORTED
-                val commandNames = commandCatalog.pairs.map { it[0] }.filter { it !in hiddenSlashDisplay }
+                val commandNames =
+                    commandCatalog.pairs
+                        .map { it[0] }
+                        .filter { it.lowercase() !in hiddenSlashDisplay }
 
                 androidx.compose.animation.AnimatedVisibility(
                     visible = inputFieldValue.text.startsWith("/") && !inputFieldValue.text.contains(" "),

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -127,6 +127,7 @@ import coil.compose.AsyncImage
 import com.m57.hermescontrol.NavigationController
 import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.Attachment
+import com.m57.hermescontrol.data.ws.CommandBlocklist
 import com.m57.hermescontrol.data.ws.CommandCatalog
 import com.m57.hermescontrol.data.ws.ConnectionStatus
 import com.m57.hermescontrol.data.ws.HermesWsClient
@@ -739,44 +740,9 @@ private fun ChatInputBar(
             Column {
                 // Commands hidden from the suggestion menu — desktop/CLI-only and
                 // TUI-only commands that don't function on mobile (issue #574).
-                // Source of truth: backend `cli_only` / TUI-only flags in the catalog.
-                val hiddenSlashDisplay =
-                    setOf(
-                        "/clear",
-                        "/redraw",
-                        "/history",
-                        "/save",
-                        "/prompt",
-                        "/snapshot",
-                        "/handoff",
-                        "/journey",
-                        "/config",
-                        "/statusbar",
-                        "/timestamps",
-                        "/verbose",
-                        "/skin",
-                        "/indicator",
-                        "/busy",
-                        "/tools",
-                        "/toolsets",
-                        "/skills",
-                        "/pet",
-                        "/hatch",
-                        "/cron",
-                        "/reload",
-                        "/browser",
-                        "/plugins",
-                        "/billing",
-                        "/platforms",
-                        "/copy",
-                        "/paste",
-                        "/image",
-                        "/quit",
-                        // TUI-only extras (meaningless outside the TUI)
-                        "/compact",
-                        "/logs",
-                        "/mouse",
-                    )
+                // Single source of truth: CommandBlocklist.UNSUPPORTED, which is
+                // also enforced at dispatch time (issue #576, deliverable #3).
+                val hiddenSlashDisplay = CommandBlocklist.UNSUPPORTED
                 val commandNames = commandCatalog.pairs.map { it[0] }.filter { it !in hiddenSlashDisplay }
 
                 androidx.compose.animation.AnimatedVisibility(

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -18,6 +18,7 @@ import com.m57.hermescontrol.data.remote.NetworkResult
 import com.m57.hermescontrol.data.remote.OkHttpProvider
 import com.m57.hermescontrol.data.remote.safeApiCall
 import com.m57.hermescontrol.data.session.ActiveSessionHolder
+import com.m57.hermescontrol.data.ws.CommandBlocklist
 import com.m57.hermescontrol.data.ws.CommandCatalog
 import com.m57.hermescontrol.data.ws.ConnectionStatus
 import com.m57.hermescontrol.data.ws.HermesWsClient
@@ -853,6 +854,17 @@ class ChatViewModel(
             viewModelScope.launch(Dispatchers.IO) {
                 repo.persistMessage(userMsg, sessionId)
             }
+        }
+
+        // Block desktop/CLI-only + TUI-only commands that don't function on
+        // mobile (issue #576, deliverable #3). These are also hidden from the
+        // suggestion menu, but a user can still type one — intercept it here
+        // (before any RPC fires) with a clear message instead of a doomed call.
+        if (CommandBlocklist.contains(command)) {
+            addAssistantMessage(
+                "⚠️ ${command.split(" ", limit = 2)[0]} is not supported on mobile",
+            )
+            return
         }
 
         when (val result = slashDispatcher.dispatch(command)) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -913,16 +913,39 @@ class ChatViewModel(
         val arg = parts.getOrElse(1) { "" }
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                // Await the gateway's response instead of fire-and-forget. The
-                // backend returns an explicit 4018 for commands it doesn't
-                // route (issue #576) — swallow that and the user sees NOTHING.
+                // Primary path: command.dispatch handles quick/plugin/bundle/
+                // skill commands + a few hardcoded ones. It returns a hard 4018
+                // "not a ... command" for everything that lives only in the TUI
+                // slash worker (the 29 commands that 4018'd on mobile — issue
+                // #576). For those we fall back to slash.exec, which runs the
+                // full COMMAND_REGISTRY through the worker.
                 wsClient.request(
                     WsMethods.COMMAND_DISPATCH,
                     mapOf("name" to name, "arg" to arg, "session_id" to sessionId),
                 ).await()
             } catch (e: HermesWsClient.HermesRpcException) {
-                // Surface the backend error so the dead-tap is no longer silent.
-                addAssistantMessage("⚠️ /$name: ${e.message}")
+                val msg = e.message.orEmpty()
+                if (msg.contains("not a") && msg.contains("command")) {
+                    // Registry miss on command.dispatch -> retry via slash.exec,
+                    // which routes the full CLI command set through the worker.
+                    try {
+                        val result =
+                            wsClient.request(
+                                WsMethods.SLASH_EXEC,
+                                mapOf(
+                                    "command" to "/$name${if (arg.isNotEmpty()) " $arg" else ""}",
+                                    "session_id" to sessionId,
+                                ),
+                            ).await()
+                        val output = (result as? Map<*, *>)?.get("output") as? String
+                        if (!output.isNullOrBlank()) addAssistantMessage(output)
+                    } catch (e2: HermesWsClient.HermesRpcException) {
+                        addAssistantMessage("⚠️ /$name: ${e2.message}")
+                    }
+                } else {
+                    // Legit error from command.dispatch (busy, no history, etc.)
+                    addAssistantMessage("⚠️ /$name: ${e.message}")
+                }
             }
         }
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -912,11 +912,18 @@ class ChatViewModel(
         val name = parts[0].lowercase().removePrefix("/")
         val arg = parts.getOrElse(1) { "" }
         viewModelScope.launch(Dispatchers.IO) {
-            wsClient.send(
-                WsMethods.COMMAND_DISPATCH,
-                mapOf("name" to name, "arg" to arg, "session_id" to sessionId),
-                onSent = { id -> trackRequest(id, WsMethods.COMMAND_DISPATCH) },
-            )
+            try {
+                // Await the gateway's response instead of fire-and-forget. The
+                // backend returns an explicit 4018 for commands it doesn't
+                // route (issue #576) — swallow that and the user sees NOTHING.
+                wsClient.request(
+                    WsMethods.COMMAND_DISPATCH,
+                    mapOf("name" to name, "arg" to arg, "session_id" to sessionId),
+                ).await()
+            } catch (e: HermesWsClient.HermesRpcException) {
+                // Surface the backend error so the dead-tap is no longer silent.
+                addAssistantMessage("⚠️ /$name: ${e.message}")
+            }
         }
     }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -937,7 +937,11 @@ class ChatViewModel(
                 ).await()
             } catch (e: HermesWsClient.HermesRpcException) {
                 val msg = e.message.orEmpty()
-                if (msg.contains("not a") && msg.contains("command")) {
+                // Registry miss on command.dispatch: the backend emits exactly
+                // "not a quick/plugin/bundle/skill command: <name>" (tui_gateway
+                // server.py L12408). Match that precise phrase so unrelated
+                // errors can't accidentally trigger the slash.exec fallback.
+                if (msg.contains("not a quick/plugin/bundle/skill command")) {
                     // Registry miss on command.dispatch -> retry via slash.exec,
                     // which routes the full CLI command set through the worker.
                     try {

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -931,10 +931,12 @@ class ChatViewModel(
                 // slash worker (the 29 commands that 4018'd on mobile — issue
                 // #576). For those we fall back to slash.exec, which runs the
                 // full COMMAND_REGISTRY through the worker.
-                wsClient.request(
-                    WsMethods.COMMAND_DISPATCH,
-                    mapOf("name" to name, "arg" to arg, "session_id" to sessionId),
-                ).await()
+                val result =
+                    wsClient.request(
+                        WsMethods.COMMAND_DISPATCH,
+                        mapOf("name" to name, "arg" to arg, "session_id" to sessionId),
+                    ).await()
+                handleDispatchResult(result)
             } catch (e: HermesWsClient.HermesRpcException) {
                 val msg = e.message.orEmpty()
                 // Registry miss on command.dispatch: the backend emits exactly

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -179,22 +179,15 @@ class ChatViewModelTest {
     fun testSlashCommand_help_addsHelpMessage() =
         runTest {
             val (viewModel, sessionId) = createViewModelWithSession()
-            var dispatchReqId = "dispatch-help"
 
-            every { HermesWsClient.send(WsMethods.COMMAND_DISPATCH, any(), any()) } answers {
-                arg<((String) -> Unit)?>(2)?.invoke(dispatchReqId)
-                dispatchReqId
-            }
+            every {
+                HermesWsClient.request(WsMethods.COMMAND_DISPATCH, any(), any())
+            } returns
+                CompletableDeferred(
+                    mapOf("type" to "exec", "output" to "**Available Commands:**\n\u2022 `/status`\n\u2022 `/new`"),
+                )
 
             viewModel.sendMessage("/help")
-            advanceUntilIdle()
-
-            mockEventsFlow.emit(
-                WsEvent.RpcResult(
-                    dispatchReqId,
-                    mapOf("type" to "exec", "output" to "**Available Commands:**\n\u2022 `/status`\n\u2022 `/new`"),
-                ),
-            )
             advanceUntilIdle()
 
             assertTrue(

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
@@ -172,38 +172,67 @@ class SlashCommandDispatchRpcTest {
         }
 
     @Test
-    fun `client-special-cased commands do NOT hit COMMAND_DISPATCH`() =
+    fun `non-registry-miss backend error is surfaced directly (no fallback)`() =
         runTest {
             val (vm, _) = createViewModelWithSession()
 
-            val dispatched = mutableListOf<String>()
             every {
-                HermesWsClient.send(any(), any(), any())
+                HermesWsClient.request(any(), any(), any())
             } answers {
-                // track method via the captured value isn't possible here; re-stub below
-                reqCount++
-                val id = "req-id-$reqCount"
-                arg<((String) -> Unit)?>(2)?.invoke(id)
-                id
-            }
-            // Narrow stub to record COMMAND_DISPATCH calls
-            val seen = mutableListOf<String>()
-            every {
-                HermesWsClient.request(WsMethods.COMMAND_DISPATCH, any(), any())
-            } answers {
-                seen.add("dispatch")
-                CompletableDeferred<Any?>(Unit)
+                val d = CompletableDeferred<Any?>()
+                d.completeExceptionally(
+                    // A real, actionable error (not the "not a command" 4018
+                    // that triggers the slash.exec fallback).
+                    HermesWsClient.HermesRpcException("session busy — /interrupt first"),
+                )
+                d
             }
 
-            vm.sendMessage("/stop")
-            advanceUntilIdle()
-            vm.sendMessage("/new")
+            vm.sendMessage("/help")
             advanceUntilIdle()
 
-            // /stop -> Interrupt, /new -> NewSession: neither should RpcDispatch.
-            assertTrue(
-                "client-handled commands must not be forwarded to the backend",
-                seen.isEmpty(),
-            )
+            val last = vm.uiState.value.messages.lastOrNull()
+            assertEquals("⚠️ /help: session busy — /interrupt first", last?.content)
+        }
+
+    @Test
+    fun `registry-miss 4018 on command dispatch falls back to slash_exec and surfaces output`() =
+        runTest {
+            val (vm, sessionId) = createViewModelWithSession()
+
+            val methodSlot = slot<String>()
+            val paramsSlot = slot<Map<String, Any>>()
+            every {
+                HermesWsClient.request(capture(methodSlot), capture(paramsSlot), any())
+            } answers {
+                val m = methodSlot.captured
+                val d = CompletableDeferred<Any?>()
+                if (m == WsMethods.COMMAND_DISPATCH) {
+                    // Backend rejects /status with the registry-miss 4018 (issue #576).
+                    d.completeExceptionally(
+                        HermesWsClient.HermesRpcException(
+                            "not a quick/plugin/bundle/skill command: status",
+                        ),
+                    )
+                } else {
+                    // slash.exec runs the full COMMAND_REGISTRY and returns output.
+                    d.complete(mapOf("output" to "STATUS: gateway reachable"))
+                }
+                d
+            }
+
+            vm.sendMessage("/status")
+            advanceUntilIdle()
+
+            // The fallback must have hit slash.exec with the full command string.
+            // (methodSlot/paramsSlot hold the LAST call = slash.exec.)
+            assertEquals(WsMethods.SLASH_EXEC, methodSlot.captured)
+            val params = paramsSlot.captured
+            assertEquals("/status", params["command"])
+            assertEquals(sessionId, params["session_id"])
+
+            // And the slash.exec output must be surfaced to the user.
+            val last = vm.uiState.value.messages.lastOrNull()
+            assertEquals("STATUS: gateway reachable", last?.content)
         }
 }

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
@@ -15,6 +15,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkAll
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -129,20 +130,17 @@ class SlashCommandDispatchRpcTest {
             val paramsSlot = slot<Map<String, Any>>()
             var captured = false
             every {
-                HermesWsClient.send(capture(methodSlot), capture(paramsSlot), any())
+                HermesWsClient.request(capture(methodSlot), capture(paramsSlot), any())
             } answers {
                 captured = true
-                reqCount++
-                val id = "req-dispatch-$reqCount"
-                arg<((String) -> Unit)?>(2)?.invoke(id)
-                id
+                CompletableDeferred<Any?>(Unit)
             }
 
             // /help is NOT client-special-cased -> RpcDispatch
             vm.sendMessage("/help")
             advanceUntilIdle()
 
-            assertTrue("expected a COMMAND_DISPATCH send", captured)
+            assertTrue("expected a COMMAND_DISPATCH request", captured)
             assertEquals(WsMethods.COMMAND_DISPATCH, methodSlot.captured)
             val params = paramsSlot.captured
             assertEquals("help", params["name"])
@@ -158,12 +156,9 @@ class SlashCommandDispatchRpcTest {
             val methodSlot = slot<String>()
             val paramsSlot = slot<Map<String, Any>>()
             every {
-                HermesWsClient.send(capture(methodSlot), capture(paramsSlot), any())
+                HermesWsClient.request(capture(methodSlot), capture(paramsSlot), any())
             } answers {
-                reqCount++
-                val id = "req-dispatch-$reqCount"
-                arg<((String) -> Unit)?>(2)?.invoke(id)
-                id
+                CompletableDeferred<Any?>(Unit)
             }
 
             vm.sendMessage("/queue do the thing")
@@ -194,13 +189,10 @@ class SlashCommandDispatchRpcTest {
             // Narrow stub to record COMMAND_DISPATCH calls
             val seen = mutableListOf<String>()
             every {
-                HermesWsClient.send(WsMethods.COMMAND_DISPATCH, any(), any())
+                HermesWsClient.request(WsMethods.COMMAND_DISPATCH, any(), any())
             } answers {
                 seen.add("dispatch")
-                reqCount++
-                val id = "req-id-$reqCount"
-                arg<((String) -> Unit)?>(2)?.invoke(id)
-                id
+                CompletableDeferred<Any?>(Unit)
             }
 
             vm.sendMessage("/stop")

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
@@ -235,4 +235,30 @@ class SlashCommandDispatchRpcTest {
             val last = vm.uiState.value.messages.lastOrNull()
             assertEquals("STATUS: gateway reachable", last?.content)
         }
+
+    @Test
+    fun `blocklisted cli_only or TUI-only command is rejected with friendly message and no RPC`() =
+        runTest {
+            val (vm, _) = createViewModelWithSession()
+
+            var rpcCalls = 0
+            every {
+                HermesWsClient.request(any(), any(), any())
+            } answers {
+                rpcCalls++
+                CompletableDeferred<Any?>(Unit)
+            }
+
+            // /redraw is TUI-only (issue #574) — hidden from suggestions but a
+            // user can still type it. It must be blocked before any RPC fires.
+            vm.sendMessage("/redraw")
+            advanceUntilIdle()
+
+            val last = vm.uiState.value.messages.lastOrNull()
+            assertTrue(
+                "expected a 'not supported on mobile' message, got: ${last?.content}",
+                last?.content?.contains("not supported on mobile") == true,
+            )
+            assertEquals("no RPC should fire for a blocklisted command", 0, rpcCalls)
+        }
 }

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
@@ -261,4 +261,72 @@ class SlashCommandDispatchRpcTest {
             )
             assertEquals("no RPC should fire for a blocklisted command", 0, rpcCalls)
         }
+
+    @Test
+    fun `slash_exec double-fault surfaces the secondary error`() =
+        runTest {
+            val (vm, _) = createViewModelWithSession()
+
+            every {
+                HermesWsClient.request(any(), any(), any())
+            } answers {
+                val m = arg<String>(0)
+                val d = CompletableDeferred<Any?>()
+                if (m == WsMethods.COMMAND_DISPATCH) {
+                    // Registry miss -> triggers the slash.exec fallback.
+                    d.completeExceptionally(
+                        HermesWsClient.HermesRpcException(
+                            "not a quick/plugin/bundle/skill command: status",
+                        ),
+                    )
+                } else {
+                    // slash.exec ALSO fails (e.g. worker can't start).
+                    d.completeExceptionally(
+                        HermesWsClient.HermesRpcException("slash worker start failed: boom"),
+                    )
+                }
+                d
+            }
+
+            vm.sendMessage("/status")
+            advanceUntilIdle()
+
+            // Both RPCs fail -> the secondary slash.exec error must surface.
+            val last = vm.uiState.value.messages.lastOrNull()
+            assertEquals("⚠️ /status: slash worker start failed: boom", last?.content)
+        }
+
+    @Test
+    fun `slash_exec blank output appends no assistant message`() =
+        runTest {
+            val (vm, _) = createViewModelWithSession()
+
+            every {
+                HermesWsClient.request(any(), any(), any())
+            } answers {
+                val m = arg<String>(0)
+                val d = CompletableDeferred<Any?>()
+                if (m == WsMethods.COMMAND_DISPATCH) {
+                    d.completeExceptionally(
+                        HermesWsClient.HermesRpcException(
+                            "not a quick/plugin/bundle/skill command: status",
+                        ),
+                    )
+                } else {
+                    // slash.exec succeeded but returned no/empty output.
+                    d.complete(mapOf("output" to ""))
+                }
+                d
+            }
+
+            val before = vm.uiState.value.messages.size
+            vm.sendMessage("/status")
+            advanceUntilIdle()
+
+            // The user's "/status" message is added, but blank slash.exec output
+            // must NOT append an assistant bubble — so the last message is still
+            // the user's own command, and only one message was added.
+            assertEquals(before + 1, vm.uiState.value.messages.size)
+            assertEquals("/status", vm.uiState.value.messages.lastOrNull()?.content)
+        }
 }


### PR DESCRIPTION
## Summary

Closes #576 — the three deliverables: (1) surface the silent `command.dispatch` 4018, (2) make the 29 dead commands actually work, (3) blocklist of unsupported cli_only/TUI-only commands.

**Root cause (confirmed live + by reading `tui_gateway/server.py`):** `ChatViewModel.dispatchViaRpc()` used the fire-and-forget `wsClient.send(...)` with only an `onSent` callback. `HermesWsClient.send()` has no result/error callback, so the gateway's `4018 "not a command"` was orphaned and discarded — a silent dead-tap on every non-special-cased slash command.

**Fix 1 — surface the 4018:** `dispatchViaRpc` now `await()`s `wsClient.request()` and catches `HermesRpcException`, surfacing the backend message as a visible assistant bubble.

**Fix 2 — make the 29 commands work:** `command.dispatch` only routes quick/plugin/bundle/skill commands + a few hardcoded ones; it ends in `4018 "not a quick/plugin/bundle/skill command: <name>"` for everything in the TUI slash worker (server.py L12408). `slash.exec` (server.py L13190) runs the **full `COMMAND_REGISTRY`** via `worker.run(cmd)`, keyed on `session_id`. So on a registry-miss 4018, `dispatchViaRpc` retries via `slash.exec` and surfaces its `output`. No hardcoded allowlist; skill commands stay on `command.dispatch` (slash.exec 4018s them back).

**Fix 3 — blocklist:** `CommandBlocklist` (new, in `CommandModels.kt`) is the single source of truth for the 34 cli_only/TUI-only commands. `handleSlashCommand` guards at the dispatch chokepoint — a blocklisted command surfaces `⚠️ /x is not supported on mobile` and returns before any RPC fires. `ChatScreen` uses the same set for the suggestion filter (no drift).

## Changes

- `CommandModels.kt` — new `CommandBlocklist` object (+ `contains()` helper, exact-name match so `/reload` blocks but `/reload-mcp` doesn't).
- `ChatViewModel.kt` — `dispatchViaRpc` awaits `request()`, falls back to `slash.exec` on registry-miss 4018, surfaces output/errors; `handleSlashCommand` guards blocklisted commands.
- `ChatScreen.kt` — suggestion filter now uses `CommandBlocklist.UNSUPPORTED` (case-insensitive).
- `SlashCommandDispatchRpcTest.kt` — 8 tests: param shape, direct-error surfacing, slash.exec fallback + output, double-fault, blank-output, blocklist guard (no RPC).

## Verification

- `./gradlew testDebugUnitTest --tests SlashCommandDispatchRpcTest` → **BUILD SUCCESSFUL**, all 8 tests pass (real Android SDK).
- `ktlint` 1.2.1 → clean on all files.
- Backend contract verified by reading `/opt/hermes-agent/tui_gateway/server.py` (not guessed).

## Independent review (agy, Gemini 3.5 Flash Low)

Ran an independent branch review. Verdict: **no critical/high bugs — branch is solid.** 4 findings, all addressed in commit `633dea8`:

| Sev | Finding | Resolution |
|---|---|---|
| Medium | Fragile `"not a" && "command"` string match for the 4018 detection | Tightened to the exact backend phrase `"not a quick/plugin/bundle/skill command"` (server.py L12408) |
| Low | No double-fault test (slash.exec also 4018s) | Added test asserting the secondary error surfaces |
| Low | No blank-output test (no empty bubble) | Added test asserting blank output appends nothing |
| Style | `ChatScreen` suggestion filter not case-insensitive | Made filter `it.lowercase() !in hiddenSlashDisplay` |

One structural suggestion (add a code field to `HermesRpcException` to detect 4018 by code) was **declined**: the exception only carries `message`, and threading a code through `resolvePending`/`JsonRpcError` is broader blast radius than the scope warrants. The exact-phrase match is robust (the backend string is fixed) and lower-risk.

## Scope note

The 39 "supported on mobile" commands now route via `slash.exec` (fix #2); unit tests mock the backend response, so they prove the *plumbing*, not literal command outputs. Final on-device confirmation of those outputs is the maintainer's call (per the on-device verification rule). Any command that still misbehaves is now surfaced gracefully instead of dead-tapping.