### PR TITLE
security: disable Android Auto Backup (issue #636)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
 
     <application
         android:name=".HermesControlApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
## Summary

Closes #636.

Sets `android:allowBackup="false"` in `AndroidManifest.xml`. This stops Android's Auto Backup for Apps from periodically snapshotting the entire `/data/data/com.m57.hermescontrol/` directory and uploading it to the user's Google Drive — which currently includes:

- `server_store.json` — connection profiles, base URLs, WS auth param
- SQLCipher-encrypted Room DB (chat history) + any key material on disk
- `EncryptedSharedPreferences` (`hermes_secure_prefs`) — tokens, cookies
- `PersistentCookieJar` cookie store — session cookies

This removes a credential + chat-history exfiltration surface via Google account compromise / lawful request / phishing.

## Trade-off

Wiping/reinstalling the phone loses saved connection profiles + chat history. Acceptable for a control-surface app (profiles are cheap to re-enter; chat history isn't the point).

## Verification

- Single one-line manifest change; no code-behavior change in normal use.
- Verified no debug/flavor manifest or `fullBackupContent`/`dataExtractionRules` re-enables backup.

## Acceptance criteria

- [x] `AndroidManifest.xml` has `android:allowBackup="false"`
- [x] No behavior change in normal app use
- [ ] ktlint + Android Lint + CI green