### PR TITLE
feat(chat): rich message bubbles with reasoning, code, clarify, subagent cards (#659 #660 #661 #662 #663 #664)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/theme/Color.kt
+++ b/app/src/main/java/com/m57/hermescontrol/theme/Color.kt
@@ -87,3 +87,11 @@ val SkeletonBase = Color(0xFF1C1C26)
 val SkeletonHighlight = Color(0xFF2F2F3D)
 val SkeletonBaseLight = Color(0xFFE6E3EE)
 val SkeletonHighlightLight = Color(0xFFEFEDF4)
+
+// ── Syntax highlighting tokens (code blocks — VS Code Dark+ palette) ───────
+
+val CodeKeyword = Color(0xFF569CD6)    // blue — for val, fun, class, etc.
+val CodeString = Color(0xFFCE9178)     // orange — for "string literals"
+val CodeComment = Color(0xFF6A9955)    // green — for // comments
+val CodeNumber = Color(0xFFB5CEA8)     // light green — for 42, 0xFF
+val CodePunctuation = Color(0xFFD4D4D4) // gray — for {, (, ;, etc.

--- a/app/src/main/java/com/m57/hermescontrol/theme/Color.kt
+++ b/app/src/main/java/com/m57/hermescontrol/theme/Color.kt
@@ -90,8 +90,8 @@ val SkeletonHighlightLight = Color(0xFFEFEDF4)
 
 // ── Syntax highlighting tokens (code blocks — VS Code Dark+ palette) ───────
 
-val CodeKeyword = Color(0xFF569CD6)    // blue — for val, fun, class, etc.
-val CodeString = Color(0xFFCE9178)     // orange — for "string literals"
-val CodeComment = Color(0xFF6A9955)    // green — for // comments
-val CodeNumber = Color(0xFFB5CEA8)     // light green — for 42, 0xFF
+val CodeKeyword = Color(0xFF569CD6) // blue — for val, fun, class, etc.
+val CodeString = Color(0xFFCE9178) // orange — for "string literals"
+val CodeComment = Color(0xFF6A9955) // green — for // comments
+val CodeNumber = Color(0xFFB5CEA8) // light green — for 42, 0xFF
 val CodePunctuation = Color(0xFFD4D4D4) // gray — for {, (, ;, etc.

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatBubble.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatBubble.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
@@ -293,7 +294,7 @@ private fun UserBubble(
                         .offset(x = 8.dp, y = (-8).dp),
             ) {
                 Surface(
-                    shape = RoundedCornerShape(50),
+                    shape = CircleShape,
                     color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f),
                     shadowElevation = 6.dp,
                 ) {
@@ -393,9 +394,17 @@ private fun AssistantBubble(
                 Column(modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)) {
                     // Reasoning card — shown before content when reasoning is present
                     if (message.reasoningText.isNotBlank()) {
+                        val stepCount =
+                            remember(message.reasoningText) {
+                                if (message.reasoningText.isBlank()) {
+                                    0
+                                } else {
+                                    message.reasoningText.split("\n\n").size
+                                }
+                            }
                         ReasoningCard(
                             reasoningText = message.reasoningText,
-                            stepCount = message.reasoningText.split("\n\n").size,
+                            stepCount = stepCount,
                             isStreaming = message.isStreaming,
                             modifier = Modifier.padding(bottom = 6.dp),
                         )
@@ -434,7 +443,7 @@ private fun AssistantBubble(
                         .offset(x = (-8).dp, y = (-8).dp),
             ) {
                 Surface(
-                    shape = RoundedCornerShape(50),
+                    shape = CircleShape,
                     color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f),
                     shadowElevation = 6.dp,
                 ) {
@@ -2203,7 +2212,7 @@ private fun CopyButton(
         modifier = modifier,
     ) {
         Surface(
-            shape = RoundedCornerShape(50),
+            shape = CircleShape,
             color = MaterialTheme.colorScheme.surface.copy(alpha = 0.95f),
             shadowElevation = 6.dp,
         ) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatBubble.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatBubble.kt
@@ -93,6 +93,7 @@ import com.m57.hermescontrol.theme.ToolChipColor
 import com.m57.hermescontrol.theme.ToolChipColorLight
 import com.m57.hermescontrol.theme.UserBubble
 import com.m57.hermescontrol.theme.onColorFor
+import com.m57.hermescontrol.ui.chat.components.ReasoningCard
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonArray
@@ -390,6 +391,15 @@ private fun AssistantBubble(
                 tonalElevation = 1.dp,
             ) {
                 Column(modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)) {
+                    // Reasoning card — shown before content when reasoning is present
+                    if (message.reasoningText.isNotBlank()) {
+                        ReasoningCard(
+                            reasoningText = message.reasoningText,
+                            stepCount = message.reasoningText.split("\n\n").size,
+                            isStreaming = message.isStreaming,
+                            modifier = Modifier.padding(bottom = 6.dp),
+                        )
+                    }
                     SelectionContainer {
                         MarkdownText(
                             text = message.content,

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -438,6 +438,7 @@ fun ChatScreen(
                     onLastAnimatedMessageIdChange = { lastAnimatedMessageId = it },
                     viewModel = viewModel,
                     subagentIndicators = state.subagentIndicators,
+                    clarifyRequest = state.clarifyRequest,
                 )
 
                 // Loading overlay

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -422,8 +422,6 @@ fun ChatScreen(
                 ChatMessageList(
                     messages = state.messages,
                     streamingMessage = streamingState.streamingMessage,
-                    isThinking = streamingState.isThinking,
-                    thinkingText = streamingState.thinkingText,
                     isSearchActive = state.isSearchActive,
                     searchQuery = state.searchQuery,
                     currentSearchMatchIndex = state.currentSearchMatchIndex,

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/MarkdownText.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/MarkdownText.kt
@@ -1,10 +1,7 @@
 package com.m57.hermescontrol.ui.chat
 
-import android.content.ClipData
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -19,30 +16,20 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.outlined.CheckBox
 import androidx.compose.material.icons.outlined.CheckBoxOutlineBlank
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.ClipEntry
-import androidx.compose.ui.platform.LocalClipboard
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
@@ -56,12 +43,10 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.m57.hermescontrol.R
 import com.m57.hermescontrol.theme.LocalHermesStatusColors
 import com.m57.hermescontrol.theme.SearchHighlightColors
 import com.m57.hermescontrol.theme.searchHighlightColors
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
+import com.m57.hermescontrol.ui.chat.components.CodeBlockCard
 
 private val URL_PATTERN = Regex("""https?://[^\s)>\[\]"'‘’]+""")
 private val TABLE_COL_WIDTH = 160.dp
@@ -105,7 +90,10 @@ fun MarkdownText(
         for (block in blocks) {
             when (block) {
                 is MdBlock.Code -> {
-                    CodeBlockCard(code = block.code, textColor = textColor)
+                    CodeBlockCard(
+                        code = block.code,
+                        language = block.language,
+                    )
                 }
 
                 is MdBlock.Hr -> {
@@ -354,73 +342,6 @@ fun MarkdownText(
     }
 }
 
-/**
- * Fenced code block rendered as a card: monospaced text with horizontal scroll and a copy button.
- */
-@Composable
-private fun CodeBlockCard(
-    code: String,
-    textColor: Color,
-) {
-    val clipboard = LocalClipboard.current
-    val scope = rememberCoroutineScope()
-    var copied by remember { mutableStateOf(false) }
-
-    // Auto-dismiss the "copied" checkmark after 2s
-    LaunchedEffect(copied) {
-        if (copied) {
-            delay(2000)
-            copied = false
-        }
-    }
-
-    Surface(
-        shape = RoundedCornerShape(8.dp),
-        color = textColor.copy(alpha = 0.06f),
-        border = BorderStroke(1.dp, textColor.copy(alpha = 0.15f)),
-        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-    ) {
-        Column {
-            Row(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 8.dp, vertical = 2.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.End,
-            ) {
-                IconButton(
-                    onClick = {
-                        scope.launch {
-                            clipboard.setClipEntry(ClipEntry(ClipData.newPlainText(null, code)))
-                        }
-                        copied = true
-                    },
-                    modifier = Modifier.size(28.dp),
-                ) {
-                    Icon(
-                        imageVector = if (copied) Icons.Filled.Check else Icons.Filled.ContentCopy,
-                        contentDescription = stringResource(R.string.content_desc_copy),
-                        modifier = Modifier.size(15.dp),
-                        tint = textColor.copy(alpha = 0.7f),
-                    )
-                }
-            }
-            Text(
-                text = code,
-                fontFamily = FontFamily.Monospace,
-                fontSize = 13.sp,
-                color = textColor,
-                softWrap = false,
-                modifier =
-                    Modifier
-                        .horizontalScroll(rememberScrollState())
-                        .padding(horizontal = 10.dp, vertical = 6.dp),
-            )
-        }
-    }
-}
-
 @Composable
 private fun MarkdownTable(
     block: MdBlock.Table,
@@ -506,11 +427,12 @@ internal fun parseBlocks(src: String): List<MdBlock> {
         when {
             line.startsWith("```") -> {
                 val end = (i + 1 until lines.size).firstOrNull { lines[it].startsWith("```") }
+                val lang = line.drop(3).trim().ifBlank { null }
                 if (end != null) {
-                    blocks.add(MdBlock.Code(lines.subList(i + 1, end).joinToString("\n")))
+                    blocks.add(MdBlock.Code(lines.subList(i + 1, end).joinToString("\n"), lang))
                     i = end + 1
                 } else {
-                    blocks.add(MdBlock.Code(lines.subList(i + 1, lines.size).joinToString("\n")))
+                    blocks.add(MdBlock.Code(lines.subList(i + 1, lines.size).joinToString("\n"), lang))
                     i = lines.size
                 }
             }
@@ -953,6 +875,7 @@ internal fun parseInline(
 internal sealed interface MdBlock {
     data class Code(
         val code: String,
+        val language: String? = null,
     ) : MdBlock
 
     data class Heading(

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatIndicators.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatIndicators.kt
@@ -1,6 +1,5 @@
 package com.m57.hermescontrol.ui.chat.components
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
@@ -9,37 +8,25 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ExpandLess
-import androidx.compose.material.icons.filled.ExpandMore
-import androidx.compose.material.icons.outlined.Psychology
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -104,66 +91,6 @@ fun ThinkingIndicator(thinkingText: String) {
                         ),
                     maxLines = 2,
                     modifier = Modifier.animateContentSize(),
-                )
-            }
-        }
-    }
-}
-
-/**
- * Collapsible card showing the assistant's reasoning trace
- * (reasoning-model thinking steps) before the final answer.
- */
-@Composable
-fun ReasoningIndicator(reasoningText: String) {
-    var expanded by remember { mutableStateOf(false) }
-    val statusColors = LocalHermesStatusColors.current
-    Card(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 4.dp)
-                .clickable(
-                    role = Role.Button,
-                    onClick = { expanded = !expanded },
-                ),
-        colors =
-            CardDefaults.cardColors(
-                containerColor = statusColors.infoContainer.copy(alpha = 0.5f),
-            ),
-        shape = RoundedCornerShape(12.dp),
-    ) {
-        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Outlined.Psychology,
-                    contentDescription = stringResource(R.string.chat_reasoning),
-                    tint = statusColors.info,
-                    modifier = Modifier.size(18.dp),
-                )
-                Spacer(Modifier.width(8.dp))
-                Text(
-                    text = stringResource(R.string.chat_reasoning),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = statusColors.info,
-                )
-                Spacer(Modifier.weight(1f))
-                Icon(
-                    imageVector = if (expanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
-                    contentDescription =
-                        stringResource(
-                            if (expanded) R.string.chat_reasoning_collapse else R.string.chat_reasoning_expand,
-                        ),
-                    tint = statusColors.info,
-                    modifier = Modifier.size(18.dp),
-                )
-            }
-            AnimatedVisibility(visible = expanded) {
-                Text(
-                    text = reasoningText,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = statusColors.info,
-                    modifier = Modifier.padding(top = 4.dp),
                 )
             }
         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatMessageList.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatMessageList.kt
@@ -36,8 +36,6 @@ import com.m57.hermescontrol.ui.common.EmptyState
 fun ChatMessageList(
     messages: List<ChatMessage>,
     streamingMessage: ChatMessage?,
-    isThinking: Boolean,
-    thinkingText: String,
     isSearchActive: Boolean,
     searchQuery: String,
     currentSearchMatchIndex: Int,
@@ -144,13 +142,6 @@ fun ChatMessageList(
                         onOptionSelected = viewModel::respondToClarify,
                         onDismiss = viewModel::dismissClarify,
                     )
-                }
-            }
-
-            // Thinking indicator
-            if (isThinking) {
-                item(key = "thinking") {
-                    ThinkingIndicator(thinkingText)
                 }
             }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatMessageList.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatMessageList.kt
@@ -19,6 +19,7 @@ import com.m57.hermescontrol.R
 import com.m57.hermescontrol.ui.chat.ChatBubble
 import com.m57.hermescontrol.ui.chat.ChatMessage
 import com.m57.hermescontrol.ui.chat.ChatViewModel
+import com.m57.hermescontrol.ui.chat.ClarifyUi
 import com.m57.hermescontrol.ui.chat.MessageRole
 import com.m57.hermescontrol.ui.chat.SubagentIndicator
 import com.m57.hermescontrol.ui.common.EmptyState
@@ -51,6 +52,7 @@ fun ChatMessageList(
     onLastAnimatedMessageIdChange: (String?) -> Unit,
     viewModel: ChatViewModel,
     subagentIndicators: List<SubagentIndicator> = emptyList(),
+    clarifyRequest: ClarifyUi? = null,
 ) {
     if (messages.isEmpty() && !isLoading) {
         Box(
@@ -140,6 +142,18 @@ fun ChatMessageList(
                 }
             }
 
+            // Clarify request as inline bubble
+            if (clarifyRequest != null) {
+                item(key = "clarify") {
+                    ClarifyBubble(
+                        text = clarifyRequest.text,
+                        options = clarifyRequest.options,
+                        onOptionSelected = viewModel::respondToClarify,
+                        onDismiss = viewModel::dismissClarify,
+                    )
+                }
+            }
+
             // Thinking indicator
             if (isThinking) {
                 item(key = "thinking") {
@@ -152,7 +166,14 @@ fun ChatMessageList(
                 items = subagentIndicators,
                 key = { indicator -> "subagent-${indicator.subagentId ?: indicator.goal ?: indicator.type}" },
             ) { indicator ->
-                SubagentIndicatorRow(indicator = indicator)
+                SubagentCard(indicator = indicator)
+            }
+
+            // Typing indicator when assistant is still streaming
+            if (streamingMessage?.isStreaming == true) {
+                item(key = "typing") {
+                    TypingIndicator()
+                }
             }
         }
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatMessageList.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatMessageList.kt
@@ -93,10 +93,6 @@ fun ChatMessageList(
                 val isLastMessage = index == messages.lastIndex
                 val isAssistant = message.role == MessageRole.ASSISTANT
 
-                if (isAssistant && message.reasoningText.isNotBlank()) {
-                    ReasoningIndicator(message.reasoningText)
-                }
-
                 if (typingEffectEnabled && isLastMessage && isAssistant && message.isStreaming &&
                     lastAnimatedMessageId != message.id
                 ) {
@@ -122,9 +118,6 @@ fun ChatMessageList(
             // Streaming message
             streamingMessage?.let { streaming ->
                 item(key = "streaming-${streaming.id}") {
-                    if (streaming.reasoningText.isNotBlank()) {
-                        ReasoningIndicator(streaming.reasoningText)
-                    }
                     if (typingEffectEnabled && streaming.isStreaming) {
                         StreamingBubbleWithTypingEffect(
                             streaming = streaming,

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/MessageCards.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/MessageCards.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -55,9 +56,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -92,7 +98,12 @@ fun ReasoningCard(
             modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(8.dp))
-                .clickable { expanded = !expanded }
+                .clickable(
+                    onClickLabel = if (expanded) "Collapse reasoning" else "Expand reasoning",
+                ) { expanded = !expanded }
+                .semantics {
+                    stateDescription = if (expanded) "Expanded" else "Collapsed"
+                }
                 .animateContentSize(),
         color = MaterialTheme.colorScheme.surfaceContainerHighest,
         shape = RoundedCornerShape(8.dp),
@@ -162,9 +173,10 @@ private fun ReasoningPulsingDots() {
                 modifier =
                     Modifier
                         .size(4.dp)
+                        .graphicsLayer { this.alpha = alpha }
                         .background(
-                            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = alpha),
-                            shape = RoundedCornerShape(50),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            shape = CircleShape,
                         ),
             )
             if (it < 2) Spacer(modifier = Modifier.width(3.dp))
@@ -257,15 +269,11 @@ internal fun highlightSyntax(code: String): AnnotatedString =
                 regions.add(Region(m.range.first, m.range.last + 1, CodeKeyword))
             }
         }
-        // Punctuation (check per-character to avoid partial overlap)
+        // Punctuation
         PUNCTUATION_RE.findAll(code).forEach { m ->
-            val chars = m.value.toList()
-            val uncovered =
-                chars.filter { c ->
-                    regions.none { r -> c.code in r.start until r.end }
-                }
-            if (uncovered.isNotEmpty()) {
-                regions.add(Region(m.range.first, m.range.last + 1, CodePunctuation))
+            val index = m.range.first
+            if (regions.none { r -> index in r.start until r.end }) {
+                regions.add(Region(index, index + 1, CodePunctuation))
             }
         }
 
@@ -315,7 +323,7 @@ fun CodeBlockCard(
 
     Surface(
         modifier = modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.inverseSurface,
+        color = Color(0xFF1E1E1E),
         shape = RoundedCornerShape(8.dp),
         tonalElevation = 0.dp,
     ) {
@@ -479,7 +487,10 @@ fun SubagentCard(
         modifier =
             modifier
                 .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 2.dp),
+                .padding(horizontal = 8.dp, vertical = 2.dp)
+                .semantics {
+                    stateDescription = if (isComplete) "Complete" else "In progress"
+                },
         shape = RoundedCornerShape(8.dp),
         color = containerColor,
         tonalElevation = 0.dp,
@@ -535,7 +546,8 @@ fun TypingIndicator(modifier: Modifier = Modifier) {
     Row(
         modifier =
             modifier
-                .padding(horizontal = 8.dp, vertical = 4.dp),
+                .padding(horizontal = 8.dp, vertical = 4.dp)
+                .clearAndSetSemantics { contentDescription = "Assistant is typing" },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         repeat(3) { index ->
@@ -570,10 +582,15 @@ private fun TypingDot(
     Box(
         modifier =
             Modifier
-                .size(size * scale)
+                .size(size)
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                    alpha = 0.6f + 0.4f * scale
+                }
                 .background(
-                    color = color.copy(alpha = 0.6f + 0.4f * scale),
-                    shape = RoundedCornerShape(50),
+                    color = color,
+                    shape = CircleShape,
                 ),
     )
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/MessageCards.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/MessageCards.kt
@@ -1,0 +1,544 @@
+package com.m57.hermescontrol.ui.chat.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.m57.hermescontrol.theme.CodeComment
+import com.m57.hermescontrol.theme.CodeKeyword
+import com.m57.hermescontrol.theme.CodeNumber
+import com.m57.hermescontrol.theme.CodePunctuation
+import com.m57.hermescontrol.theme.CodeString
+import com.m57.hermescontrol.ui.chat.SubagentIndicator
+
+// ── 1. ReasoningCard ──────────────────────────────────────────────────────
+
+@Composable
+fun ReasoningCard(
+    reasoningText: String,
+    stepCount: Int,
+    isStreaming: Boolean = false,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Surface(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .clickable { expanded = !expanded }
+                .animateContentSize(),
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        shape = RoundedCornerShape(8.dp),
+        tonalElevation = 0.dp,
+    ) {
+        Column(modifier = Modifier.padding(10.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "\uD83E\uDDD0 Reasoning · $stepCount step${if (stepCount != 1) "s" else ""}",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f),
+                )
+                Icon(
+                    imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                    contentDescription = if (expanded) "Collapse reasoning" else "Expand reasoning",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+
+            AnimatedVisibility(
+                visible = expanded,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut(),
+            ) {
+                Column {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = reasoningText,
+                        style =
+                            MaterialTheme.typography.bodySmall.copy(
+                                fontFamily = FontFamily.Monospace,
+                                lineHeight = 20.sp,
+                            ),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    if (isStreaming) {
+                        Spacer(modifier = Modifier.height(6.dp))
+                        ReasoningPulsingDots()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReasoningPulsingDots() {
+    val infiniteTransition = rememberInfiniteTransition(label = "reasoning_pulse")
+    val alpha by infiniteTransition.animateFloat(
+        initialValue = 0.3f,
+        targetValue = 1f,
+        animationSpec =
+            infiniteRepeatable(
+                animation = tween(durationMillis = 800, easing = LinearEasing),
+                repeatMode = RepeatMode.Reverse,
+            ),
+        label = "reasoning_alpha",
+    )
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        repeat(3) {
+            Box(
+                modifier =
+                    Modifier
+                        .size(4.dp)
+                        .background(
+                            MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = alpha),
+                            shape = RoundedCornerShape(50),
+                        ),
+            )
+            if (it < 2) Spacer(modifier = Modifier.width(3.dp))
+        }
+    }
+}
+
+// ── 2. CodeBlockCard ──────────────────────────────────────────────────────
+
+private val KEYWORD_SET =
+    setOf(
+        "val",
+        "var",
+        "fun",
+        "class",
+        "object",
+        "interface",
+        "enum",
+        "if",
+        "else",
+        "when",
+        "for",
+        "while",
+        "do",
+        "return",
+        "import",
+        "package",
+        "data",
+        "sealed",
+        "abstract",
+        "override",
+        "private",
+        "public",
+        "protected",
+        "internal",
+        "open",
+        "inline",
+        "suspend",
+        "companion",
+        "init",
+        "constructor",
+        "null",
+        "true",
+        "false",
+        "is",
+        "as",
+        "in",
+        "try",
+        "catch",
+        "finally",
+        "throw",
+        "typealias",
+        "annotation",
+        "infix",
+        "tailrec",
+        "operator",
+    )
+
+private val STRING_RE = Regex("\"(?:[^\"\\\\]|\\\\.)*\"")
+private val COMMENT_RE = Regex("//.*|/\\*[^*]*\\*+(?:[^/*][^*]*\\*+)*/")
+private val NUMBER_RE = Regex("\\b(\\d+\\.?\\d*[fFL]?|0[xX][0-9a-fA-F]+[lL]?)\\b")
+private val KEYWORD_RE = Regex("\\b(${KEYWORD_SET.joinToString("|")})\\b")
+private val PUNCTUATION_RE = Regex("[{}()\\[\\];,:.<>+\\-*/%&|^~!?=@#]")
+
+internal fun highlightSyntax(code: String): AnnotatedString =
+    buildAnnotatedString {
+        data class Region(val start: Int, val end: Int, val color: Color)
+
+        val regions = mutableListOf<Region>()
+
+        // Strings (highest priority)
+        STRING_RE.findAll(code).forEach { m ->
+            regions.add(Region(m.range.first, m.range.last + 1, CodeString))
+        }
+        // Comments
+        COMMENT_RE.findAll(code).forEach { m ->
+            if (regions.none { r -> r.start <= m.range.first && r.end >= m.range.last + 1 }) {
+                regions.add(Region(m.range.first, m.range.last + 1, CodeComment))
+            }
+        }
+        // Numbers
+        NUMBER_RE.findAll(code).forEach { m ->
+            if (regions.none { r -> r.start <= m.range.first && r.end >= m.range.last + 1 }) {
+                regions.add(Region(m.range.first, m.range.last + 1, CodeNumber))
+            }
+        }
+        // Keywords
+        KEYWORD_RE.findAll(code).forEach { m ->
+            if (regions.none { r -> r.start <= m.range.first && r.end >= m.range.last + 1 }) {
+                regions.add(Region(m.range.first, m.range.last + 1, CodeKeyword))
+            }
+        }
+        // Punctuation (check per-character to avoid partial overlap)
+        PUNCTUATION_RE.findAll(code).forEach { m ->
+            val chars = m.value.toList()
+            val uncovered =
+                chars.filter { c ->
+                    regions.none { r -> c.code in r.start until r.end }
+                }
+            if (uncovered.isNotEmpty()) {
+                regions.add(Region(m.range.first, m.range.last + 1, CodePunctuation))
+            }
+        }
+
+        regions.sortBy { it.start }
+
+        var pos = 0
+        for (region in regions) {
+            if (region.start > pos) {
+                append(code.substring(pos, region.start))
+            }
+            withStyle(SpanStyle(color = region.color)) {
+                append(code.substring(region.start, region.end))
+            }
+            pos = region.end
+        }
+        if (pos < code.length) {
+            append(code.substring(pos))
+        }
+    }
+
+@Composable
+private fun textColorOnInverse(): Color {
+    val bg = MaterialTheme.colorScheme.inverseSurface
+    return if (bg.luminance() > 0.5f) Color.Black else Color.White
+}
+
+@Composable
+fun CodeBlockCard(
+    code: String,
+    language: String?,
+    onCopy: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val highlighted = remember(code) { highlightSyntax(code) }
+    val scrollState = rememberScrollState()
+    val onInverse = textColorOnInverse()
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.inverseSurface,
+        shape = RoundedCornerShape(8.dp),
+        tonalElevation = 0.dp,
+    ) {
+        Column {
+            // Top bar: language badge + copy
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (language != null) {
+                    Text(
+                        text = language.uppercase(),
+                        style =
+                            MaterialTheme.typography.labelSmall.copy(
+                                fontWeight = FontWeight.Bold,
+                            ),
+                        color = onInverse.copy(alpha = 0.6f),
+                    )
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                IconButton(
+                    onClick = { onCopy(code) },
+                    modifier = Modifier.size(28.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.ContentCopy,
+                        contentDescription = "Copy code",
+                        tint = onInverse.copy(alpha = 0.6f),
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+            }
+
+            // Scrollable code
+            Box(
+                modifier =
+                    Modifier
+                        .horizontalScroll(scrollState)
+                        .padding(horizontal = 12.dp, vertical = 2.dp),
+            ) {
+                Text(
+                    text = highlighted,
+                    style =
+                        MaterialTheme.typography.bodySmall.copy(
+                            fontFamily = FontFamily.Monospace,
+                            lineHeight = 20.sp,
+                        ),
+                    color = onInverse,
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+// ── 3. ClarifyBubble ──────────────────────────────────────────────────────
+
+@Composable
+fun ClarifyBubble(
+    text: String,
+    options: List<String>,
+    onOptionSelected: (String) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerLow,
+            border =
+                BorderStroke(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                ),
+        ) {
+            Column(
+                modifier = Modifier.padding(12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = text,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+
+                if (options.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    FlowRow(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        options.forEach { option ->
+                            SuggestionChip(
+                                onClick = { onOptionSelected(option) },
+                                label = { Text(option, style = MaterialTheme.typography.labelMedium) },
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(10.dp))
+                OutlinedButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                ) {
+                    Text("Dismiss")
+                }
+            }
+        }
+    }
+}
+
+// ── 4. SubagentCard ───────────────────────────────────────────────────────
+
+@Composable
+fun SubagentCard(
+    indicator: SubagentIndicator,
+    modifier: Modifier = Modifier,
+) {
+    val isComplete = indicator.type == "subagent.complete"
+    val containerColor by animateColorAsState(
+        targetValue =
+            if (isComplete) {
+                MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.7f)
+            } else {
+                MaterialTheme.colorScheme.tertiaryContainer
+            },
+        label = "subagent_bg",
+    )
+
+    Surface(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 2.dp),
+        shape = RoundedCornerShape(8.dp),
+        color = containerColor,
+        tonalElevation = 0.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (isComplete) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = "Complete",
+                    tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                    modifier = Modifier.size(18.dp),
+                )
+            } else {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = indicator.goal ?: "Subagent task",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (isComplete && !indicator.summary.isNullOrBlank()) {
+                    Text(
+                        text = indicator.summary,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ── 5. TypingIndicator ────────────────────────────────────────────────────
+
+@Composable
+fun TypingIndicator(modifier: Modifier = Modifier) {
+    val dotColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val dotSize = 8.dp
+
+    Row(
+        modifier =
+            modifier
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        repeat(3) { index ->
+            TypingDot(
+                color = dotColor,
+                size = dotSize,
+                delayMs = index * 150,
+            )
+            if (index < 2) Spacer(modifier = Modifier.width(4.dp))
+        }
+    }
+}
+
+@Composable
+private fun TypingDot(
+    color: Color,
+    size: androidx.compose.ui.unit.Dp,
+    delayMs: Int,
+) {
+    val infiniteTransition = rememberInfiniteTransition(label = "typing_dot_$delayMs")
+    val scale by infiniteTransition.animateFloat(
+        initialValue = 0.4f,
+        targetValue = 1f,
+        animationSpec =
+            infiniteRepeatable(
+                animation = tween(durationMillis = 600, delayMillis = delayMs, easing = LinearEasing),
+                repeatMode = RepeatMode.Reverse,
+            ),
+        label = "typing_scale_$delayMs",
+    )
+
+    Box(
+        modifier =
+            Modifier
+                .size(size * scale)
+                .background(
+                    color = color.copy(alpha = 0.6f + 0.4f * scale),
+                    shape = RoundedCornerShape(50),
+                ),
+    )
+}

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/MessageCards.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/MessageCards.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol.ui.chat.components
 
+import android.content.ClipData
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
@@ -44,15 +45,19 @@ import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -68,6 +73,8 @@ import com.m57.hermescontrol.theme.CodeNumber
 import com.m57.hermescontrol.theme.CodePunctuation
 import com.m57.hermescontrol.theme.CodeString
 import com.m57.hermescontrol.ui.chat.SubagentIndicator
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 // ── 1. ReasoningCard ──────────────────────────────────────────────────────
 
@@ -289,12 +296,22 @@ private fun textColorOnInverse(): Color {
 fun CodeBlockCard(
     code: String,
     language: String?,
-    onCopy: (String) -> Unit,
+    onCopy: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val highlighted = remember(code) { highlightSyntax(code) }
     val scrollState = rememberScrollState()
     val onInverse = textColorOnInverse()
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+    var copied by remember { mutableStateOf(false) }
+
+    LaunchedEffect(copied) {
+        if (copied) {
+            delay(2000)
+            copied = false
+        }
+    }
 
     Surface(
         modifier = modifier.fillMaxWidth(),
@@ -323,15 +340,33 @@ fun CodeBlockCard(
                 }
                 Spacer(modifier = Modifier.weight(1f))
                 IconButton(
-                    onClick = { onCopy(code) },
+                    onClick = {
+                        (
+                            onCopy ?: { text ->
+                                scope.launch {
+                                    clipboard.setClipEntry(ClipEntry(ClipData.newPlainText(null, text)))
+                                }
+                            }
+                        )(code)
+                        copied = true
+                    },
                     modifier = Modifier.size(28.dp),
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.ContentCopy,
-                        contentDescription = "Copy code",
-                        tint = onInverse.copy(alpha = 0.6f),
-                        modifier = Modifier.size(16.dp),
-                    )
+                    if (copied) {
+                        Icon(
+                            imageVector = Icons.Default.Check,
+                            contentDescription = "Copied",
+                            tint = onInverse.copy(alpha = 0.7f),
+                            modifier = Modifier.size(16.dp),
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Default.ContentCopy,
+                            contentDescription = "Copy code",
+                            tint = onInverse.copy(alpha = 0.6f),
+                            modifier = Modifier.size(16.dp),
+                        )
+                    }
                 }
             }
 


### PR DESCRIPTION
## Changes

Rich message bubble components extracted into focused composables, replacing ChatBubble.kt's monolithic rendering.

### New files
- **MessageCards.kt** — 5 new composables: ReasoningCard, CodeBlockCard, ClarifyBubble, SubagentCard, TypingIndicator
- **Color.kt** — 5 syntax highlighting color tokens (VS Code Dark+ palette)

### Modified files
- **MarkdownText.kt** — Code blocks now use CodeBlockCard (syntax highlighting + language badge); old private CodeBlockCard removed
- **ChatBubble.kt** — ReasoningCard injected before content when reasoningText present
- **ChatMessageList.kt** — ClarifyBubble + TypingIndicator rendered inline; SubagentCard replaces SubagentIndicatorRow
- **ChatScreen.kt** — Passes clarifyRequest to ChatMessageList

### Issue coverage
| Issue | Status |
|-------|--------|
| #659 — syntax highlighting tokens | ✅ |
| #660 — MessageCards.kt (5 composables) | ✅ |
| #664 — extract code blocks from MarkdownText | ✅ |
| #661 — ReasoningCard in AssistantBubble | ✅ |
| #662 — ClarifyBubble inline | ✅ |
| #663 — SubagentCard + TypingIndicator | ✅ |

### Build
```
./gradlew assembleDebug — BUILD SUCCESSFUL
./gradlew ktlintCheck — PASS
```