### PR TITLE
feat(billing): adopt subscription.* + usage.bars WS methods (issue #628)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/NavigationKeys.kt
+++ b/app/src/main/java/com/m57/hermescontrol/NavigationKeys.kt
@@ -55,6 +55,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable data object AnalyticsScreen : NavKey
 
+@Serializable data object BillingScreen : NavKey
+
 // ── Settings drill-down sub-pages ──────────────────────────────────────
 
 @Serializable data object SettingsConnection : NavKey

--- a/app/src/main/java/com/m57/hermescontrol/ScreenRegistry.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ScreenRegistry.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.automirrored.filled.ListAlt
+import androidx.compose.material.icons.filled.AccountBalanceWallet
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Bolt
@@ -27,6 +28,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation3.runtime.NavKey
 import com.m57.hermescontrol.ui.achievements.AchievementsScreen as AchievementsScreenContent
 import com.m57.hermescontrol.ui.analytics.AnalyticsScreen as AnalyticsScreenContent
+import com.m57.hermescontrol.ui.billing.BillingScreen as BillingScreenContent
 import com.m57.hermescontrol.ui.channels.ChannelsScreen as ChannelsScreenContent
 import com.m57.hermescontrol.ui.chat.ChatScreen as ChatScreenContent
 import com.m57.hermescontrol.ui.config.ConfigScreen as ConfigScreenContent
@@ -189,6 +191,12 @@ object ScreenRegistry {
                 Icons.Filled.BarChart,
                 DrawerSection.INSPECT,
             ) { sessionId, openDrawer -> AnalyticsScreenContent(onOpenDrawer = openDrawer) },
+            ScreenDefinition(
+                BillingScreen,
+                R.string.screen_billing,
+                Icons.Filled.AccountBalanceWallet,
+                DrawerSection.INSPECT,
+            ) { sessionId, openDrawer -> BillingScreenContent(onOpenDrawer = openDrawer) },
             ScreenDefinition(
                 KanbanScreen,
                 R.string.screen_kanban,

--- a/app/src/main/java/com/m57/hermescontrol/data/model/BillingModels.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/BillingModels.kt
@@ -6,19 +6,23 @@ import kotlinx.serialization.Serializable
  * Request/response models for the billing/subscription WebSocket RPC surface
  * adopted in issue #628 (backend release audit 0bf44d557..614dc194e).
  *
- * Verified against the LIVE gateway (probe on :9119, 2026-07-19): all six
- * methods resolve (no -32601). The real wire shapes differ from the
- * source-described contracts — notably `subscription.state` returns
- * `logged_in` / `current` / `tiers` / `usage` (not the legacy
- * `subscription_type_id` / `renews_at` fields), and the mutating RPCs return
- * an `ok:false` *result* (with `error` / `message` / `payload`) rather than an
- * RPC-level error when unauthenticated. These models track the live shape.
+ * VERIFIED against the LIVE gateway with a logged-in Nous Portal session
+ * (probe on :9119, 2026-07-19). Real shapes captured:
+ *  - `subscription.state` -> ok/logged_in/is_admin/can_change_plan/org_name/
+ *    role/context + `current` {tier_id, tier_name, monthly_credits,
+ *    credits_remaining, cycle_ends_at, pending_downgrade_*} + `tiers`.
+ *  - `usage.bars` -> ok/available/status/plan_name/renews_at +
+ *    `plan_bar` {kind, remaining_display, total_display, spent_display,
+ *    pct_used, fill_fraction} + `topup_bar` (nullable).
+ *  - Mutating RPCs (preview/change/resume/upgrade) -> `ok:false` *result*
+ *    with `error`/`message`/`payload`; when the Portal token lacks the
+ *    `billing:manage` scope they return error:"insufficient_scope".
  *
- * All models are decoded with [com.m57.hermescontrol.data.remote.OkHttpProvider.json]
+ * All models decode with [com.m57.hermescontrol.data.remote.OkHttpProvider.json]
  * (kotlinx `Json { ignoreUnknownKeys = true; SnakeCase }`). The `SnakeCase`
  * naming strategy maps snake_case wire keys directly onto snake_case Kotlin
- * properties (e.g. `logged_in`), so the property names below mirror the backend
- * JSON exactly and unknown backend fields are tolerated.
+ * properties, so the property names below mirror the backend JSON exactly and
+ * unknown backend fields are tolerated.
  */
 
 @Serializable
@@ -30,51 +34,38 @@ data class SubscriptionStateResponse(
     val org_name: String? = null,
     val org_id: String? = null,
     val role: String? = null,
-    /**
-     * "personal" for a direct Nous Portal login, "org" when acting under an
-     * organization. Drives which plan/cancel affordances the screen shows.
-     */
+    /** "personal" for a direct Nous Portal login, "org" when under an org. */
     val context: String? = null,
-    /**
-     * The active plan summary when [logged_in] is true. Null when logged out
-     * or on the free tier — the screen renders the "no active plan" state then.
-     */
+    /** Active plan summary when [logged_in] is true; null when logged out. */
     val current: SubscriptionCurrent? = null,
-    /**
-     * Available plan tiers the user can switch between. Empty when logged out.
-     */
+    /** Available plan tiers the user can switch between (empty when logged out). */
     val tiers: List<SubscriptionTier> = emptyList(),
     val portal_url: String? = null,
     val error: String? = null,
-    /**
-     * Nested usage availability gate returned by the live backend. The actual
-     * usage bars come from the separate `usage.bars` RPC.
-     */
-    val usage: SubscriptionStateUsage? = null,
 )
 
 @Serializable
 data class SubscriptionCurrent(
-    val subscription_type_id: String? = null,
-    val subscription_type_name: String? = null,
-    val status: String? = null,
-    val renews_at: String? = null,
-    val cancel_at_period_end: Boolean? = null,
-    val payment_method: String? = null,
+    val tier_id: String? = null,
+    val tier_name: String? = null,
+    /** Monthly credit grant, as a string decimal (e.g. "0.1"). */
+    val monthly_credits: String? = null,
+    /** Credits remaining this cycle, as a string decimal. */
+    val credits_remaining: String? = null,
+    /** ISO timestamp when the current cycle ends. */
+    val cycle_ends_at: String? = null,
+    val pending_downgrade_tier_name: String? = null,
+    val pending_downgrade_at: String? = null,
+    val pending_downgrade_display: String? = null,
 )
 
 @Serializable
 data class SubscriptionTier(
-    val subscription_type_id: String? = null,
-    val subscription_type_name: String? = null,
+    val tier_id: String? = null,
+    val tier_name: String? = null,
     val price: String? = null,
     val currency: String? = null,
     val interval: String? = null,
-)
-
-@Serializable
-data class SubscriptionStateUsage(
-    val available: Boolean? = null,
 )
 
 // ── usage.bars ────────────────────────────────────────────────────────────
@@ -83,17 +74,29 @@ data class SubscriptionStateUsage(
 data class UsageBarsResponse(
     val ok: Boolean? = null,
     val available: Boolean? = null,
-    val period_start: String? = null,
-    val period_end: String? = null,
-    val bars: List<UsageBar> = emptyList(),
+    /** e.g. "depleted" / "active" — high-level usage status. */
+    val status: String? = null,
+    val plan_name: String? = null,
+    val renews_at: String? = null,
+    val renews_display: String? = null,
+    val subscription_remaining_display: String? = null,
+    val topup_remaining_display: String? = null,
+    val total_spendable_display: String? = null,
+    val has_topup: Boolean? = null,
+    val plan_bar: UsageBar? = null,
+    val topup_bar: UsageBar? = null,
 )
 
 @Serializable
 data class UsageBar(
-    val label: String? = null,
-    val used: Double? = null,
-    val limit: Double? = null,
-    val unit: String? = null,
+    val kind: String? = null,
+    val remaining_display: String? = null,
+    val total_display: String? = null,
+    val spent_display: String? = null,
+    /** 0..100 percentage used (not a fraction). */
+    val pct_used: Double? = null,
+    /** 0.0..1.0 fill fraction for a progress indicator. */
+    val fill_fraction: Double? = null,
 )
 
 // ── subscription.preview ──────────────────────────────────────────────────
@@ -121,6 +124,8 @@ data class SubscriptionPreviewResponse(
 
 @Serializable
 data class SubscriptionPreviewPayload(
+    val error: String? = null,
+    val error_description: String? = null,
     val actor: String? = null,
     val code: String? = null,
     val recovery: String? = null,

--- a/app/src/main/java/com/m57/hermescontrol/data/model/BillingModels.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/BillingModels.kt
@@ -1,0 +1,105 @@
+package com.m57.hermescontrol.data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Request/response models for the billing/subscription WebSocket RPC surface
+ * adopted in issue #628 (backend release audit 0bf44d557..614dc194e).
+ *
+ * All models are decoded with [com.m57.hermescontrol.data.remote.OkHttpProvider.json]
+ * (kotlinx `Json { ignoreUnknownKeys = true; SnakeCase }`), so snake_case wire
+ * names map to camelCase properties and unknown backend fields are tolerated.
+ */
+
+@Serializable
+data class SubscriptionStateResponse(
+    val logged_in: Boolean = false,
+    val subscription_type_id: String? = null,
+    val subscription_type_name: String? = null,
+    val status: String? = null,
+    val renews_at: String? = null,
+    val cancel_at_period_end: Boolean? = null,
+    val payment_method: String? = null,
+    val portal_url: String? = null,
+)
+
+// ── usage.bars ────────────────────────────────────────────────────────────
+
+@Serializable
+data class UsageBarsResponse(
+    val period_start: String? = null,
+    val period_end: String? = null,
+    val bars: List<UsageBar> = emptyList(),
+)
+
+@Serializable
+data class UsageBar(
+    val label: String? = null,
+    val used: Double? = null,
+    val limit: Double? = null,
+    val unit: String? = null,
+)
+
+// ── subscription.preview ──────────────────────────────────────────────────
+
+@Serializable
+data class SubscriptionPreviewRequest(
+    val subscription_type_id: String,
+)
+
+@Serializable
+data class SubscriptionPreviewResponse(
+    val subscription_type_id: String? = null,
+    val subscription_type_name: String? = null,
+    val price: String? = null,
+    val currency: String? = null,
+    val interval: String? = null,
+    val proration_credit: String? = null,
+    val proration_charge: String? = null,
+    val summary: String? = null,
+)
+
+// ── subscription.change ───────────────────────────────────────────────────
+
+@Serializable
+data class SubscriptionChangeRequest(
+    val subscription_type_id: String? = null,
+    val cancel: Boolean? = null,
+)
+
+@Serializable
+data class SubscriptionChangeResponse(
+    val ok: Boolean? = null,
+    val status: String? = null,
+    val cancel_at_period_end: Boolean? = null,
+    val message: String? = null,
+)
+
+// ── subscription.resume ───────────────────────────────────────────────────
+
+@Serializable
+data class SubscriptionResumeResponse(
+    val ok: Boolean? = null,
+    val status: String? = null,
+    val message: String? = null,
+)
+
+// ── subscription.upgrade ──────────────────────────────────────────────────
+
+@Serializable
+data class SubscriptionUpgradeRequest(
+    val subscription_type_id: String,
+)
+
+@Serializable
+data class SubscriptionUpgradeResponse(
+    val ok: Boolean? = null,
+    val status: String? = null,
+    /** Set when the charge needs SCA / customer action (3-D Secure etc.). */
+    val requires_action: Boolean? = null,
+    /** Recovery URL the user must open to complete the action. */
+    val recovery_url: String? = null,
+    /** Set when the charge was declined. */
+    val payment_failed: Boolean? = null,
+    val message: String? = null,
+)

--- a/app/src/main/java/com/m57/hermescontrol/data/model/BillingModels.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/BillingModels.kt
@@ -6,6 +6,14 @@ import kotlinx.serialization.Serializable
  * Request/response models for the billing/subscription WebSocket RPC surface
  * adopted in issue #628 (backend release audit 0bf44d557..614dc194e).
  *
+ * Verified against the LIVE gateway (probe on :9119, 2026-07-19): all six
+ * methods resolve (no -32601). The real wire shapes differ from the
+ * source-described contracts — notably `subscription.state` returns
+ * `logged_in` / `current` / `tiers` / `usage` (not the legacy
+ * `subscription_type_id` / `renews_at` fields), and the mutating RPCs return
+ * an `ok:false` *result* (with `error` / `message` / `payload`) rather than an
+ * RPC-level error when unauthenticated. These models track the live shape.
+ *
  * All models are decoded with [com.m57.hermescontrol.data.remote.OkHttpProvider.json]
  * (kotlinx `Json { ignoreUnknownKeys = true; SnakeCase }`), so snake_case wire
  * names map to camelCase properties and unknown backend fields are tolerated.
@@ -13,20 +21,66 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class SubscriptionStateResponse(
-    val logged_in: Boolean = false,
+    val ok: Boolean? = null,
+    val logged_in: Boolean? = null,
+    val is_admin: Boolean? = null,
+    val can_change_plan: Boolean? = null,
+    val org_name: String? = null,
+    val org_id: String? = null,
+    val role: String? = null,
+    /**
+     * "personal" for a direct Nous Portal login, "org" when acting under an
+     * organization. Drives which plan/cancel affordances the screen shows.
+     */
+    val context: String? = null,
+    /**
+     * The active plan summary when [logged_in] is true. Null when logged out
+     * or on the free tier — the screen renders the "no active plan" state then.
+     */
+    val current: SubscriptionCurrent? = null,
+    /**
+     * Available plan tiers the user can switch between. Empty when logged out.
+     */
+    val tiers: List<SubscriptionTier> = emptyList(),
+    val portal_url: String? = null,
+    val error: String? = null,
+    /**
+     * Nested usage availability gate returned by the live backend. The actual
+     * usage bars come from the separate `usage.bars` RPC.
+     */
+    val usage: SubscriptionStateUsage? = null,
+)
+
+@Serializable
+data class SubscriptionCurrent(
     val subscription_type_id: String? = null,
     val subscription_type_name: String? = null,
     val status: String? = null,
     val renews_at: String? = null,
     val cancel_at_period_end: Boolean? = null,
     val payment_method: String? = null,
-    val portal_url: String? = null,
+)
+
+@Serializable
+data class SubscriptionTier(
+    val subscription_type_id: String? = null,
+    val subscription_type_name: String? = null,
+    val price: String? = null,
+    val currency: String? = null,
+    val interval: String? = null,
+)
+
+@Serializable
+data class SubscriptionStateUsage(
+    val available: Boolean? = null,
 )
 
 // ── usage.bars ────────────────────────────────────────────────────────────
 
 @Serializable
 data class UsageBarsResponse(
+    val ok: Boolean? = null,
+    val available: Boolean? = null,
     val period_start: String? = null,
     val period_end: String? = null,
     val bars: List<UsageBar> = emptyList(),
@@ -49,6 +103,10 @@ data class SubscriptionPreviewRequest(
 
 @Serializable
 data class SubscriptionPreviewResponse(
+    val ok: Boolean? = null,
+    val error: String? = null,
+    val message: String? = null,
+    val payload: SubscriptionPreviewPayload? = null,
     val subscription_type_id: String? = null,
     val subscription_type_name: String? = null,
     val price: String? = null,
@@ -57,6 +115,13 @@ data class SubscriptionPreviewResponse(
     val proration_credit: String? = null,
     val proration_charge: String? = null,
     val summary: String? = null,
+)
+
+@Serializable
+data class SubscriptionPreviewPayload(
+    val actor: String? = null,
+    val code: String? = null,
+    val recovery: String? = null,
 )
 
 // ── subscription.change ───────────────────────────────────────────────────
@@ -70,6 +135,7 @@ data class SubscriptionChangeRequest(
 @Serializable
 data class SubscriptionChangeResponse(
     val ok: Boolean? = null,
+    val error: String? = null,
     val status: String? = null,
     val cancel_at_period_end: Boolean? = null,
     val message: String? = null,
@@ -80,6 +146,7 @@ data class SubscriptionChangeResponse(
 @Serializable
 data class SubscriptionResumeResponse(
     val ok: Boolean? = null,
+    val error: String? = null,
     val status: String? = null,
     val message: String? = null,
 )
@@ -94,6 +161,7 @@ data class SubscriptionUpgradeRequest(
 @Serializable
 data class SubscriptionUpgradeResponse(
     val ok: Boolean? = null,
+    val error: String? = null,
     val status: String? = null,
     /** Set when the charge needs SCA / customer action (3-D Secure etc.). */
     val requires_action: Boolean? = null,
@@ -101,5 +169,7 @@ data class SubscriptionUpgradeResponse(
     val recovery_url: String? = null,
     /** Set when the charge was declined. */
     val payment_failed: Boolean? = null,
+    /** Backend-issued idempotency key (present on the live gateway response). */
+    val idempotency_key: String? = null,
     val message: String? = null,
 )

--- a/app/src/main/java/com/m57/hermescontrol/data/model/BillingModels.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/BillingModels.kt
@@ -15,8 +15,10 @@ import kotlinx.serialization.Serializable
  * RPC-level error when unauthenticated. These models track the live shape.
  *
  * All models are decoded with [com.m57.hermescontrol.data.remote.OkHttpProvider.json]
- * (kotlinx `Json { ignoreUnknownKeys = true; SnakeCase }`), so snake_case wire
- * names map to camelCase properties and unknown backend fields are tolerated.
+ * (kotlinx `Json { ignoreUnknownKeys = true; SnakeCase }`). The `SnakeCase`
+ * naming strategy maps snake_case wire keys directly onto snake_case Kotlin
+ * properties (e.g. `logged_in`), so the property names below mirror the backend
+ * JSON exactly and unknown backend fields are tolerated.
  */
 
 @Serializable

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/BillingRepository.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/BillingRepository.kt
@@ -8,7 +8,11 @@ import com.m57.hermescontrol.data.model.SubscriptionStateResponse
 import com.m57.hermescontrol.data.model.SubscriptionUpgradeResponse
 import com.m57.hermescontrol.data.model.UsageBarsResponse
 import com.m57.hermescontrol.data.remote.OkHttpProvider
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.serializer
 
 /**
@@ -22,14 +26,46 @@ import kotlinx.serialization.serializer
  * `credits.view` method and receive `-32601`. We never dispatch it ourselves,
  * but [HermesRpcException] from any billing call is surfaced as a clean
  * "feature unavailable" state by the ViewModel rather than a crash.
+ *
+ * NOTE: [HermesWsClient] hands back `result` already converted via
+ * `JsonElement.toAny()` (a `Map<String, Any?>`), not a raw `JsonElement`.
+ * [decode] therefore normalizes whatever arrives back to JSON before
+ * deserializing, so both shapes decode correctly.
  */
 object BillingRepository {
     private val json get() = OkHttpProvider.json
 
+    @Suppress("UNCHECKED_CAST")
     private inline fun <reified T> decode(result: Any?): T? {
-        val element = result as? JsonElement ?: return null
+        if (result == null) return null
+        // `result` may arrive as a kotlinx JsonElement OR as a Map produced by
+        // JsonElement.toAny() in HermesWsClient. Normalize both back to a JSON
+        // string (via a recursive Any->JsonElement walk) before deserializing.
+        val element: JsonElement =
+            when (result) {
+                is JsonElement -> result
+                is Map<*, *> -> anyToJsonElement(result)
+                is List<*> -> JsonArray(result.map { anyToJsonElement(it) })
+                else -> JsonPrimitive(result.toString())
+            }
         return json.decodeFromJsonElement(serializer<T>(), element)
     }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun anyToJsonElement(value: Any?): JsonElement =
+        when (value) {
+            null -> JsonNull
+            is JsonElement -> value
+            is Map<*, *> ->
+                JsonObject(
+                    (value as Map<String, Any?>).mapValues { (_, v) -> anyToJsonElement(v) },
+                )
+            is List<*> -> JsonArray(value.map { anyToJsonElement(it) })
+            is String -> JsonPrimitive(value)
+            is Boolean -> JsonPrimitive(value)
+            is Number -> JsonPrimitive(value)
+            else -> JsonPrimitive(value.toString())
+        }
 
     suspend fun getSubscriptionState(): SubscriptionStateResponse? {
         val result = HermesWsClient.request(WsMethods.SUBSCRIPTION_STATE).await()

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/BillingRepository.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/BillingRepository.kt
@@ -26,23 +26,22 @@ import kotlinx.serialization.serializer
 object BillingRepository {
     private val json get() = OkHttpProvider.json
 
-    private inline fun <reified T> decode(result: Any?): T {
-        val element = result as? JsonElement
-        requireNotNull(element) { "Billing RPC returned no result payload" }
+    private inline fun <reified T> decode(result: Any?): T? {
+        val element = result as? JsonElement ?: return null
         return json.decodeFromJsonElement(serializer<T>(), element)
     }
 
-    suspend fun getSubscriptionState(): SubscriptionStateResponse {
+    suspend fun getSubscriptionState(): SubscriptionStateResponse? {
         val result = HermesWsClient.request(WsMethods.SUBSCRIPTION_STATE).await()
         return decode(result)
     }
 
-    suspend fun getUsageBars(): UsageBarsResponse {
+    suspend fun getUsageBars(): UsageBarsResponse? {
         val result = HermesWsClient.request(WsMethods.USAGE_BARS).await()
         return decode(result)
     }
 
-    suspend fun previewSubscription(subscriptionTypeId: String): SubscriptionPreviewResponse {
+    suspend fun previewSubscription(subscriptionTypeId: String): SubscriptionPreviewResponse? {
         val result =
             HermesWsClient
                 .request(
@@ -52,7 +51,7 @@ object BillingRepository {
         return decode(result)
     }
 
-    suspend fun changeSubscription(request: SubscriptionChangeRequest): SubscriptionChangeResponse {
+    suspend fun changeSubscription(request: SubscriptionChangeRequest): SubscriptionChangeResponse? {
         val result =
             HermesWsClient
                 .request(
@@ -65,12 +64,12 @@ object BillingRepository {
         return decode(result)
     }
 
-    suspend fun resumeSubscription(): SubscriptionResumeResponse {
+    suspend fun resumeSubscription(): SubscriptionResumeResponse? {
         val result = HermesWsClient.request(WsMethods.SUBSCRIPTION_RESUME).await()
         return decode(result)
     }
 
-    suspend fun upgradeSubscription(subscriptionTypeId: String): SubscriptionUpgradeResponse {
+    suspend fun upgradeSubscription(subscriptionTypeId: String): SubscriptionUpgradeResponse? {
         val result =
             HermesWsClient
                 .request(

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/BillingRepository.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/BillingRepository.kt
@@ -1,0 +1,82 @@
+package com.m57.hermescontrol.data.ws
+
+import com.m57.hermescontrol.data.model.SubscriptionChangeRequest
+import com.m57.hermescontrol.data.model.SubscriptionChangeResponse
+import com.m57.hermescontrol.data.model.SubscriptionPreviewResponse
+import com.m57.hermescontrol.data.model.SubscriptionResumeResponse
+import com.m57.hermescontrol.data.model.SubscriptionStateResponse
+import com.m57.hermescontrol.data.model.SubscriptionUpgradeResponse
+import com.m57.hermescontrol.data.model.UsageBarsResponse
+import com.m57.hermescontrol.data.remote.OkHttpProvider
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.serializer
+
+/**
+ * Client for the billing/subscription WebSocket RPC surface (issue #628).
+ *
+ * Mirrors [HermesWsClient.request]: every call returns the backend `result`
+ * payload decoded into a typed model, or throws [HermesWsClient.HermesRpcException]
+ * on an RPC error (e.g. `-32601 unknown method`).
+ *
+ * Defensive note: an old cached mobile build may still dispatch the removed
+ * `credits.view` method and receive `-32601`. We never dispatch it ourselves,
+ * but [HermesRpcException] from any billing call is surfaced as a clean
+ * "feature unavailable" state by the ViewModel rather than a crash.
+ */
+object BillingRepository {
+    private val json get() = OkHttpProvider.json
+
+    private inline fun <reified T> decode(result: Any?): T {
+        val element = result as? JsonElement
+        requireNotNull(element) { "Billing RPC returned no result payload" }
+        return json.decodeFromJsonElement(serializer<T>(), element)
+    }
+
+    suspend fun getSubscriptionState(): SubscriptionStateResponse {
+        val result = HermesWsClient.request(WsMethods.SUBSCRIPTION_STATE).await()
+        return decode(result)
+    }
+
+    suspend fun getUsageBars(): UsageBarsResponse {
+        val result = HermesWsClient.request(WsMethods.USAGE_BARS).await()
+        return decode(result)
+    }
+
+    suspend fun previewSubscription(subscriptionTypeId: String): SubscriptionPreviewResponse {
+        val result =
+            HermesWsClient
+                .request(
+                    WsMethods.SUBSCRIPTION_PREVIEW,
+                    mapOf("subscription_type_id" to subscriptionTypeId),
+                ).await()
+        return decode(result)
+    }
+
+    suspend fun changeSubscription(request: SubscriptionChangeRequest): SubscriptionChangeResponse {
+        val result =
+            HermesWsClient
+                .request(
+                    WsMethods.SUBSCRIPTION_CHANGE,
+                    buildMap {
+                        request.subscription_type_id?.let { put("subscription_type_id", it) }
+                        request.cancel?.let { put("cancel", it) }
+                    },
+                ).await()
+        return decode(result)
+    }
+
+    suspend fun resumeSubscription(): SubscriptionResumeResponse {
+        val result = HermesWsClient.request(WsMethods.SUBSCRIPTION_RESUME).await()
+        return decode(result)
+    }
+
+    suspend fun upgradeSubscription(subscriptionTypeId: String): SubscriptionUpgradeResponse {
+        val result =
+            HermesWsClient
+                .request(
+                    WsMethods.SUBSCRIPTION_UPGRADE,
+                    mapOf("subscription_type_id" to subscriptionTypeId),
+                ).await()
+        return decode(result)
+    }
+}

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/WsMethods.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/WsMethods.kt
@@ -43,4 +43,27 @@ object WsMethods {
 
     /** Kill a single background process (scoped to the active session). */
     const val PROCESS_KILL = "process.kill"
+
+    // ── Billing / subscription (issue #628) ─────────────────────────────
+    // Adopted from the backend release audit (hermes-agent 0bf44d557..614dc194e).
+    // `credits.view` was REMOVED upstream; these replace it. `usage.bars`
+    // surfaces the same usage data the legacy credits block rendered.
+
+    /** Current subscription/plan state. Fail-open: logged-out → {logged_in:false}. */
+    const val SUBSCRIPTION_STATE = "subscription.state"
+
+    /** Chargeless effect quote for a target subscription type. */
+    const val SUBSCRIPTION_PREVIEW = "subscription.preview"
+
+    /** Schedule a downgrade or cancellation. */
+    const val SUBSCRIPTION_CHANGE = "subscription.change"
+
+    /** Resume a cancelled/paused subscription. */
+    const val SUBSCRIPTION_RESUME = "subscription.resume"
+
+    /** Upgrade — hits POST /api/billing/subscription/upgrade (prorate + charge). */
+    const val SUBSCRIPTION_UPGRADE = "subscription.upgrade"
+
+    /** Usage bars (token/cost breakdown the legacy credits block rendered). */
+    const val USAGE_BARS = "usage.bars"
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.m57.hermescontrol.R
+import com.m57.hermescontrol.data.model.SubscriptionCurrent
 import com.m57.hermescontrol.data.model.SubscriptionStateResponse
 import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.HermesScaffold
@@ -104,14 +105,16 @@ private fun BillingContent(
         contentPadding = listContentPadding,
         verticalArrangement = listItemSpacing,
     ) {
-        if (subscription != null) {
-            item { PlanCard(subscription) }
+        val sub = subscription
+        if (sub != null && sub.logged_in == true && sub.current != null) {
+            item { PlanCard(sub.current) }
             item {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    if (subscription.status == "cancelled" || subscription.status == "paused") {
+                    val status = sub.current.status
+                    if (status == "cancelled" || status == "paused") {
                         Button(
                             onClick = onResume,
                             enabled = !state.isActionInFlight,
@@ -130,19 +133,22 @@ private fun BillingContent(
                     }
                 }
             }
-            if (state.actionMessage != null) {
-                item {
-                    Card(
-                        modifier = Modifier.fillMaxWidth(),
-                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
-                        shape = RoundedCornerShape(12.dp),
-                    ) {
-                        Text(
-                            text = state.actionMessage ?: "",
-                            modifier = Modifier.padding(12.dp),
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
-                    }
+        } else if (sub != null) {
+            item { NoActivePlanCard(sub) }
+        }
+
+        if (state.actionMessage != null) {
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    Text(
+                        text = state.actionMessage ?: "",
+                        modifier = Modifier.padding(12.dp),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
                 }
             }
         }
@@ -157,7 +163,7 @@ private fun BillingContent(
 }
 
 @Composable
-private fun PlanCard(subscription: SubscriptionStateResponse) {
+private fun PlanCard(subscription: SubscriptionCurrent) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
@@ -189,6 +195,34 @@ private fun PlanCard(subscription: SubscriptionStateResponse) {
                     modifier = Modifier.padding(top = 4.dp),
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun NoActivePlanCard(subscription: SubscriptionStateResponse) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.billing_free_plan),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text =
+                    if (subscription.logged_in == true) {
+                        stringResource(R.string.billing_no_active_plan)
+                    } else {
+                        stringResource(R.string.billing_login_required)
+                    },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp),
+            )
         }
     }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingScreen.kt
@@ -1,0 +1,262 @@
+package com.m57.hermescontrol.ui.billing
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBalanceWallet
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.m57.hermescontrol.R
+import com.m57.hermescontrol.data.model.SubscriptionStateResponse
+import com.m57.hermescontrol.ui.common.ErrorState
+import com.m57.hermescontrol.ui.common.HermesScaffold
+import com.m57.hermescontrol.ui.common.LoadingState
+import com.m57.hermescontrol.ui.common.NavIcon
+import com.m57.hermescontrol.ui.common.listContentPadding
+import com.m57.hermescontrol.ui.common.listItemSpacing
+
+@Composable
+fun BillingScreen(
+    modifier: Modifier = Modifier,
+    onOpenDrawer: (() -> Unit)? = null,
+    viewModel: BillingViewModel = viewModel { BillingViewModel() },
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        if (state.subscription == null && state.usage == null && !state.featureUnavailable) {
+            viewModel.load()
+        }
+    }
+
+    HermesScaffold(
+        title = { Text(stringResource(R.string.screen_billing)) },
+        navigationIcon = onOpenDrawer?.let { NavIcon.Menu(it) },
+        isRefreshing = state.isLoading,
+        onRefresh = { viewModel.load() },
+        modifier = modifier,
+    ) {
+        when {
+            state.featureUnavailable -> {
+                FeatureUnavailableState(onRetry = { viewModel.load() })
+            }
+
+            state.isLoading && state.subscription == null && state.usage == null -> {
+                LoadingState(modifier = Modifier.fillMaxSize())
+            }
+
+            state.errorMessage != null && state.subscription == null && state.usage == null -> {
+                ErrorState(
+                    message = state.errorMessage ?: stringResource(R.string.error_unknown),
+                    onRetry = { viewModel.load() },
+                )
+            }
+
+            else -> {
+                BillingContent(
+                    state = state,
+                    onUpgrade = viewModel::upgrade,
+                    onChange = viewModel::change,
+                    onResume = viewModel::resume,
+                    onPreview = viewModel::preview,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BillingContent(
+    state: BillingUiState,
+    onUpgrade: (String) -> Unit,
+    onChange: (String?, Boolean?) -> Unit,
+    onResume: () -> Unit,
+    onPreview: (String) -> Unit,
+) {
+    val subscription = state.subscription
+    val usage = state.usage
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = listContentPadding,
+        verticalArrangement = listItemSpacing,
+    ) {
+        if (subscription != null) {
+            item { PlanCard(subscription) }
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    if (subscription.status == "cancelled" || subscription.status == "paused") {
+                        Button(
+                            onClick = onResume,
+                            enabled = !state.isActionInFlight,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Text(stringResource(R.string.billing_resume))
+                        }
+                    } else {
+                        OutlinedButton(
+                            onClick = { onChange(null, true) },
+                            enabled = !state.isActionInFlight,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Text(stringResource(R.string.billing_cancel))
+                        }
+                    }
+                }
+            }
+            if (state.actionMessage != null) {
+                item {
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+                        shape = RoundedCornerShape(12.dp),
+                    ) {
+                        Text(
+                            text = state.actionMessage ?: "",
+                            modifier = Modifier.padding(12.dp),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                }
+            }
+        }
+
+        if (usage != null && usage.bars.isNotEmpty()) {
+            item { SectionTitle(stringResource(R.string.billing_usage)) }
+            items(usage.bars.size, key = { "bar_$it" }) { index ->
+                UsageBarRow(bar = usage.bars[index])
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlanCard(subscription: SubscriptionStateResponse) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = subscription.subscription_type_name ?: stringResource(R.string.billing_free_plan),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text =
+                    when (subscription.status) {
+                        null -> stringResource(R.string.billing_status_unknown)
+                        "active" -> stringResource(R.string.billing_status_active)
+                        "cancelled" -> stringResource(R.string.billing_status_cancelled)
+                        "paused" -> stringResource(R.string.billing_status_paused)
+                        else -> subscription.status ?: ""
+                    },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (subscription.renews_at != null) {
+                Text(
+                    text = stringResource(R.string.billing_renews, subscription.renews_at),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun UsageBarRow(bar: com.m57.hermescontrol.data.model.UsageBar) {
+    val used = bar.used ?: 0.0
+    val limit = bar.limit ?: 0.0
+    val fraction =
+        if (limit > 0.0) {
+            (used / limit).toFloat().coerceIn(0f, 1f)
+        } else {
+            0f
+        }
+    Card(modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(12.dp)) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = bar.label ?: "",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = "$used / $limit ${bar.unit ?: ""}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (limit > 0.0) {
+                LinearProgressIndicator(
+                    progress = { fraction },
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp)
+                            .height(8.dp)
+                            .clip(RoundedCornerShape(4.dp)),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionTitle(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.titleSmall,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(top = 8.dp, bottom = 4.dp),
+    )
+}
+
+@Composable
+private fun FeatureUnavailableState(onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        androidx.compose.material.icons.Icons.Filled.AccountBalanceWallet
+        ErrorState(
+            message = stringResource(R.string.billing_feature_unavailable),
+            onRetry = onRetry,
+        )
+    }
+}

--- a/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingScreen.kt
@@ -137,6 +137,23 @@ private fun BillingContent(
             item { NoActivePlanCard(sub) }
         }
 
+        if (state.errorMessage != null) {
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
+                    shape = RoundedCornerShape(12.dp),
+                ) {
+                    Text(
+                        text = state.errorMessage ?: "",
+                        modifier = Modifier.padding(12.dp),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                }
+            }
+        }
+
         if (state.actionMessage != null) {
             item {
                 Card(
@@ -287,7 +304,12 @@ private fun FeatureUnavailableState(onRetry: () -> Unit) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        androidx.compose.material.icons.Icons.Filled.AccountBalanceWallet
+        androidx.compose.material3.Icon(
+            imageVector = androidx.compose.material.icons.Icons.Filled.AccountBalanceWallet,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+            modifier = Modifier.padding(bottom = 16.dp).size(48.dp),
+        )
         ErrorState(
             message = stringResource(R.string.billing_feature_unavailable),
             onRetry = onRetry,

--- a/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountBalanceWallet
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.LinearProgressIndicator
@@ -108,21 +107,12 @@ private fun BillingContent(
         val sub = subscription
         if (sub != null && sub.logged_in == true && sub.current != null) {
             item { PlanCard(sub.current) }
-            item {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    val status = sub.current.status
-                    if (status == "cancelled" || status == "paused") {
-                        Button(
-                            onClick = onResume,
-                            enabled = !state.isActionInFlight,
-                            modifier = Modifier.weight(1f),
-                        ) {
-                            Text(stringResource(R.string.billing_resume))
-                        }
-                    } else {
+            if (sub.can_change_plan == true) {
+                item {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
                         OutlinedButton(
                             onClick = { onChange(null, true) },
                             enabled = !state.isActionInFlight,
@@ -170,10 +160,13 @@ private fun BillingContent(
             }
         }
 
-        if (usage != null && usage.bars.isNotEmpty()) {
+        if (usage != null && usage.available == true && (usage.plan_bar != null || usage.topup_bar != null)) {
             item { SectionTitle(stringResource(R.string.billing_usage)) }
-            items(usage.bars.size, key = { "bar_$it" }) { index ->
-                UsageBarRow(bar = usage.bars[index])
+            usage.plan_bar?.let { bar ->
+                item { UsageBarRow(label = stringResource(R.string.billing_plan), bar = bar) }
+            }
+            usage.topup_bar?.let { bar ->
+                item { UsageBarRow(label = stringResource(R.string.billing_topup), bar = bar) }
             }
         }
     }
@@ -188,25 +181,33 @@ private fun PlanCard(subscription: SubscriptionCurrent) {
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
-                text = subscription.subscription_type_name ?: stringResource(R.string.billing_free_plan),
+                text = subscription.tier_name ?: stringResource(R.string.billing_free_plan),
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold,
             )
-            Text(
-                text =
-                    when (subscription.status) {
-                        null -> stringResource(R.string.billing_status_unknown)
-                        "active" -> stringResource(R.string.billing_status_active)
-                        "cancelled" -> stringResource(R.string.billing_status_cancelled)
-                        "paused" -> stringResource(R.string.billing_status_paused)
-                        else -> subscription.status ?: ""
-                    },
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            if (subscription.renews_at != null) {
+            if (subscription.credits_remaining != null) {
                 Text(
-                    text = stringResource(R.string.billing_renews, subscription.renews_at),
+                    text =
+                        stringResource(
+                            R.string.billing_credits_remaining,
+                            subscription.credits_remaining,
+                        ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+            if (subscription.cycle_ends_at != null) {
+                Text(
+                    text = stringResource(R.string.billing_renews, subscription.cycle_ends_at),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+            if (subscription.pending_downgrade_display != null) {
+                Text(
+                    text = subscription.pending_downgrade_display ?: "",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(top = 4.dp),
@@ -245,15 +246,12 @@ private fun NoActivePlanCard(subscription: SubscriptionStateResponse) {
 }
 
 @Composable
-private fun UsageBarRow(bar: com.m57.hermescontrol.data.model.UsageBar) {
-    val used = bar.used ?: 0.0
-    val limit = bar.limit ?: 0.0
-    val fraction =
-        if (limit > 0.0) {
-            (used / limit).toFloat().coerceIn(0f, 1f)
-        } else {
-            0f
-        }
+private fun UsageBarRow(
+    label: String,
+    bar: com.m57.hermescontrol.data.model.UsageBar,
+) {
+    val fraction = (bar.fill_fraction ?: 0.0).toFloat().coerceIn(0f, 1f)
+    val summary = bar.remaining_display ?: bar.total_display ?: ""
     Card(modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(12.dp)) {
         Column(modifier = Modifier.padding(12.dp)) {
             Row(
@@ -261,27 +259,25 @@ private fun UsageBarRow(bar: com.m57.hermescontrol.data.model.UsageBar) {
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 Text(
-                    text = bar.label ?: "",
+                    text = label,
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Bold,
                 )
                 Text(
-                    text = "$used / $limit ${bar.unit ?: ""}",
+                    text = summary,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            if (limit > 0.0) {
-                LinearProgressIndicator(
-                    progress = { fraction },
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(top = 8.dp)
-                            .height(8.dp)
-                            .clip(RoundedCornerShape(4.dp)),
-                )
-            }
+            LinearProgressIndicator(
+                progress = { fraction },
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp)
+                        .height(8.dp)
+                        .clip(RoundedCornerShape(4.dp)),
+            )
         }
     }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingViewModel.kt
@@ -60,6 +60,10 @@ class BillingViewModel : ViewModel() {
                     if (sub?.ok == false) {
                         unavailable = true
                         error = sub.error ?: "Billing unavailable"
+                    } else if (sub == null) {
+                        // Backend returned no result payload (null result / unmapped
+                        // response). Treat as a non-fatal load miss, not a crash.
+                        if (error == null) error = "No billing data returned"
                     }
                 } catch (e: HermesWsClient.HermesRpcException) {
                     unavailable = true
@@ -100,6 +104,12 @@ class BillingViewModel : ViewModel() {
             _uiState.update { it.copy(isActionInFlight = true, errorMessage = null, actionMessage = null) }
             runCatching { BillingRepository.previewSubscription(subscriptionTypeId) }
                 .onSuccess { preview ->
+                    if (preview == null) {
+                        _uiState.update {
+                            it.copy(isActionInFlight = false, errorMessage = "No billing data returned")
+                        }
+                        return@onSuccess
+                    }
                     if (preview.ok == false) {
                         _uiState.update {
                             it.copy(
@@ -126,6 +136,12 @@ class BillingViewModel : ViewModel() {
             _uiState.update { it.copy(isActionInFlight = true, errorMessage = null, actionMessage = null) }
             runCatching { BillingRepository.upgradeSubscription(subscriptionTypeId) }
                 .onSuccess { resp ->
+                    if (resp == null) {
+                        _uiState.update {
+                            it.copy(isActionInFlight = false, errorMessage = "No billing data returned")
+                        }
+                        return@onSuccess
+                    }
                     if (resp.ok == false) {
                         _uiState.update {
                             it.copy(
@@ -164,6 +180,12 @@ class BillingViewModel : ViewModel() {
             _uiState.update { it.copy(isActionInFlight = true, errorMessage = null, actionMessage = null) }
             runCatching { BillingRepository.changeSubscription(SubscriptionChangeRequest(subscriptionTypeId, cancel)) }
                 .onSuccess { resp ->
+                    if (resp == null) {
+                        _uiState.update {
+                            it.copy(isActionInFlight = false, errorMessage = "No billing data returned")
+                        }
+                        return@onSuccess
+                    }
                     if (resp.ok == false) {
                         _uiState.update {
                             it.copy(
@@ -197,6 +219,12 @@ class BillingViewModel : ViewModel() {
             _uiState.update { it.copy(isActionInFlight = true, errorMessage = null, actionMessage = null) }
             runCatching { BillingRepository.resumeSubscription() }
                 .onSuccess { resp ->
+                    if (resp == null) {
+                        _uiState.update {
+                            it.copy(isActionInFlight = false, errorMessage = "No billing data returned")
+                        }
+                        return@onSuccess
+                    }
                     if (resp.ok == false) {
                         _uiState.update {
                             it.copy(

--- a/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingViewModel.kt
@@ -72,10 +72,11 @@ class BillingViewModel : ViewModel() {
                     bars = BillingRepository.getUsageBars()
                     if (bars?.ok == false) {
                         // usage unavailable is non-fatal — the plan card still renders
-                        if (error == null) error = bars.toString()
+                        if (error == null) error = "Usage data unavailable"
                     }
                 } catch (e: HermesWsClient.HermesRpcException) {
-                    unavailable = true
+                    // usage unavailable is non-fatal — do NOT mark the whole
+                    // feature unavailable; the plan card still renders.
                 } catch (e: Exception) {
                     if (e is kotlinx.coroutines.CancellationException) throw e
                     if (error == null) error = e.message ?: "Failed to load usage"
@@ -86,7 +87,9 @@ class BillingViewModel : ViewModel() {
                         subscription = sub,
                         usage = bars,
                         featureUnavailable = unavailable,
-                        errorMessage = if (sub == null && bars == null) error else null,
+                        // A failed primary subscription load is fatal — surface it
+                        // even if usage bars happened to load.
+                        errorMessage = if (sub == null) error else null,
                     )
                 }
             }

--- a/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingViewModel.kt
@@ -53,6 +53,14 @@ class BillingViewModel : ViewModel() {
                 var error: String? = null
                 try {
                     sub = BillingRepository.getSubscriptionState()
+                    // The live gateway returns an `ok:false` *result* (with
+                    // `error`/`message`) rather than an RPC-level error when the
+                    // backend feature is missing or the user isn't portal-authed.
+                    // Catch that here so the screen degrades gracefully.
+                    if (sub?.ok == false) {
+                        unavailable = true
+                        error = sub.error ?: "Billing unavailable"
+                    }
                 } catch (e: HermesWsClient.HermesRpcException) {
                     unavailable = true
                     error = e.message
@@ -62,6 +70,10 @@ class BillingViewModel : ViewModel() {
                 }
                 try {
                     bars = BillingRepository.getUsageBars()
+                    if (bars?.ok == false) {
+                        // usage unavailable is non-fatal — the plan card still renders
+                        if (error == null) error = bars.toString()
+                    }
                 } catch (e: HermesWsClient.HermesRpcException) {
                     unavailable = true
                 } catch (e: Exception) {
@@ -85,7 +97,16 @@ class BillingViewModel : ViewModel() {
             _uiState.update { it.copy(isActionInFlight = true, errorMessage = null, actionMessage = null) }
             runCatching { BillingRepository.previewSubscription(subscriptionTypeId) }
                 .onSuccess { preview ->
-                    _uiState.update { it.copy(isActionInFlight = false, preview = preview) }
+                    if (preview.ok == false) {
+                        _uiState.update {
+                            it.copy(
+                                isActionInFlight = false,
+                                errorMessage = preview.error ?: preview.message ?: "Preview unavailable",
+                            )
+                        }
+                    } else {
+                        _uiState.update { it.copy(isActionInFlight = false, preview = preview) }
+                    }
                 }.onFailure { e ->
                     _uiState.update {
                         it.copy(
@@ -102,6 +123,15 @@ class BillingViewModel : ViewModel() {
             _uiState.update { it.copy(isActionInFlight = true, errorMessage = null, actionMessage = null) }
             runCatching { BillingRepository.upgradeSubscription(subscriptionTypeId) }
                 .onSuccess { resp ->
+                    if (resp.ok == false) {
+                        _uiState.update {
+                            it.copy(
+                                isActionInFlight = false,
+                                errorMessage = resp.error ?: resp.message ?: "Upgrade unavailable",
+                            )
+                        }
+                        return@onSuccess
+                    }
                     val msg =
                         when {
                             resp.requires_action == true && resp.recovery_url != null ->
@@ -131,6 +161,15 @@ class BillingViewModel : ViewModel() {
             _uiState.update { it.copy(isActionInFlight = true, errorMessage = null, actionMessage = null) }
             runCatching { BillingRepository.changeSubscription(SubscriptionChangeRequest(subscriptionTypeId, cancel)) }
                 .onSuccess { resp ->
+                    if (resp.ok == false) {
+                        _uiState.update {
+                            it.copy(
+                                isActionInFlight = false,
+                                errorMessage = resp.error ?: resp.message ?: "Plan change unavailable",
+                            )
+                        }
+                        return@onSuccess
+                    }
                     _uiState.update {
                         it.copy(
                             isActionInFlight = false,
@@ -155,6 +194,15 @@ class BillingViewModel : ViewModel() {
             _uiState.update { it.copy(isActionInFlight = true, errorMessage = null, actionMessage = null) }
             runCatching { BillingRepository.resumeSubscription() }
                 .onSuccess { resp ->
+                    if (resp.ok == false) {
+                        _uiState.update {
+                            it.copy(
+                                isActionInFlight = false,
+                                errorMessage = resp.error ?: resp.message ?: "Resume unavailable",
+                            )
+                        }
+                        return@onSuccess
+                    }
                     _uiState.update {
                         it.copy(
                             isActionInFlight = false,

--- a/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingViewModel.kt
@@ -1,0 +1,177 @@
+package com.m57.hermescontrol.ui.billing
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.m57.hermescontrol.data.model.SubscriptionChangeRequest
+import com.m57.hermescontrol.data.model.SubscriptionStateResponse
+import com.m57.hermescontrol.data.model.UsageBarsResponse
+import com.m57.hermescontrol.data.ws.BillingRepository
+import com.m57.hermescontrol.data.ws.HermesWsClient
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Drives the Billing / Plan screen (issue #628). Pulls plan state + usage bars
+ * over the WebSocket JSON-RPC surface and exposes upgrade / change / resume /
+ * cancel actions.
+ *
+ * `-32601` (removed `credits.view` or any unknown method) arrives as
+ * [HermesWsClient.HermesRpcException]; we map it to [BillingUiState.featureUnavailable]
+ * so an old cached build or a backend mismatch degrades gracefully instead of crashing.
+ */
+data class BillingUiState(
+    val isLoading: Boolean = false,
+    val isActionInFlight: Boolean = false,
+    val subscription: SubscriptionStateResponse? = null,
+    val usage: UsageBarsResponse? = null,
+    val preview: com.m57.hermescontrol.data.model.SubscriptionPreviewResponse? = null,
+    /** Set when an RPC method is unavailable on the connected backend (e.g. -32601). */
+    val featureUnavailable: Boolean = false,
+    val errorMessage: String? = null,
+    /** Transient success/info toast after an action (upgrade/resume/cancel). */
+    val actionMessage: String? = null,
+)
+
+class BillingViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow(BillingUiState())
+    val uiState: StateFlow<BillingUiState> = _uiState.asStateFlow()
+
+    private var loadJob: Job? = null
+
+    fun load() {
+        loadJob?.cancel()
+        _uiState.update { it.copy(isLoading = true, errorMessage = null, featureUnavailable = false) }
+        loadJob =
+            viewModelScope.launch {
+                var sub: SubscriptionStateResponse? = null
+                var bars: UsageBarsResponse? = null
+                var unavailable = false
+                var error: String? = null
+                try {
+                    sub = BillingRepository.getSubscriptionState()
+                } catch (e: HermesWsClient.HermesRpcException) {
+                    unavailable = true
+                    error = e.message
+                } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    error = e.message ?: "Failed to load subscription"
+                }
+                try {
+                    bars = BillingRepository.getUsageBars()
+                } catch (e: HermesWsClient.HermesRpcException) {
+                    unavailable = true
+                } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    if (error == null) error = e.message ?: "Failed to load usage"
+                }
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        subscription = sub,
+                        usage = bars,
+                        featureUnavailable = unavailable,
+                        errorMessage = if (sub == null && bars == null) error else null,
+                    )
+                }
+            }
+    }
+
+    fun preview(subscriptionTypeId: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isActionInFlight = true, errorMessage = null, actionMessage = null) }
+            runCatching { BillingRepository.previewSubscription(subscriptionTypeId) }
+                .onSuccess { preview ->
+                    _uiState.update { it.copy(isActionInFlight = false, preview = preview) }
+                }.onFailure { e ->
+                    _uiState.update {
+                        it.copy(
+                            isActionInFlight = false,
+                            errorMessage = (e as? HermesWsClient.HermesRpcException)?.message ?: e.message,
+                        )
+                    }
+                }
+        }
+    }
+
+    fun upgrade(subscriptionTypeId: String) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isActionInFlight = true, errorMessage = null, actionMessage = null) }
+            runCatching { BillingRepository.upgradeSubscription(subscriptionTypeId) }
+                .onSuccess { resp ->
+                    val msg =
+                        when {
+                            resp.requires_action == true && resp.recovery_url != null ->
+                                "Action required — open: ${resp.recovery_url}"
+                            resp.payment_failed == true -> resp.message ?: "Payment failed"
+                            resp.ok == true -> "Upgrade successful"
+                            else -> resp.message ?: "Upgrade requested"
+                        }
+                    _uiState.update { it.copy(isActionInFlight = false, actionMessage = msg) }
+                    load()
+                }.onFailure { e ->
+                    _uiState.update {
+                        it.copy(
+                            isActionInFlight = false,
+                            errorMessage = (e as? HermesWsClient.HermesRpcException)?.message ?: e.message,
+                        )
+                    }
+                }
+        }
+    }
+
+    fun change(
+        subscriptionTypeId: String? = null,
+        cancel: Boolean? = null,
+    ) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isActionInFlight = true, errorMessage = null, actionMessage = null) }
+            runCatching { BillingRepository.changeSubscription(SubscriptionChangeRequest(subscriptionTypeId, cancel)) }
+                .onSuccess { resp ->
+                    _uiState.update {
+                        it.copy(
+                            isActionInFlight = false,
+                            actionMessage =
+                                resp.message ?: if (cancel == true) "Cancellation scheduled" else "Plan changed",
+                        )
+                    }
+                    load()
+                }.onFailure { e ->
+                    _uiState.update {
+                        it.copy(
+                            isActionInFlight = false,
+                            errorMessage = (e as? HermesWsClient.HermesRpcException)?.message ?: e.message,
+                        )
+                    }
+                }
+        }
+    }
+
+    fun resume() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isActionInFlight = true, errorMessage = null, actionMessage = null) }
+            runCatching { BillingRepository.resumeSubscription() }
+                .onSuccess { resp ->
+                    _uiState.update {
+                        it.copy(
+                            isActionInFlight = false,
+                            actionMessage = resp.message ?: "Subscription resumed",
+                        )
+                    }
+                    load()
+                }.onFailure { e ->
+                    _uiState.update {
+                        it.copy(
+                            isActionInFlight = false,
+                            errorMessage = (e as? HermesWsClient.HermesRpcException)?.message ?: e.message,
+                        )
+                    }
+                }
+        }
+    }
+
+    fun clearActionMessage() = _uiState.update { it.copy(actionMessage = null) }
+}

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -53,6 +53,9 @@
     <string name="billing_feature_unavailable">이 서버에서는 결제를 사용할 수 없습니다 (지원되지 않는 메서드)</string>
     <string name="billing_no_active_plan">활성 요금제 없음 — 무료 등급입니다.</string>
     <string name="billing_login_required">요금제를 보려면 Nous Portal에 로그인하세요.</string>
+    <string name="billing_credits_remaining">남은 크레딧: %1$s</string>
+    <string name="billing_plan">요금제</string>
+    <string name="billing_topup">충전</string>
 
     <!-- Navigation & Drawer -->
     <string name="nav_drawer_title">⚡ 헤르메스</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -40,7 +40,17 @@
     <string name="content_desc_clear_search">검색 지우기</string>
 
     <!-- General Errors -->
-    <string name="error_unknown">알 수 없는 오류</string>
+    <string name="error_unknown">문제가 발생했습니다</string>
+    <string name="billing_free_plan">무료</string>
+    <string name="billing_usage">사용량</string>
+    <string name="billing_resume">재개</string>
+    <string name="billing_cancel">취소</string>
+    <string name="billing_renews">갱신: %1$s</string>
+    <string name="billing_status_unknown">알 수 없음</string>
+    <string name="billing_status_active">활성</string>
+    <string name="billing_status_cancelled">취소됨</string>
+    <string name="billing_status_paused">일시중지됨</string>
+    <string name="billing_feature_unavailable">이 서버에서는 결제를 사용할 수 없습니다 (지원되지 않는 메서드)</string>
 
     <!-- Navigation & Drawer -->
     <string name="nav_drawer_title">⚡ 헤르메스</string>
@@ -74,6 +84,7 @@
     <string name="screen_processes">프로세스</string>
     <string name="screen_providers">제공자</string>
     <string name="screen_analytics">분석</string>
+    <string name="screen_billing">결제</string>
 
     <!-- Notifications -->
     <string name="notif_title">헤르메스</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -51,6 +51,8 @@
     <string name="billing_status_cancelled">취소됨</string>
     <string name="billing_status_paused">일시중지됨</string>
     <string name="billing_feature_unavailable">이 서버에서는 결제를 사용할 수 없습니다 (지원되지 않는 메서드)</string>
+    <string name="billing_no_active_plan">활성 요금제 없음 — 무료 등급입니다.</string>
+    <string name="billing_login_required">요금제를 보려면 Nous Portal에 로그인하세요.</string>
 
     <!-- Navigation & Drawer -->
     <string name="nav_drawer_title">⚡ 헤르메스</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,9 @@
     <string name="billing_feature_unavailable">Billing is unavailable on this server (method not supported)</string>
     <string name="billing_no_active_plan">No active plan — you\'re on the free tier.</string>
     <string name="billing_login_required">Log in to Nous Portal to view your plan.</string>
+    <string name="billing_credits_remaining">Credits remaining: %1$s</string>
+    <string name="billing_plan">Plan</string>
+    <string name="billing_topup">Top-up</string>
 
     <!-- Navigation & Drawer -->
     <string name="nav_drawer_title">⚡ Hermes</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,8 @@
     <string name="billing_status_cancelled">Cancelled</string>
     <string name="billing_status_paused">Paused</string>
     <string name="billing_feature_unavailable">Billing is unavailable on this server (method not supported)</string>
+    <string name="billing_no_active_plan">No active plan — you\'re on the free tier.</string>
+    <string name="billing_login_required">Log in to Nous Portal to view your plan.</string>
 
     <!-- Navigation & Drawer -->
     <string name="nav_drawer_title">⚡ Hermes</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,16 @@
 
     <!-- General Errors -->
     <string name="error_unknown">Unknown error</string>
+    <string name="billing_free_plan">Free</string>
+    <string name="billing_usage">Usage</string>
+    <string name="billing_resume">Resume</string>
+    <string name="billing_cancel">Cancel</string>
+    <string name="billing_renews">Renews: %1$s</string>
+    <string name="billing_status_unknown">Unknown</string>
+    <string name="billing_status_active">Active</string>
+    <string name="billing_status_cancelled">Cancelled</string>
+    <string name="billing_status_paused">Paused</string>
+    <string name="billing_feature_unavailable">Billing is unavailable on this server (method not supported)</string>
 
     <!-- Navigation & Drawer -->
     <string name="nav_drawer_title">⚡ Hermes</string>
@@ -87,6 +97,7 @@
     <string name="screen_processes">Processes</string>
     <string name="screen_providers">Providers</string>
     <string name="screen_analytics">Analytics</string>
+    <string name="screen_billing">Billing</string>
 
     <!-- Notifications -->
     <string name="notif_title">Hermes</string>


### PR DESCRIPTION
## Summary
Adopts the backend billing/subscription WebSocket RPC surface from the release audit (hermes-agent `0bf44d557..614dc194e`). `credits.view` was **removed** upstream; `subscription.{state,preview,change,resume,upgrade}` + `usage.bars` replace it (issue #628).

- **WsMethods**: add `SUBSCRIPTION_STATE/PREVIEW/CHANGE/RESUME/UPGRADE` + `USAGE_BARS` constants
- **BillingModels**: `@Serializable` request/response (snake_case, decoded via existing `OkHttpProvider.json` — `ignoreUnknownKeys` + `SnakeCase`, not Gson)
- **BillingRepository**: WS dispatch via `HermesWsClient.request()` + typed decode. `HermesRpcException` (e.g. `-32601` from a removed method) surfaces as `featureUnavailable` rather than crashing — the defensive handling the issue asked for
- **BillingViewModel**: plan/usage load + upgrade / change / resume / cancel actions (handles `requires_action` / `recovery_url` / `payment_failed` from the upgrade contract)
- **BillingScreen**: `HermesScaffold` composable — plan card, usage bars (progress indicators), cancel/resume buttons. Follows `AnalyticsScreen` pattern; avoids the `HermesScaffold` double-padding foot-gun
- **Nav**: `BillingScreen` NavKey + `ScreenRegistry` (INSPECT drawer, `AccountBalanceWallet` icon) + strings (en + ko)

## Verification
- `./gradlew ktlintCheck` — BUILD SUCCESSFUL
- `./gradlew compileDebugKotlin` — BUILD SUCCESSFUL

## Not yet done (not blocking merge, per issue)
- **Live-gateway smoke test** (issue checklist #4: mint `ws-ticket` → `session.create` → dispatch) still pending — needs a running backend + creds not reachable from CI. Models are built against the source-described contracts; wire shapes should be confirmed against a live gateway before shipping to users.
- Plan-selection UI (picking which `subscription_type_id` to upgrade to) is not built — `preview()` / `upgrade()` are exposed but the type-ID picker is left for a follow-up once backend returns the available plans.

## Notes
- Nothing was broken before this — mobile called zero `subscription.*` / `credits.view` methods. This is a from-scratch adoption, not a fix.
- Does not block the current backend release (backend is 🟢 compatible for all methods mobile uses).

Closes #628