### PR TITLE
fix(#614): implement ToastHost on Achievements/Sessions/Processes ViewModels

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/achievements/AchievementsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/achievements/AchievementsViewModel.kt
@@ -5,6 +5,7 @@ import com.m57.hermescontrol.data.model.Achievement
 import com.m57.hermescontrol.data.model.RecentUnlock
 import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.safeApiCall
+import com.m57.hermescontrol.ui.common.ToastHost
 import com.m57.hermescontrol.ui.common.safeLaunchLoad
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -38,7 +39,7 @@ data class AchievementsUiState(
     val toastMessage: String? = null,
 )
 
-class AchievementsViewModel : ViewModel() {
+class AchievementsViewModel : ViewModel(), ToastHost {
     private val _uiState = MutableStateFlow(AchievementsUiState())
     val uiState: StateFlow<AchievementsUiState> = _uiState.asStateFlow()
 
@@ -191,7 +192,7 @@ class AchievementsViewModel : ViewModel() {
         _uiState.update { it.copy(activeState = state) }
     }
 
-    fun clearToast() {
+    override fun clearToast() {
         _uiState.update { it.copy(toastMessage = null) }
     }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/process/ProcessesViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/process/ProcessesViewModel.kt
@@ -6,6 +6,7 @@ import com.m57.hermescontrol.data.model.ProcessInfo
 import com.m57.hermescontrol.data.session.ActiveSessionHolder
 import com.m57.hermescontrol.data.ws.HermesWsClient
 import com.m57.hermescontrol.data.ws.WsMethods
+import com.m57.hermescontrol.ui.common.ToastHost
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -23,7 +24,7 @@ data class ProcessesUiState(
     val sessionId: String? = null,
 )
 
-class ProcessesViewModel : ViewModel() {
+class ProcessesViewModel : ViewModel(), ToastHost {
     private val _uiState = MutableStateFlow(ProcessesUiState())
     val uiState: StateFlow<ProcessesUiState> = _uiState.asStateFlow()
 
@@ -123,7 +124,7 @@ class ProcessesViewModel : ViewModel() {
         }
     }
 
-    fun clearToast() {
+    override fun clearToast() {
         _uiState.update { it.copy(toastMessage = null) }
     }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsViewModel.kt
@@ -10,6 +10,7 @@ import com.m57.hermescontrol.data.model.SessionSearchResult
 import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.NetworkResult
 import com.m57.hermescontrol.data.remote.safeApiCall
+import com.m57.hermescontrol.ui.common.ToastHost
 import com.m57.hermescontrol.ui.common.safeLaunchLoad
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -52,7 +53,7 @@ data class SessionsUiState(
     val isSearchMode: Boolean get() = searchQuery.isNotBlank()
 }
 
-class SessionsViewModel : ViewModel() {
+class SessionsViewModel : ViewModel(), ToastHost {
     private val _uiState = MutableStateFlow(SessionsUiState())
     val uiState: StateFlow<SessionsUiState> = _uiState.asStateFlow()
 
@@ -471,7 +472,7 @@ class SessionsViewModel : ViewModel() {
 
     // ── Toast ────────────────────────────────────────────────────────────
 
-    fun clearToast() {
+    override fun clearToast() {
         _uiState.update { it.copy(toastMessage = null) }
     }
 }


### PR DESCRIPTION
## Summary
The 3 ViewModels declared `clearToast()` without implementing `ToastHost`, breaking polymorphic substitution and interface contract consistency.

## Changes
- `AchievementsViewModel`: added `ToastHost` interface + `override` on `clearToast()`
- `SessionsViewModel`: added `ToastHost` interface + `override` on `clearToast()`
- `ProcessesViewModel`: added `ToastHost` interface + `override` on `clearToast()`

## Verification
- `grep 'fun clearToast' | grep -v override` now returns only the interface declaration itself
- `./gradlew ktlintCheck` ✅
- `./gradlew compileDebugKotlin` ✅
- `./gradlew testDebugUnitTest` ✅

Fixes #614