### PR TITLE
feat(navigation): regroup Kanban to AUTOMATE and Gateway to INSPECT in navigation drawer

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ScreenRegistry.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ScreenRegistry.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.Dashboard
+import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.HistoryEdu
@@ -198,7 +199,7 @@ object ScreenRegistry {
             ScreenDefinition(
                 AchievementsScreen,
                 R.string.screen_achievements,
-                Icons.Filled.Info,
+                Icons.Filled.EmojiEvents,
                 DrawerSection.INSPECT,
             ) { sessionId, openDrawer -> AchievementsScreenContent(onOpenDrawer = openDrawer) },
             ScreenDefinition(

--- a/app/src/main/java/com/m57/hermescontrol/ScreenRegistry.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ScreenRegistry.kt
@@ -100,11 +100,11 @@ object ScreenRegistry {
                 DrawerSection.AUTOMATE,
             ) { sessionId, openDrawer -> WebhooksScreenContent(onOpenDrawer = openDrawer) },
             ScreenDefinition(
-                GatewayScreen,
-                R.string.screen_gateway,
-                Icons.Filled.Bolt,
+                KanbanScreen,
+                R.string.screen_kanban,
+                Icons.Filled.Dashboard,
                 DrawerSection.AUTOMATE,
-            ) { sessionId, openDrawer -> GatewayScreenContent(onOpenDrawer = openDrawer) },
+            ) { sessionId, openDrawer -> KanbanScreenContent(onOpenDrawer = openDrawer) },
             ScreenDefinition(
                 SkillsScreen,
                 R.string.screen_skills,
@@ -160,6 +160,12 @@ object ScreenRegistry {
                 DrawerSection.CONFIGURE,
             ) { sessionId, openDrawer -> ProvidersScreenContent(onOpenDrawer = openDrawer) },
             ScreenDefinition(
+                GatewayScreen,
+                R.string.screen_gateway,
+                Icons.Filled.Bolt,
+                DrawerSection.INSPECT,
+            ) { sessionId, openDrawer -> GatewayScreenContent(onOpenDrawer = openDrawer) },
+            ScreenDefinition(
                 SystemScreen,
                 R.string.screen_system,
                 Icons.Filled.Info,
@@ -189,12 +195,6 @@ object ScreenRegistry {
                 Icons.Filled.AccountBalanceWallet,
                 DrawerSection.INSPECT,
             ) { sessionId, openDrawer -> BillingScreenContent(onOpenDrawer = openDrawer) },
-            ScreenDefinition(
-                KanbanScreen,
-                R.string.screen_kanban,
-                Icons.Filled.Dashboard,
-                DrawerSection.INSPECT,
-            ) { sessionId, openDrawer -> KanbanScreenContent(onOpenDrawer = openDrawer) },
             ScreenDefinition(
                 AchievementsScreen,
                 R.string.screen_achievements,


### PR DESCRIPTION
## Summary

Regrouped navigation drawer items in `ScreenRegistry.kt` to align screen categorization with logical domain functions:

- **Moved Kanban Board (`KanbanScreen`)** from `INSPECT` to `AUTOMATE` (grouped with Cron Jobs and Webhooks for task/workflow management).
- **Moved Gateway (`GatewayScreen`)** from `AUTOMATE` to `INSPECT` (grouped with System, Logs, and Processes for server daemon diagnostics and monitoring).