### PR TITLE
[enhancement] feat(#606): support auth mode + bearer token when adding HTTP MCP servers

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/model/McpServer.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/McpServer.kt
@@ -31,6 +31,8 @@ data class AddMcpServerRequest(
     val command: String? = null,
     val args: List<String>? = null,
     val env: Map<String, String>? = null,
+    val auth: String? = null, // "none" | "header" | "oauth"
+    val bearerToken: String? = null, // sent only when auth == "header"
 )
 
 @Serializable

--- a/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -51,6 +52,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -256,6 +258,44 @@ private fun AddServerSection(
                         modifier = Modifier.fillMaxWidth(),
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
                     )
+                    Spacer(modifier = Modifier.height(spacing.sm))
+                    Text(
+                        text = stringResource(R.string.mcp_servers_auth_mode),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(spacing.xs))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                    ) {
+                        FilterChip(
+                            selected = state.addServerAuth == "none",
+                            onClick = { viewModel.updateAddServerAuth("none") },
+                            label = { Text(stringResource(R.string.mcp_servers_auth_none)) },
+                        )
+                        FilterChip(
+                            selected = state.addServerAuth == "header",
+                            onClick = { viewModel.updateAddServerAuth("header") },
+                            label = { Text(stringResource(R.string.mcp_servers_auth_header)) },
+                        )
+                        FilterChip(
+                            selected = state.addServerAuth == "oauth",
+                            onClick = { viewModel.updateAddServerAuth("oauth") },
+                            label = { Text(stringResource(R.string.mcp_servers_auth_oauth)) },
+                        )
+                    }
+                    if (state.addServerAuth == "header") {
+                        Spacer(modifier = Modifier.height(spacing.sm))
+                        OutlinedTextField(
+                            value = state.addServerBearerToken,
+                            onValueChange = viewModel::updateAddServerBearerToken,
+                            label = { Text(stringResource(R.string.mcp_servers_field_bearer_token)) },
+                            singleLine = true,
+                            visualTransformation = PasswordVisualTransformation(),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                 } else {
                     OutlinedTextField(
                         value = state.addServerCommand,

--- a/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -265,9 +266,10 @@ private fun AddServerSection(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     Spacer(modifier = Modifier.height(spacing.xs))
-                    Row(
+                    FlowRow(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+                        verticalArrangement = Arrangement.spacedBy(spacing.sm),
                     ) {
                         FilterChip(
                             selected = state.addServerAuth == "none",
@@ -292,7 +294,7 @@ private fun AddServerSection(
                             onValueChange = viewModel::updateAddServerBearerToken,
                             label = { Text(stringResource(R.string.mcp_servers_field_bearer_token)) },
                             singleLine = true,
-                            visualTransformation = PasswordVisualTransformation(),
+                            visualTransformation = remember { PasswordVisualTransformation() },
                             modifier = Modifier.fillMaxWidth(),
                         )
                     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersViewModel.kt
@@ -34,6 +34,8 @@ data class McpServersUiState(
     val addServerUrl: String = "",
     val addServerCommand: String = "",
     val addServerArgs: String = "",
+    val addServerAuth: String = "none", // "none" | "header" | "oauth"
+    val addServerBearerToken: String = "",
     val addingServer: Boolean = false,
     // Env vars for editing
     val editingEnvFor: String? = null,
@@ -204,6 +206,14 @@ class McpServersViewModel :
         _uiState.update { it.copy(addServerArgs = v) }
     }
 
+    fun updateAddServerAuth(v: String) {
+        _uiState.update { it.copy(addServerAuth = v) }
+    }
+
+    fun updateAddServerBearerToken(v: String) {
+        _uiState.update { it.copy(addServerBearerToken = v) }
+    }
+
     fun submitAddServer() {
         val state = _uiState.value
         if (state.addServerName.isBlank()) {
@@ -231,6 +241,18 @@ class McpServersViewModel :
                         } else {
                             null
                         },
+                    auth =
+                        if (state.addMode == AddServerMode.HTTP && state.addServerAuth != "none") {
+                            state.addServerAuth
+                        } else {
+                            null
+                        },
+                    bearerToken =
+                        if (state.addMode == AddServerMode.HTTP && state.addServerAuth == "header") {
+                            state.addServerBearerToken.trim().ifBlank { null }
+                        } else {
+                            null
+                        },
                 )
             val result =
                 withContext(Dispatchers.IO) {
@@ -246,6 +268,8 @@ class McpServersViewModel :
                             addServerUrl = "",
                             addServerCommand = "",
                             addServerArgs = "",
+                            addServerAuth = "none",
+                            addServerBearerToken = "",
                             toastMessage = "Server '${request.name}' added",
                         )
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -727,6 +727,11 @@
     <string name="mcp_servers_catalog_installing">Installing…</string>
     <string name="mcp_servers_catalog_source">source: %1$s</string>
     <string name="mcp_servers_catalog_required_env">Required env vars</string>
+    <string name="mcp_servers_auth_mode">Authentication</string>
+    <string name="mcp_servers_auth_none">None</string>
+    <string name="mcp_servers_auth_header">Header</string>
+    <string name="mcp_servers_auth_oauth">OAuth</string>
+    <string name="mcp_servers_field_bearer_token">Bearer token</string>
  
      <!-- Gateway Screen -->
     <string name="gateway_status_running">GATEWAY RUNNING</string>


### PR DESCRIPTION
## What
Extend the HTTP MCP add-server flow to support the backend's new `auth` (`none`/`header`/`oauth`) and `bearer_token` fields (backend audit 569b912d7..0c1adb487).

## Changes
- **`AddMcpServerRequest`**: added `auth` + `bearerToken` fields (global `JsonNamingStrategy.SnakeCase` auto-serializes `bearerToken` -> `bearer_token`, so no `@SerialName` needed)
- **`McpServersViewModel`**: wires the new fields; only sends `auth`/`bearerToken` when mode is HTTP and values are non-default (token only when `auth == "header"`)
- **`McpServersScreen`**: auth mode `FilterChip` selector (HTTP tab only); conditional masked bearer token field (`PasswordVisualTransformation`) when `header` is selected
- **Strings**: 5 new localized strings

## Backend contract (respected)
- Exactly one of `url`/`command` required
- `bearer_token` requires `auth == "header"`
- `args`/`env` only for stdio (`command`) servers

## Scope note
Issue states "no response-model change" — `McpServer` response model intentionally left without an `auth` field; `ignoreUnknownKeys = true` handles the extra backend field gracefully. Did not add card display of `auth` to stay in scope.

## Verification
- `ktlint` clean (`./ktlint` + will be confirmed by CI `ktlintCheck`)
- `assembleDebug` successful (local box64-shimmed aapt2 at /opt/android-sdk)

Fixes #606