### PR TITLE
feat(ux): add CTAs to EmptyState across screens (closes #618)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/analytics/AnalyticsScreen.kt
@@ -39,7 +39,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.m57.hermescontrol.NavigationController
 import com.m57.hermescontrol.R
+import com.m57.hermescontrol.SkillsScreen
 import com.m57.hermescontrol.data.model.AnalyticsDailyEntry
 import com.m57.hermescontrol.data.model.ModelsAnalyticsModelEntry
 import com.m57.hermescontrol.theme.LocalHermesStatusColors
@@ -89,6 +91,8 @@ fun AnalyticsScreen(
                     title = stringResource(R.string.analytics_empty_title),
                     subtitle = stringResource(R.string.analytics_empty_desc),
                     icon = Icons.Filled.BarChart,
+                    actionLabel = stringResource(R.string.empty_action_explore),
+                    onAction = { NavigationController.navigateTo(SkillsScreen) },
                 )
             }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/channels/ChannelsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/channels/ChannelsScreen.kt
@@ -147,6 +147,8 @@ fun ChannelsScreen(
                 EmptyState(
                     title = stringResource(R.string.channels_empty_title),
                     subtitle = stringResource(R.string.channels_empty_desc),
+                    actionLabel = stringResource(R.string.empty_action_connect_telegram),
+                    onAction = { viewModel.startTelegramOnboarding() },
                     modifier = Modifier.padding(paddingValues),
                 )
             }

--- a/app/src/main/java/com/m57/hermescontrol/ui/cron/CronJobsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/cron/CronJobsScreen.kt
@@ -112,6 +112,8 @@ fun CronJobsScreen(
                     icon = Icons.Filled.Schedule,
                     title = stringResource(R.string.cron_empty_title),
                     subtitle = stringResource(R.string.cron_empty_desc),
+                    actionLabel = stringResource(R.string.empty_action_create_job),
+                    onAction = { viewModel.openNewJobDialog() },
                 )
             }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/keys/KeysScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/keys/KeysScreen.kt
@@ -158,8 +158,10 @@ fun KeysScreen(
                     if (filteredCategories.isEmpty() && query.isNotBlank()) {
                         item(key = "no-results") {
                             EmptyState(
-                                title = "No matching keys",
-                                subtitle = "Try a different search term.",
+                                title = stringResource(R.string.keys_no_matching_title),
+                                subtitle = stringResource(R.string.keys_no_matching_desc),
+                                actionLabel = stringResource(R.string.empty_action_clear_search),
+                                onAction = { query = "" },
                                 modifier = Modifier.padding(paddingValues),
                             )
                         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
@@ -155,8 +155,10 @@ fun McpServersScreen(
                     if (filteredServers.isEmpty() && query.isEmpty()) {
                         item(key = "empty") {
                             EmptyState(
-                                title = "No MCP servers",
-                                subtitle = "Add a server above or from the catalog.",
+                                title = stringResource(R.string.mcp_servers_empty_title),
+                                subtitle = stringResource(R.string.mcp_servers_empty_desc),
+                                actionLabel = stringResource(R.string.empty_action_add_server),
+                                onAction = { viewModel.toggleAddForm() },
                             )
                         }
                     } else if (filteredServers.isEmpty()) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/model/ModelScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/ModelScreen.kt
@@ -54,7 +54,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.m57.hermescontrol.NavigationController
 import com.m57.hermescontrol.R
+import com.m57.hermescontrol.SettingsConnection
 import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.HermesScaffold
@@ -116,8 +118,8 @@ fun ModelScreen(
                 EmptyState(
                     title = stringResource(R.string.model_empty_title),
                     subtitle = stringResource(R.string.model_empty_desc),
-                    onAction = { viewModel.loadAll() },
-                    actionLabel = stringResource(R.string.content_desc_refresh),
+                    actionLabel = stringResource(R.string.empty_action_configure_model),
+                    onAction = { NavigationController.navigateTo(SettingsConnection) },
                     modifier = Modifier.padding(paddingValues),
                 )
             }

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
@@ -595,6 +595,8 @@ fun SessionsScreen(
                             title = stringResource(R.string.history_empty_title),
                             subtitle = stringResource(R.string.history_empty_desc),
                             icon = Icons.Filled.History,
+                            actionLabel = stringResource(R.string.empty_action_start_chat),
+                            onAction = { NavigationController.navigateTo(ChatScreen) },
                         )
                     }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -150,6 +150,7 @@ fun SkillsScreen(
                         isUninstalling = state.isUninstalling,
                         uninstallingSkillName = state.uninstallingSkillName,
                         onRefresh = viewModel::loadSkills,
+                        onBrowseHub = { viewModel.setViewMode(SkillsViewMode.HUB) },
                     )
                 }
 
@@ -219,6 +220,7 @@ private fun InstalledSkillsView(
     isUninstalling: Boolean,
     uninstallingSkillName: String?,
     onRefresh: () -> Unit,
+    onBrowseHub: () -> Unit,
 ) {
     var showDetail by remember { mutableStateOf<Skill?>(null) }
 
@@ -332,6 +334,8 @@ private fun InstalledSkillsView(
                 EmptyState(
                     icon = Icons.Filled.Extension,
                     title = stringResource(R.string.skills_empty_message),
+                    actionLabel = stringResource(R.string.empty_action_browse_hub),
+                    onAction = onBrowseHub,
                 )
             }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
@@ -131,6 +131,8 @@ internal fun HubBrowseView(
                 EmptyState(
                     icon = Icons.Filled.Extension,
                     title = stringResource(R.string.skills_hub_empty_results),
+                    actionLabel = stringResource(R.string.empty_action_retry_search),
+                    onAction = { onSearch(hubQuery) },
                 )
             }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/webhooks/WebhooksScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/webhooks/WebhooksScreen.kt
@@ -341,7 +341,7 @@ fun WebhooksScreen(
                             EmptyState(
                                 title =
                                     if (state.subscriptions.isEmpty()) {
-                                        "No subscriptions"
+                                        stringResource(R.string.webhooks_empty_title)
                                     } else {
                                         stringResource(R.string.webhooks_no_matching)
                                     },
@@ -350,6 +350,18 @@ fun WebhooksScreen(
                                         stringResource(R.string.webhooks_empty_desc)
                                     } else {
                                         stringResource(R.string.webhooks_no_matching_desc)
+                                    },
+                                actionLabel =
+                                    if (state.subscriptions.isEmpty()) {
+                                        stringResource(R.string.webhooks_action_add)
+                                    } else {
+                                        null
+                                    },
+                                onAction =
+                                    if (state.subscriptions.isEmpty()) {
+                                        { viewModel.showCreateDialog() }
+                                    } else {
+                                        null
                                     },
                             )
                         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,19 @@
     <string name="content_desc_open_drawer">Open navigation drawer</string>
     <string name="content_desc_refresh">Refresh</string>
     <string name="common_save">Save</string>
+
+    <!-- Empty-state CTAs (issue #618) -->
+    <string name="empty_action_browse_hub">Browse skill hub</string>
+    <string name="empty_action_retry_search">Retry search</string>
+    <string name="empty_action_create_job">Create your first job</string>
+    <string name="empty_action_add_server">Add a server</string>
+    <string name="empty_action_create_subscription">Create subscription</string>
+    <string name="empty_action_connect_telegram">Connect a Telegram channel</string>
+    <string name="empty_action_configure_model">Configure model</string>
+    <string name="empty_action_start_chat">Start a new chat</string>
+    <string name="empty_action_install_plugin">Install from URL</string>
+    <string name="empty_action_explore">Explore Skills or Cron jobs</string>
+    <string name="empty_action_clear_search">Clear search</string>
     <string name="common_cancel">Cancel</string>
     <string name="content_desc_clear_search">Clear search</string>
 
@@ -487,6 +500,7 @@
     <string name="webhooks_sec_status">Global Webhooks Status</string>
     <string name="webhooks_sec_subscriptions">Subscriptions</string>
     <string name="webhooks_empty_desc">No webhook subscriptions configured.</string>
+    <string name="webhooks_empty_title">No subscriptions</string>
     <string name="webhooks_search_placeholder">Search subscriptions…</string>
     <string name="webhooks_action_add">Add subscription</string>
     <string name="webhooks_action_create">Create</string>
@@ -645,6 +659,8 @@
     <string name="mcp_servers_action_test">Test</string>
     <string name="mcp_servers_add_server">Add server</string>
     <string name="mcp_servers_add_http">HTTP URL</string>
+    <string name="mcp_servers_empty_title">No MCP servers</string>
+    <string name="mcp_servers_empty_desc">Add a server above or from the catalog.</string>
     <string name="mcp_servers_add_stdio">Stdio command</string>
     <string name="mcp_servers_field_name">Server name</string>
     <string name="mcp_servers_field_url">URL (e.g. http://localhost:8000/sse)</string>
@@ -747,6 +763,8 @@
     <string name="keys_label_not_configured">Not configured</string>
     <string name="keys_action_toggle_visibility">Toggle Visibility</string>
     <string name="keys_search_placeholder">Search keys…</string>
+    <string name="keys_no_matching_title">No matching keys</string>
+    <string name="keys_no_matching_desc">Try a different search term.</string>
     <string name="keys_add_header">Add new key</string>
     <string name="keys_add_key_label">Key</string>
     <string name="keys_add_value_label">Value</string>


### PR DESCRIPTION
## Summary
Closes #618. Turns dead-end empty states into on-ramps by wiring the existing `EmptyState` `actionLabel`/`onAction` params to real next actions.

### Screens wired (real, existing actions)
- **Skills (installed):** "Browse skill hub" → `viewModel.setViewMode(HUB)`
- **Skills (hub):** "Retry search" → `searchHub(hubQuery)`
- **Cron Jobs:** "Create your first job" → `openNewJobDialog()`
- **MCP servers:** "Add a server" → `toggleAddForm()` (hardcoded literal moved to `strings.xml`)
- **Webhooks:** "Create subscription" → `showCreateDialog()` (hardcoded literal moved to `strings.xml`)
- **Channels:** "Connect a Telegram channel" → `startTelegramOnboarding()`
- **Model:** "Configure model" → `navigateTo(SettingsConnection)`
- **Sessions (history):** "Start a new chat" → `navigateTo(ChatScreen)`
- **Analytics:** "Explore Skills or Cron jobs" → `navigateTo(SkillsScreen)`
- **Keys (no match):** "Clear search" → `query = ""` (literal moved to `strings.xml`)

All new labels use `strings.xml` under `empty_action_*` / `screenname_empty_*` keys — no new hardcoded literals.

### Deviations from the issue (flagged honestly)
- **Toolsets, Profiles, Plugins keep `Refresh`.** The issue suggested "Create toolset" / "Create profile" / "Install from URL", but **no in-app create path exists** for these: toolsets are server-defined toggles, and profiles/plugins have no create dialog wired into the UI. Faking a create CTA would be a dead button, so `Refresh` (the correct recovery) stays. If create flows get built later, those are the natural CTAs to add.
- **Skills:** edited the real `private InstalledSkillsView` in `SkillsScreen.kt`. Note there is a **duplicate `internal InstalledSkillsView` in `InstalledSkillsTab.kt` that is dead code** (never called) — left as-is this PR; recommend a cleanup follow-up.

## Verification
- `./gradlew ktlintCheck` — clean
- `./gradlew assembleDebug` — green (only pre-existing unrelated `Locale` deprecation warnings)

## Test plan
- [ ] Land on each empty screen listed above; confirm the CTA button appears and triggers the correct action
- [ ] MCP / Webhooks / Keys empty states show localized (non-hardcoded) strings