### PR TITLE
[Add edge case tests for DashboardSessionTokenRefresher]

### DIFF
--- a/app/src/test/java/com/m57/hermescontrol/data/remote/DashboardSessionTokenRefresherTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/remote/DashboardSessionTokenRefresherTest.kt
@@ -1,5 +1,10 @@
 package com.m57.hermescontrol.data.remote
 
+import com.m57.hermescontrol.data.local.AuthManager
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -16,11 +21,14 @@ class DashboardSessionTokenRefresherTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
+        mockkObject(OkHttpProvider)
+        every { OkHttpProvider.probe } returns OkHttpClient()
     }
 
     @AfterEach
     fun tearDown() {
         server.shutdown()
+        unmockkAll()
     }
 
     @Test
@@ -66,5 +74,46 @@ class DashboardSessionTokenRefresherTest {
         val token = DashboardSessionTokenRefresher.fetch(server.url("/").toString(), OkHttpClient())
 
         assertNull(token)
+    }
+
+    @Test
+    fun refreshUpdatesAuthManagerOnSuccess() {
+        mockkObject(AuthManager)
+        every { AuthManager.baseUrl() } returns server.url("/").toString()
+        every { AuthManager.setToken(any()) } returns Unit
+
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""<script>window.__HERMES_SESSION_TOKEN__ = "mocked-token";</script>"""),
+        )
+
+        val token = DashboardSessionTokenRefresher.refresh()
+
+        assertEquals("mocked-token", token)
+        verify { AuthManager.setToken("mocked-token") }
+    }
+
+    @Test
+    fun refreshReturnsNullOnException() {
+        mockkObject(AuthManager)
+        every { AuthManager.baseUrl() } throws RuntimeException("Network Error")
+
+        val token = DashboardSessionTokenRefresher.refresh()
+
+        assertNull(token)
+    }
+
+    @Test
+    fun refreshReturnsNullWhenFetchReturnsNull() {
+        mockkObject(AuthManager)
+        every { AuthManager.baseUrl() } returns server.url("/").toString()
+        // No token returned from fetch
+        server.enqueue(MockResponse().setResponseCode(200).setBody("<html></html>"))
+
+        val token = DashboardSessionTokenRefresher.refresh()
+
+        assertNull(token)
+        verify(exactly = 0) { AuthManager.setToken(any()) }
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The catch block in `DashboardSessionTokenRefresher.refresh()` was missing an edge case test where an exception could be thrown (e.g., if a network or base URL error occurred).

📊 **Coverage:** What scenarios are now tested
1. **Happy path:** Mocked a token response from the network and verified that it correctly updates `AuthManager`.
2. **Exception handling:** Mocked an exception thrown during `AuthManager.baseUrl()` to verify that the `refresh()` method catches it and safely returns `null` as expected.
3. **Empty result:** Verified that if `fetch()` returns `null`, `refresh()` appropriately passes the `null` value back without modifying `AuthManager`.

✨ **Result:** The improvement in test coverage
`DashboardSessionTokenRefresher.kt` now has complete coverage for both `fetch()` and `refresh()`, verifying both their success states and resilient error handling for unhandled exceptions or missing token payloads.

---
*PR created automatically by Jules for task [9530109835009412057](https://jules.google.com/task/9530109835009412057) started by @Hy4ri*