### PR TITLE
fix(cron): remove double-stacked top padding in cron editor dialog

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/cron/CronJobsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/cron/CronJobsScreen.kt
@@ -350,14 +350,13 @@ fun CronJobEditorDialog(
                 },
             ) { padding ->
                 if (state.isLoading) {
-                    LoadingState()
+                    LoadingState(modifier = Modifier.padding(padding))
                 } else {
                     Column(
                         modifier =
                             Modifier
                                 .fillMaxSize()
-                                .padding(padding)
-                                .padding(horizontal = 16.dp)
+                                .padding(horizontal = 16.dp, vertical = 16.dp)
                                 .verticalScroll(rememberScrollState()),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {


### PR DESCRIPTION
## Summary
- Removed double-stacked top padding inside `CronJobEditorDialog` by removing redundant `.padding(padding)` from the dialog's content column inside `HermesScaffold`.

## Changes
- `CronJobsScreen.kt`: Removed `.padding(padding)` from Column modifier and passed modifier to `LoadingState()`.