### PR TITLE
Add comprehensive tests for loadSettings in SettingsViewModel

### DIFF
--- a/app/src/test/java/com/m57/hermescontrol/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/settings/SettingsViewModelTest.kt
@@ -12,10 +12,10 @@ import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -108,37 +108,38 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun testLoadSettings_loadsAllProperties() = runTest {
-        every { AuthManager.getSelectedProfileId() } answers { "prof-2" }
-        every { AuthManager.getBaseUrl() } returns "https://192.168.1.10:9119/"
-        every { AuthManager.getToken() } returns "dummy_token"
-        every { AuthManager.isAutoReconnect() } returns false
-        every { AuthManager.getThemePreference() } returns ThemePreference.DARK
-        every { AuthManager.isUseDynamicColors() } returns false
-        every { AuthManager.getThemePreset() } returns ThemePreset.CATPPUCCIN
-        every { AuthManager.isTypingEffectEnabled() } returns false
-        every { AuthManager.getTypingEffectDelayMs() } returns 15
-        every { AuthManager.getConnectionProfiles() } returns testProfiles
-        every { AuthManager.getAppLanguage() } returns "fr"
+    fun testLoadSettings_loadsAllProperties() =
+        runTest {
+            every { AuthManager.getSelectedProfileId() } answers { "prof-2" }
+            every { AuthManager.getBaseUrl() } returns "https://192.168.1.10:9119/"
+            every { AuthManager.getToken() } returns "dummy_token"
+            every { AuthManager.isAutoReconnect() } returns false
+            every { AuthManager.getThemePreference() } returns ThemePreference.DARK
+            every { AuthManager.isUseDynamicColors() } returns false
+            every { AuthManager.getThemePreset() } returns ThemePreset.CATPPUCCIN
+            every { AuthManager.isTypingEffectEnabled() } returns false
+            every { AuthManager.getTypingEffectDelayMs() } returns 15
+            every { AuthManager.getConnectionProfiles() } returns testProfiles
+            every { AuthManager.getAppLanguage() } returns "fr"
 
-        val viewModel = SettingsViewModel(ioDispatcher = testDispatcher)
-        testDispatcher.scheduler.advanceUntilIdle()
+            val viewModel = SettingsViewModel(ioDispatcher = testDispatcher)
+            testDispatcher.scheduler.advanceUntilIdle()
 
-        val state = viewModel.uiState.value
+            val state = viewModel.uiState.value
 
-        assertEquals("https://192.168.1.10:9119/", state.baseUrl)
-        assertEquals("dummy_token", state.token)
-        assertEquals(false, state.autoReconnect)
-        assertEquals(ThemePreference.DARK, state.themePreference)
-        assertEquals(false, state.useDynamicColors)
-        assertEquals(ThemePreset.CATPPUCCIN, state.themePreset)
-        assertEquals(false, state.typingEffectEnabled)
-        assertEquals(15, state.typingEffectDelayMs)
-        assertEquals(testProfiles, state.profiles)
-        assertEquals("prof-2", state.selectedProfileId)
-        assertEquals("Home", state.renameProfileName)
-        assertEquals("fr", state.appLanguage)
-    }
+            assertEquals("https://192.168.1.10:9119/", state.baseUrl)
+            assertEquals("dummy_token", state.token)
+            assertEquals(false, state.autoReconnect)
+            assertEquals(ThemePreference.DARK, state.themePreference)
+            assertEquals(false, state.useDynamicColors)
+            assertEquals(ThemePreset.CATPPUCCIN, state.themePreset)
+            assertEquals(false, state.typingEffectEnabled)
+            assertEquals(15, state.typingEffectDelayMs)
+            assertEquals(testProfiles, state.profiles)
+            assertEquals("prof-2", state.selectedProfileId)
+            assertEquals("Home", state.renameProfileName)
+            assertEquals("fr", state.appLanguage)
+        }
 
     @Test
     fun testLoadSettings_noSelectedProfile_renameEmpty() {

--- a/app/src/test/java/com/m57/hermescontrol/ui/settings/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/settings/SettingsViewModelTest.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -103,6 +105,39 @@ class SettingsViewModelTest {
         assertEquals(2, state.profiles.size)
         assertEquals("prof-1", state.selectedProfileId)
         assertEquals("Work", state.renameProfileName)
+    }
+
+    @Test
+    fun testLoadSettings_loadsAllProperties() = runTest {
+        every { AuthManager.getSelectedProfileId() } answers { "prof-2" }
+        every { AuthManager.getBaseUrl() } returns "https://192.168.1.10:9119/"
+        every { AuthManager.getToken() } returns "dummy_token"
+        every { AuthManager.isAutoReconnect() } returns false
+        every { AuthManager.getThemePreference() } returns ThemePreference.DARK
+        every { AuthManager.isUseDynamicColors() } returns false
+        every { AuthManager.getThemePreset() } returns ThemePreset.CATPPUCCIN
+        every { AuthManager.isTypingEffectEnabled() } returns false
+        every { AuthManager.getTypingEffectDelayMs() } returns 15
+        every { AuthManager.getConnectionProfiles() } returns testProfiles
+        every { AuthManager.getAppLanguage() } returns "fr"
+
+        val viewModel = SettingsViewModel(ioDispatcher = testDispatcher)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+
+        assertEquals("https://192.168.1.10:9119/", state.baseUrl)
+        assertEquals("dummy_token", state.token)
+        assertEquals(false, state.autoReconnect)
+        assertEquals(ThemePreference.DARK, state.themePreference)
+        assertEquals(false, state.useDynamicColors)
+        assertEquals(ThemePreset.CATPPUCCIN, state.themePreset)
+        assertEquals(false, state.typingEffectEnabled)
+        assertEquals(15, state.typingEffectDelayMs)
+        assertEquals(testProfiles, state.profiles)
+        assertEquals("prof-2", state.selectedProfileId)
+        assertEquals("Home", state.renameProfileName)
+        assertEquals("fr", state.appLanguage)
     }
 
     @Test


### PR DESCRIPTION
🎯 **What:** The `loadSettings` suspend function within `SettingsViewModel` lacked exhaustive test coverage, leaving the state mapping logic unverified.
📊 **Coverage:** A new test `testLoadSettings_loadsAllProperties` has been added. It systematically mocks all relevant properties on `AuthManager` (`getBaseUrl`, `getToken`, `isAutoReconnect`, `getThemePreference`, `isUseDynamicColors`, `getThemePreset`, `isTypingEffectEnabled`, `getTypingEffectDelayMs`, `getConnectionProfiles`, `getAppLanguage`) and validates that the `uiState` perfectly reflects these exact mock values after `loadSettings` completes execution.
✨ **Result:** Test coverage for `SettingsViewModel` is substantially improved. The robust assertion of all loaded properties acts as a safety net against accidental property drops or mapping errors during future refactoring.

---
*PR created automatically by Jules for task [165915487064829862](https://jules.google.com/task/165915487064829862) started by @Hy4ri*