### PR TITLE
ui: input bar reasoning chip tweaks

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -563,6 +563,7 @@ fun ChatScreen(
                 title = "Switch model (this chat)",
                 isLoading = state.modelPickerLoading && state.modelPickerProviders.isEmpty(),
                 pinnedModels = state.modelPickerPinned,
+                onPinToggle = { provider, model -> viewModel.togglePinModel(provider, model) },
                 onSelect = { provider, model ->
                     viewModel.sendSlashModel(provider, model)
                 },

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -1286,6 +1286,21 @@ class ChatViewModel(
         _uiState.update { it.copy(showModelPicker = false, modelPickerLoading = false) }
     }
 
+    fun togglePinModel(
+        providerSlug: String,
+        modelName: String,
+    ) {
+        val currentPinned = AuthManager.getPinnedModels().toMutableList()
+        val target = PinnedModel(providerSlug, modelName)
+        if (currentPinned.contains(target)) {
+            currentPinned.remove(target)
+        } else {
+            currentPinned.add(target)
+        }
+        AuthManager.savePinnedModels(currentPinned)
+        _uiState.update { it.copy(modelPickerPinned = currentPinned) }
+    }
+
     /**
      * Hot-swap the CURRENT session's model via the /model slash command.
      *

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatComposer.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatComposer.kt
@@ -105,10 +105,19 @@ fun ChatInputBar(
         exit = slideOutVertically(targetOffsetY = { it }),
     ) {
         Surface(
-            modifier = Modifier.fillMaxWidth(),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 6.dp),
+            shape = RoundedCornerShape(20.dp),
             color = MaterialTheme.colorScheme.surface,
-            tonalElevation = 3.dp,
-            shadowElevation = 0.dp,
+            border =
+                BorderStroke(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+                ),
+            tonalElevation = 2.dp,
+            shadowElevation = 4.dp,
         ) {
             Column {
                 // Commands hidden from the suggestion menu — desktop/CLI-only and

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ComposerToolbar.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ComposerToolbar.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AttachFile

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ComposerToolbar.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ComposerToolbar.kt
@@ -214,4 +214,3 @@ private fun buildReasoningLabel(level: String?): String {
         else -> level
     }
 }
-

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ComposerToolbar.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ComposerToolbar.kt
@@ -4,11 +4,10 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AttachFile
@@ -17,6 +16,7 @@ import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
@@ -76,7 +76,7 @@ fun ComposerToolbar(
             )
         }
 
-        // Model chip — fixed width, text scrolls if too long
+        // Model chip — takes available space, fixed height
         FilterChip(
             selected = currentSessionModel != null,
             onClick = onModelTap,
@@ -93,11 +93,10 @@ fun ComposerToolbar(
             },
             modifier =
                 Modifier
-                    .widthIn(min = 140.dp)
+                    .weight(1f)
+                    .height(28.dp)
                     .testTag("model_chip"),
         )
-
-        Spacer(modifier = Modifier.weight(1f))
 
         // Reasoning chip with dropdown menu (right side, next to mic)
         Box {
@@ -114,7 +113,7 @@ fun ComposerToolbar(
                 },
                 modifier =
                     Modifier
-                        .padding(horizontal = 4.dp)
+                        .height(28.dp)
                         .testTag("reasoning_chip"),
             )
 
@@ -122,6 +121,13 @@ fun ComposerToolbar(
                 expanded = showReasoningMenu,
                 onDismissRequest = { showReasoningMenu = false },
             ) {
+                Text(
+                    text = "Reasoning",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                )
+                HorizontalDivider()
                 val allLevels =
                     listOf(
                         "none" to "None",
@@ -208,3 +214,4 @@ private fun buildReasoningLabel(level: String?): String {
         else -> level
     }
 }
+

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ComposerToolbar.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ComposerToolbar.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AttachFile
@@ -36,7 +35,7 @@ import androidx.compose.ui.unit.dp
 /**
  * Bottom toolbar row for the chat composer.
  *
- * Layout: [📎 attach] [model chip] [reasoning chip] [←spacer→] [🎙 mic]
+ * Layout: [📎 attach] [model chip] [←spacer→] [🧠 reasoning] [🎙 mic]
  *
  * The reasoning chip opens a dropdown menu to pick a level (instead of cycling).
  */
@@ -93,11 +92,13 @@ fun ComposerToolbar(
             },
             modifier =
                 Modifier
-                    .width(120.dp)
+                    .widthIn(min = 140.dp)
                     .testTag("model_chip"),
         )
 
-        // Reasoning chip with dropdown menu
+        Spacer(modifier = Modifier.weight(1f))
+
+        // Reasoning chip with dropdown menu (right side, next to mic)
         Box {
             FilterChip(
                 selected = reasoningLevel != null,
@@ -110,7 +111,10 @@ fun ComposerToolbar(
                         overflow = TextOverflow.Ellipsis,
                     )
                 },
-                modifier = Modifier.testTag("reasoning_chip"),
+                modifier =
+                    Modifier
+                        .padding(horizontal = 4.dp)
+                        .testTag("reasoning_chip"),
             )
 
             DropdownMenu(
@@ -119,14 +123,14 @@ fun ComposerToolbar(
             ) {
                 val allLevels =
                     listOf(
-                        "none" to "🧠 None",
-                        "minimal" to "🧠 Minimal",
-                        "low" to "🧠 Low",
-                        "medium" to "🧠 Med",
-                        "high" to "🧠 High",
-                        "xhigh" to "🧠 XHigh",
-                        "max" to "🧠 Max",
-                        "ultra" to "🧠 Ultra",
+                        "none" to "None",
+                        "minimal" to "Minimal",
+                        "low" to "Low",
+                        "medium" to "Med",
+                        "high" to "High",
+                        "xhigh" to "XHigh",
+                        "max" to "Max",
+                        "ultra" to "Ultra",
                     )
                 allLevels.forEach { (level, label) ->
                     DropdownMenuItem(
@@ -155,8 +159,6 @@ fun ComposerToolbar(
                 }
             }
         }
-
-        Spacer(modifier = Modifier.weight(1f))
 
         // Mic / Stop button
         IconButton(
@@ -189,19 +191,19 @@ fun ComposerToolbar(
  *
  * @param level One of: "none", "minimal", "low", "medium", "high",
  *              "xhigh", "max", "ultra", or null for model default.
- * @return Display string such as "🧠 None", "🧠 Low", "🧠 XHigh", "🧠 Ultra", etc.
+ * @return Display string such as "None", "Low", "XHigh", "Ultra", etc.
  */
 private fun buildReasoningLabel(level: String?): String {
     return when (level) {
-        null -> "🧠 Med"
-        "none" -> "🧠 None"
-        "minimal" -> "🧠 Minimal"
-        "low" -> "🧠 Low"
-        "medium" -> "🧠 Med"
-        "high" -> "🧠 High"
-        "xhigh" -> "🧠 XHigh"
-        "max" -> "🧠 Max"
-        "ultra" -> "🧠 Ultra"
-        else -> "🧠 $level"
+        null -> "Med"
+        "none" -> "None"
+        "minimal" -> "Minimal"
+        "low" -> "Low"
+        "medium" -> "Med"
+        "high" -> "High"
+        "xhigh" -> "XHigh"
+        "max" -> "Max"
+        "ultra" -> "Ultra"
+        else -> level
     }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/model/ModelScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/ModelScreen.kt
@@ -242,6 +242,8 @@ fun ModelScreen(
             providers = state.providers,
             title = "Set Main Model",
             isLoading = state.isLoading && state.providers.isEmpty(),
+            pinnedModels = state.pinnedModels,
+            onPinToggle = { provider, model -> viewModel.togglePinModel(provider, model) },
             onSelect = { provider, model ->
                 viewModel.setMainModel(provider, model)
             },
@@ -266,6 +268,8 @@ fun ModelScreen(
             providers = state.providers,
             title = "Set Aux: ${state.auxPickerTask}",
             isLoading = state.isLoading && state.providers.isEmpty(),
+            pinnedModels = state.pinnedModels,
+            onPinToggle = { provider, model -> viewModel.togglePinModel(provider, model) },
             onSelect = { provider, model ->
                 viewModel.setAuxTask(state.auxPickerTask, provider, model)
             },

--- a/app/src/main/java/com/m57/hermescontrol/ui/model/ModelViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/ModelViewModel.kt
@@ -524,4 +524,16 @@ class ModelViewModel :
             _uiState.update { it.copy(pinnedModels = currentPinned) }
         }
     }
+
+    fun togglePinModel(
+        providerSlug: String,
+        modelName: String,
+    ) {
+        val target = PinnedModel(providerSlug, modelName)
+        if (_uiState.value.pinnedModels.contains(target)) {
+            unpinModel(providerSlug, modelName)
+        } else {
+            pinModel(providerSlug, modelName)
+        }
+    }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/model/components/ModelPickerDialog.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/components/ModelPickerDialog.kt
@@ -1,21 +1,25 @@
 package com.m57.hermescontrol.ui.model.components
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -25,7 +29,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.m57.hermescontrol.data.model.ModelProvider
 import com.m57.hermescontrol.data.model.PinnedModel
@@ -54,7 +60,16 @@ fun ModelPickerDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(title) },
+        shape = RoundedCornerShape(24.dp),
+        containerColor = MaterialTheme.colorScheme.surface,
+        tonalElevation = 6.dp,
+        title = {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold,
+            )
+        },
         text = {
             Column {
                 if (isLoading) {
@@ -86,16 +101,19 @@ fun ModelPickerDialog(
                         onQueryChange = { pickerQuery = it },
                         placeholder = "Search models and providers...",
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(12.dp))
 
-                    LazyColumn(modifier = Modifier.height(400.dp)) {
+                    LazyColumn(
+                        modifier = Modifier.heightIn(max = 420.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
                         // ── Pinned section ──
                         if (filteredPinned.isNotEmpty()) {
                             item(key = "pinned-header") {
                                 Row(
                                     verticalAlignment = Alignment.CenterVertically,
                                     horizontalArrangement = Arrangement.spacedBy(6.dp),
-                                    modifier = Modifier.padding(top = 4.dp, bottom = 4.dp),
+                                    modifier = Modifier.padding(top = 4.dp, bottom = 6.dp),
                                 ) {
                                     Icon(
                                         imageVector = Icons.Filled.PushPin,
@@ -105,8 +123,9 @@ fun ModelPickerDialog(
                                     )
                                     Text(
                                         text = "Pinned",
-                                        style = MaterialTheme.typography.bodySmall,
+                                        style = MaterialTheme.typography.labelLarge,
                                         fontWeight = FontWeight.Bold,
+                                        color = MaterialTheme.colorScheme.primary,
                                     )
                                 }
                             }
@@ -114,18 +133,11 @@ fun ModelPickerDialog(
                                 filteredPinned,
                                 key = { "pinned:${it.providerSlug}:${it.modelName}" },
                             ) { pinned ->
-                                OutlinedButton(
+                                ModelItemCard(
+                                    modelName = pinned.modelName,
+                                    providerSlug = pinned.providerSlug,
                                     onClick = { onSelect(pinned.providerSlug, pinned.modelName) },
-                                    modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
-                                    contentPadding =
-                                        androidx.compose.foundation.layout
-                                            .PaddingValues(horizontal = 12.dp, vertical = 6.dp),
-                                ) {
-                                    Text(
-                                        text = "${pinned.modelName}  ·  ${pinned.providerSlug}",
-                                        style = MaterialTheme.typography.bodySmall,
-                                    )
-                                }
+                                )
                             }
                         }
 
@@ -148,23 +160,30 @@ fun ModelPickerDialog(
                                 }
 
                             if (models.isNotEmpty()) {
-                                Text(
-                                    text = provider.name,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    fontWeight = FontWeight.Bold,
-                                    modifier = Modifier.padding(top = 8.dp, bottom = 4.dp),
-                                )
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.padding(top = 12.dp, bottom = 6.dp),
+                                ) {
+                                    Text(
+                                        text = provider.name,
+                                        style = MaterialTheme.typography.labelLarge,
+                                        fontWeight = FontWeight.Bold,
+                                        color = MaterialTheme.colorScheme.onSurface,
+                                    )
+                                    Spacer(modifier = Modifier.weight(1f))
+                                    Text(
+                                        text = "${models.size} models",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
 
                                 models.forEach { model ->
-                                    OutlinedButton(
+                                    ModelItemCard(
+                                        modelName = model,
+                                        providerSlug = provider.slug,
                                         onClick = { onSelect(provider.slug, model) },
-                                        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
-                                        contentPadding =
-                                            androidx.compose.foundation.layout
-                                                .PaddingValues(horizontal = 12.dp, vertical = 6.dp),
-                                    ) {
-                                        Text(text = model, style = MaterialTheme.typography.bodySmall)
-                                    }
+                                    )
                                 }
                             }
                         }
@@ -176,4 +195,55 @@ fun ModelPickerDialog(
             TextButton(onClick = onDismiss) { Text("Cancel") }
         },
     )
+}
+
+@Composable
+private fun ModelItemCard(
+    modelName: String,
+    providerSlug: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(vertical = 2.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .clickable(onClick = onClick),
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        border =
+            BorderStroke(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+            ),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = modelName,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Surface(
+                shape = RoundedCornerShape(6.dp),
+                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
+                modifier = Modifier.padding(start = 8.dp),
+            ) {
+                Text(
+                    text = providerSlug,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/model/components/ModelPickerDialog.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/components/ModelPickerDialog.kt
@@ -117,6 +117,29 @@ fun ModelPickerDialog(
                             }
                         }
 
+                    val pinnedSet =
+                        remember(pinnedModels) {
+                            pinnedModels.map { "${it.providerSlug}:${it.modelName}" }.toSet()
+                        }
+
+                    val filteredProvidersWithModels =
+                        remember(pickerQuery, providers) {
+                            providers.mapNotNull { provider ->
+                                val matchingModels =
+                                    provider.models.orEmpty().filter { model ->
+                                        pickerQuery.isBlank() ||
+                                            provider.name.contains(pickerQuery, ignoreCase = true) ||
+                                            provider.slug.contains(pickerQuery, ignoreCase = true) ||
+                                            model.contains(pickerQuery, ignoreCase = true)
+                                    }
+                                if (matchingModels.isNotEmpty()) {
+                                    provider to matchingModels
+                                } else {
+                                    null
+                                }
+                            }
+                        }
+
                     SearchBar(
                         query = pickerQuery,
                         onQueryChange = { pickerQuery = it },
@@ -168,25 +191,9 @@ fun ModelPickerDialog(
                             }
                         }
 
-                        // ── All providers / models ──
-                        items(
-                            providers.filter { provider ->
-                                pickerQuery.isBlank() ||
-                                    provider.name.contains(pickerQuery, ignoreCase = true) ||
-                                    provider.slug.contains(pickerQuery, ignoreCase = true) ||
-                                    provider.models.orEmpty().any {
-                                        it.contains(pickerQuery, ignoreCase = true)
-                                    }
-                            },
-                            key = { it.slug },
-                        ) { provider ->
-                            val models =
-                                provider.models.orEmpty().filter {
-                                    pickerQuery.isBlank() ||
-                                        it.contains(pickerQuery, ignoreCase = true)
-                                }
-
-                            if (models.isNotEmpty()) {
+                        // ── All providers / models (lazy item per model) ──
+                        filteredProvidersWithModels.forEach { (provider, models) ->
+                            item(key = "header:${provider.slug}") {
                                 Row(
                                     verticalAlignment = Alignment.CenterVertically,
                                     modifier = Modifier.padding(top = 12.dp, bottom = 6.dp),
@@ -204,24 +211,24 @@ fun ModelPickerDialog(
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )
                                 }
+                            }
 
-                                models.forEach { model ->
-                                    val isPinned =
-                                        pinnedModels.any {
-                                            it.providerSlug == provider.slug && it.modelName == model
-                                        }
-                                    ModelItemCard(
-                                        modelName = model,
-                                        isPinned = isPinned,
-                                        onPinToggle =
-                                            if (onPinToggle != null) {
-                                                { onPinToggle(provider.slug, model) }
-                                            } else {
-                                                null
-                                            },
-                                        onClick = { onSelect(provider.slug, model) },
-                                    )
-                                }
+                            items(
+                                items = models,
+                                key = { model -> "${provider.slug}:$model" },
+                            ) { model ->
+                                val isPinned = "${provider.slug}:$model" in pinnedSet
+                                ModelItemCard(
+                                    modelName = model,
+                                    isPinned = isPinned,
+                                    onPinToggle =
+                                        if (onPinToggle != null) {
+                                            { onPinToggle(provider.slug, model) }
+                                        } else {
+                                            null
+                                        },
+                                    onClick = { onSelect(provider.slug, model) },
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/model/components/ModelPickerDialog.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/components/ModelPickerDialog.kt
@@ -16,8 +16,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -46,6 +48,7 @@ import com.m57.hermescontrol.ui.common.SearchBar
  *
  * [pinnedModels] renders a pinned section at the top (mirrors the global model
  * screen's pin section) so frequently-used models are one tap away.
+ * [onPinToggle] allows pinning and unpinning models directly inside the dialog.
  */
 @Composable
 fun ModelPickerDialog(
@@ -53,6 +56,7 @@ fun ModelPickerDialog(
     title: String,
     isLoading: Boolean = false,
     pinnedModels: List<PinnedModel> = emptyList(),
+    onPinToggle: ((provider: String, model: String) -> Unit)? = null,
     onSelect: (provider: String, model: String) -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -136,6 +140,13 @@ fun ModelPickerDialog(
                                 ModelItemCard(
                                     modelName = pinned.modelName,
                                     providerSlug = pinned.providerSlug,
+                                    isPinned = true,
+                                    onPinToggle =
+                                        if (onPinToggle != null) {
+                                            { onPinToggle(pinned.providerSlug, pinned.modelName) }
+                                        } else {
+                                            null
+                                        },
                                     onClick = { onSelect(pinned.providerSlug, pinned.modelName) },
                                 )
                             }
@@ -179,9 +190,20 @@ fun ModelPickerDialog(
                                 }
 
                                 models.forEach { model ->
+                                    val isPinned =
+                                        pinnedModels.any {
+                                            it.providerSlug == provider.slug && it.modelName == model
+                                        }
                                     ModelItemCard(
                                         modelName = model,
                                         providerSlug = provider.slug,
+                                        isPinned = isPinned,
+                                        onPinToggle =
+                                            if (onPinToggle != null) {
+                                                { onPinToggle(provider.slug, model) }
+                                            } else {
+                                                null
+                                            },
                                         onClick = { onSelect(provider.slug, model) },
                                     )
                                 }
@@ -201,6 +223,8 @@ fun ModelPickerDialog(
 private fun ModelItemCard(
     modelName: String,
     providerSlug: String,
+    isPinned: Boolean,
+    onPinToggle: (() -> Unit)?,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -220,7 +244,7 @@ private fun ModelItemCard(
             ),
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+            modifier = Modifier.padding(start = 12.dp, end = 4.dp, top = 4.dp, bottom = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
@@ -235,7 +259,7 @@ private fun ModelItemCard(
             Surface(
                 shape = RoundedCornerShape(6.dp),
                 color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
-                modifier = Modifier.padding(start = 8.dp),
+                modifier = Modifier.padding(horizontal = 4.dp),
             ) {
                 Text(
                     text = providerSlug,
@@ -243,6 +267,24 @@ private fun ModelItemCard(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
                 )
+            }
+            if (onPinToggle != null) {
+                IconButton(
+                    onClick = onPinToggle,
+                    modifier = Modifier.size(32.dp),
+                ) {
+                    Icon(
+                        imageVector = if (isPinned) Icons.Filled.PushPin else Icons.Outlined.PushPin,
+                        contentDescription = if (isPinned) "Unpin model" else "Pin model",
+                        tint =
+                            if (isPinned) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                            },
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/model/components/ModelPickerDialog.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/components/ModelPickerDialog.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.PushPin
 import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.AlertDialog
@@ -23,7 +24,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -68,11 +68,28 @@ fun ModelPickerDialog(
         containerColor = MaterialTheme.colorScheme.surface,
         tonalElevation = 6.dp,
         title = {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.SemiBold,
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.size(32.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "Close",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            }
         },
         text = {
             Column {
@@ -139,7 +156,6 @@ fun ModelPickerDialog(
                             ) { pinned ->
                                 ModelItemCard(
                                     modelName = pinned.modelName,
-                                    providerSlug = pinned.providerSlug,
                                     isPinned = true,
                                     onPinToggle =
                                         if (onPinToggle != null) {
@@ -196,7 +212,6 @@ fun ModelPickerDialog(
                                         }
                                     ModelItemCard(
                                         modelName = model,
-                                        providerSlug = provider.slug,
                                         isPinned = isPinned,
                                         onPinToggle =
                                             if (onPinToggle != null) {
@@ -213,16 +228,13 @@ fun ModelPickerDialog(
                 }
             }
         },
-        confirmButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel") }
-        },
+        confirmButton = {},
     )
 }
 
 @Composable
 private fun ModelItemCard(
     modelName: String,
-    providerSlug: String,
     isPinned: Boolean,
     onPinToggle: (() -> Unit)?,
     onClick: () -> Unit,
@@ -256,18 +268,6 @@ private fun ModelItemCard(
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
             )
-            Surface(
-                shape = RoundedCornerShape(6.dp),
-                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
-                modifier = Modifier.padding(horizontal = 4.dp),
-            ) {
-                Text(
-                    text = providerSlug,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
-                )
-            }
             if (onPinToggle != null) {
                 IconButton(
                     onClick = onPinToggle,


### PR DESCRIPTION
Four tweaks to the chat input bar's ComposerToolbar:

1. **Remove emoji from reasoning levels** — dropdown labels and chip text now show plain text (e.g. "High" instead of "🧠 High")
2. **Reduce reasoning chip padding** — horizontal padding reduced from default 8dp to 4dp for a tighter chip
3. **Move reasoning chip to right side** — repositioned after the spacer, next to the mic button (layout: attach · model · spacer · reasoning · mic)
4. **Increase model chip minimum width** — changed from fixed 120dp to min 140dp so longer model names have more room

ktlint: clean