### PR TITLE
fix(#682): add last-item index guard to chat isAtBottom check

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatScrollController.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatScrollController.kt
@@ -187,9 +187,10 @@ fun LazyListState.isAtBottom(tolerance: Int = 8): Boolean {
     val visibleItems = layoutInfo.visibleItemsInfo
     if (visibleItems.isEmpty()) return true
     val lastItem = visibleItems.last()
+    if (lastItem.index < layoutInfo.totalItemsCount - 1) return false
     val lastBottom = lastItem.offset + lastItem.size
     val viewportBottom = layoutInfo.viewportEndOffset - layoutInfo.afterContentPadding
-    return lastBottom >= viewportBottom - tolerance
+    return lastBottom <= viewportBottom + tolerance
 }
 
 /**


### PR DESCRIPTION
Closes #682. Fixes an issue in `isAtBottom()` where only pixel distance was checked without verifying if the last visible item is the final item in the list. This was causing `isFollowingBottom` to remain true at all scroll positions and forced streaming bot messages to pull the user to the bottom even when scrolled up.