### PR TITLE
feat(ui): redesign history prune button and compact search bar

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/common/SharedComponents.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/common/SharedComponents.kt
@@ -1,17 +1,21 @@
 package com.m57.hermescontrol.ui.common
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
@@ -21,7 +25,6 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -34,6 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.m57.hermescontrol.R
 import com.m57.hermescontrol.theme.LocalHermesStatusColors
@@ -201,30 +205,60 @@ fun SearchBar(
     modifier: Modifier = Modifier,
     placeholder: String = "Search…",
 ) {
-    OutlinedTextField(
+    val textColor = MaterialTheme.colorScheme.onSurface
+    BasicTextField(
         value = query,
         onValueChange = onQueryChange,
-        modifier = modifier.fillMaxWidth(),
-        placeholder = { Text(placeholder) },
-        leadingIcon = {
-            Icon(
-                imageVector = Icons.Filled.Search,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        },
-        trailingIcon = {
-            if (query.isNotEmpty()) {
-                IconButton(onClick = { onQueryChange("") }) {
-                    Icon(
-                        imageVector = Icons.Filled.Close,
-                        contentDescription = stringResource(R.string.content_desc_clear_search),
-                    )
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(40.dp)
+                .background(
+                    color = MaterialTheme.colorScheme.surfaceContainer,
+                    shape = RoundedCornerShape(12.dp),
+                ).border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+                    shape = RoundedCornerShape(12.dp),
+                ).padding(horizontal = 12.dp),
+        singleLine = true,
+        textStyle = MaterialTheme.typography.bodyMedium.copy(color = textColor),
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+        decorationBox = { innerTextField ->
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Search,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp),
+                )
+                Box(modifier = Modifier.weight(1f)) {
+                    if (query.isEmpty()) {
+                        Text(
+                            text = placeholder,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                        )
+                    }
+                    innerTextField()
+                }
+                if (query.isNotEmpty()) {
+                    IconButton(
+                        onClick = { onQueryChange("") },
+                        modifier = Modifier.size(20.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Close,
+                            contentDescription = stringResource(R.string.content_desc_clear_search),
+                            modifier = Modifier.size(16.dp),
+                        )
+                    }
                 }
             }
         },
-        singleLine = true,
-        shape = RoundedCornerShape(12.dp),
     )
 }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
@@ -14,9 +14,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -607,6 +609,7 @@ fun SessionsScreen(
                                 modifier =
                                     Modifier
                                         .fillMaxWidth()
+                                        .height(IntrinsicSize.Max)
                                         .padding(horizontal = spacing.md, vertical = spacing.sm),
                                 horizontalArrangement = Arrangement.spacedBy(spacing.sm),
                             ) {
@@ -614,18 +617,18 @@ fun SessionsScreen(
                                     label = stringResource(R.string.sessions_stat_total),
                                     value = if (state.isLoadingStats) "…" else state.stats.total.toString(),
                                     icon = Icons.Filled.History,
-                                    modifier = Modifier.weight(1f),
+                                    modifier = Modifier.weight(1f).fillMaxHeight(),
                                 )
                                 StatCard(
                                     label = stringResource(R.string.sessions_stat_active),
                                     value = if (state.isLoadingStats) "…" else state.stats.active.toString(),
                                     icon = Icons.Filled.CheckCircle,
                                     accentColor = statusColors.success,
-                                    modifier = Modifier.weight(1f),
+                                    modifier = Modifier.weight(1f).fillMaxHeight(),
                                 )
                                 // Prune button card
                                 Card(
-                                    modifier = Modifier.weight(1f),
+                                    modifier = Modifier.weight(1f).fillMaxHeight(),
                                     colors =
                                         CardDefaults.cardColors(
                                             containerColor = MaterialTheme.colorScheme.surfaceContainer,
@@ -633,7 +636,7 @@ fun SessionsScreen(
                                     onClick = { viewModel.showPruneDialog() },
                                 ) {
                                     Box(
-                                        modifier = Modifier.padding(spacing.md),
+                                        modifier = Modifier.fillMaxSize().padding(spacing.md),
                                         contentAlignment = Alignment.Center,
                                     ) {
                                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -646,8 +649,9 @@ fun SessionsScreen(
                                             Spacer(modifier = Modifier.height(spacing.xs))
                                             Text(
                                                 text = stringResource(R.string.sessions_action_prune),
-                                                style = MaterialTheme.typography.labelSmall,
+                                                style = MaterialTheme.typography.labelMedium,
                                                 color = statusColors.warning,
+                                                fontWeight = FontWeight.SemiBold,
                                             )
                                         }
                                     }


### PR DESCRIPTION
## Summary
- Equalized Prune action card height and width with Total and Active stat cards in History tab.
- Made search input bar compact (40.dp height) with clean container styling and icons.

## Changes
- `SessionsScreen.kt`: Applied `.height(IntrinsicSize.Max)` to stats row and `.fillMaxHeight()` / `.fillMaxSize()` to all 3 stat cards.
- `SharedComponents.kt`: Updated `SearchBar` to use compact `BasicTextField` with 40.dp container height and padding.