### PR TITLE
feat(skills): redesign view mode switcher and fix status filter alignment & card padding

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -33,11 +33,15 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -82,6 +86,7 @@ import com.m57.hermescontrol.ui.common.toDetailRows
 
 internal const val CATEGORY_ALL = "All"
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SkillsScreen(
     modifier: Modifier = Modifier,
@@ -116,20 +121,26 @@ fun SkillsScreen(
             modifier = Modifier.fillMaxSize(),
         ) {
             // ── View mode tabs ──────────────────────────────────────
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            SingleChoiceSegmentedButtonRow(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
             ) {
-                FilterChip(
+                SegmentedButton(
                     selected = state.viewMode == SkillsViewMode.INSTALLED,
                     onClick = { viewModel.setViewMode(SkillsViewMode.INSTALLED) },
-                    label = { Text(stringResource(R.string.skills_mode_installed)) },
-                )
-                FilterChip(
+                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                ) {
+                    Text(stringResource(R.string.skills_mode_installed))
+                }
+                SegmentedButton(
                     selected = state.viewMode == SkillsViewMode.HUB,
                     onClick = { viewModel.setViewMode(SkillsViewMode.HUB) },
-                    label = { Text(stringResource(R.string.skills_mode_hub)) },
-                )
+                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                ) {
+                    Text(stringResource(R.string.skills_mode_hub))
+                }
             }
 
             when (state.viewMode) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol.ui.skills
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -391,18 +392,19 @@ private fun SkillCard(
     onClick: () -> Unit,
 ) {
     Card(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).clickable(onClick = onClick),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp).clickable(onClick = onClick),
         colors =
             CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface,
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
             ),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(
-                modifier = Modifier.weight(1f).padding(16.dp),
+                modifier = Modifier.weight(1f).padding(horizontal = 12.dp, vertical = 10.dp),
             ) {
                 // ── Top row: name + source badge + toggle ──
                 Row(
@@ -682,14 +684,15 @@ private fun HubSkillCard(
     onClick: () -> Unit,
 ) {
     Card(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).clickable(onClick = onClick),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp).clickable(onClick = onClick),
         colors =
             CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface,
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
             ),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
         ) {
             // ── Top row: name ──
             Text(

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -82,7 +81,6 @@ import com.m57.hermescontrol.ui.common.NavIcon
 import com.m57.hermescontrol.ui.common.SearchBar
 import com.m57.hermescontrol.ui.common.SkeletonListState
 import com.m57.hermescontrol.ui.common.ToastEffect
-import com.m57.hermescontrol.ui.common.listContentPadding
 import com.m57.hermescontrol.ui.common.listItemSpacing
 import com.m57.hermescontrol.ui.common.toDetailRows
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -126,7 +127,7 @@ fun SkillsScreen(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                        .padding(horizontal = 8.dp, vertical = 6.dp),
             ) {
                 SegmentedButton(
                     selected = state.viewMode == SkillsViewMode.INSTALLED,
@@ -273,18 +274,23 @@ private fun InstalledSkillsView(
             query = query,
             onQueryChange = onQueryChange,
             placeholder = stringResource(R.string.skills_search_placeholder),
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
         )
 
         FilterChipRow(
-            chips =
-                listOf(
-                    SkillFilter.ALL_STATUSES,
-                    SkillFilter.ENABLED,
-                    SkillFilter.DISABLED,
-                ),
+            chips = SkillFilter.entries.toList(),
             selectedChip = selectedStatus,
             onChipSelected = onStatusChange,
-            chipLabel = { chip -> Text(stringResource(chip.labelRes)) },
+            chipLabel = { chip ->
+                Text(
+                    text =
+                        if (chip == SkillFilter.ALL_STATUSES) {
+                            stringResource(R.string.skills_category_all)
+                        } else {
+                            stringResource(chip.labelRes)
+                        },
+                )
+            },
         )
 
         if (categories.isNotEmpty() || sources.isNotEmpty()) {
@@ -294,31 +300,17 @@ private fun InstalledSkillsView(
                 onChipSelected = onCategoryChange,
             )
             if (sources.isNotEmpty()) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 2.dp),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    FilterChip(
-                        selected = sourceFilter == null,
-                        onClick = { onSetSourceFilter(null) },
-                        label = {
-                            Text(
-                                stringResource(R.string.skills_source_all),
-                                style = MaterialTheme.typography.labelSmall,
-                            )
-                        },
-                    )
-                    sources.forEach { source ->
-                        FilterChip(
-                            selected = sourceFilter == source,
-                            onClick = { onSetSourceFilter(if (sourceFilter == source) null else source) },
-                            label = { Text(source, style = MaterialTheme.typography.labelSmall) },
+                FilterChipRow(
+                    chips = listOf<String?>(null) + sources,
+                    selectedChip = sourceFilter,
+                    onChipSelected = onSetSourceFilter,
+                    chipLabel = { source ->
+                        Text(
+                            text = source ?: stringResource(R.string.skills_source_all),
+                            style = MaterialTheme.typography.labelSmall,
                         )
-                    }
-                }
+                    },
+                )
             }
         }
 
@@ -345,7 +337,8 @@ private fun InstalledSkillsView(
 
             else -> {
                 LazyColumn(
-                    modifier = Modifier.padding(listContentPadding),
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
                     verticalArrangement = listItemSpacing,
                 ) {
                     itemsIndexed(
@@ -404,7 +397,7 @@ private fun SkillCard(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(
-                modifier = Modifier.weight(1f).padding(horizontal = 12.dp, vertical = 10.dp),
+                modifier = Modifier.weight(1f).padding(horizontal = 8.dp, vertical = 8.dp),
             ) {
                 // ── Top row: name + source badge + toggle ──
                 Row(
@@ -554,7 +547,7 @@ private fun HubBrowseView(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
+                    .padding(horizontal = 8.dp, vertical = 6.dp),
             placeholder = { Text(stringResource(R.string.skills_hub_search_placeholder)) },
             trailingIcon = {
                 Row(
@@ -616,7 +609,8 @@ private fun HubBrowseView(
 
             state.hubResults.isNotEmpty() -> {
                 LazyColumn(
-                    modifier = Modifier.weight(1f).padding(listContentPadding),
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
                     verticalArrangement = listItemSpacing,
                 ) {
                     itemsIndexed(
@@ -692,7 +686,7 @@ private fun HubSkillCard(
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 8.dp),
         ) {
             // ── Top row: name ──
             Text(

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -274,25 +274,17 @@ private fun InstalledSkillsView(
             placeholder = stringResource(R.string.skills_search_placeholder),
         )
 
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 4.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            FilterChipRow(
-                chips =
-                    listOf(
-                        SkillFilter.ALL_STATUSES,
-                        SkillFilter.ENABLED,
-                        SkillFilter.DISABLED,
-                    ),
-                selectedChip = selectedStatus,
-                onChipSelected = onStatusChange,
-                chipLabel = { chip -> Text(stringResource(chip.labelRes)) },
-            )
-        }
+        FilterChipRow(
+            chips =
+                listOf(
+                    SkillFilter.ALL_STATUSES,
+                    SkillFilter.ENABLED,
+                    SkillFilter.DISABLED,
+                ),
+            selectedChip = selectedStatus,
+            onChipSelected = onStatusChange,
+            chipLabel = { chip -> Text(stringResource(chip.labelRes)) },
+        )
 
         if (categories.isNotEmpty() || sources.isNotEmpty()) {
             FilterChipRow(

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -75,7 +76,7 @@ internal fun HubBrowseView(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
+                    .padding(horizontal = 8.dp, vertical = 6.dp),
             placeholder = { Text(stringResource(R.string.skills_hub_search_placeholder)) },
             trailingIcon = {
                 Row(
@@ -140,7 +141,7 @@ internal fun HubBrowseView(
             state.hubResults.isNotEmpty() -> {
                 LazyColumn(
                     modifier = Modifier.weight(1f),
-                    contentPadding = listContentPadding,
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
                     verticalArrangement = listItemSpacing,
                 ) {
                     itemsIndexed(
@@ -214,7 +215,7 @@ private fun HubSkillCard(
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 8.dp),
         ) {
             // ── Top row: name + source badge ──
             Row(

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol.ui.skills.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -208,11 +209,12 @@ private fun HubSkillCard(
         modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
         colors =
             CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface,
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
             ),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
     ) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
         ) {
             // ── Top row: name + source badge ──
             Row(

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
@@ -4,12 +4,12 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -51,7 +51,6 @@ import com.m57.hermescontrol.ui.common.DetailRow
 import com.m57.hermescontrol.ui.common.EmptyState
 import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.SkeletonListState
-import com.m57.hermescontrol.ui.common.listContentPadding
 import com.m57.hermescontrol.ui.common.listItemSpacing
 import com.m57.hermescontrol.ui.skills.SkillsUiState
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/HubSkillsTab.kt
@@ -138,7 +138,8 @@ internal fun HubBrowseView(
 
             state.hubResults.isNotEmpty() -> {
                 LazyColumn(
-                    modifier = Modifier.weight(1f).padding(listContentPadding),
+                    modifier = Modifier.weight(1f),
+                    contentPadding = listContentPadding,
                     verticalArrangement = listItemSpacing,
                 ) {
                     itemsIndexed(
@@ -204,7 +205,7 @@ private fun HubSkillCard(
     onClick: () -> Unit,
 ) {
     Card(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).clickable(onClick = onClick),
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
         colors =
             CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surface,

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
@@ -122,22 +122,21 @@ internal fun InstalledSkillsView(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
         )
 
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 4.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            SkillFilter.entries.forEach { filter ->
-                FilterChip(
-                    selected = selectedStatus == filter,
-                    onClick = { onStatusChange(filter) },
-                    label = { Text(stringResource(filter.labelRes)) },
+        FilterChipRow(
+            chips = SkillFilter.entries.toList(),
+            selectedChip = selectedStatus,
+            onChipSelected = onStatusChange,
+            chipLabel = { chip ->
+                Text(
+                    text =
+                        if (chip == SkillFilter.ALL_STATUSES) {
+                            stringResource(R.string.skills_category_all)
+                        } else {
+                            stringResource(chip.labelRes)
+                        },
                 )
-            }
-        }
+            },
+        )
 
         if (categories.isNotEmpty() || sources.isNotEmpty()) {
             FilterChipRow(

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
@@ -119,7 +119,7 @@ internal fun InstalledSkillsView(
             query = query,
             onQueryChange = onQueryChange,
             placeholder = stringResource(R.string.skills_search_placeholder),
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
         )
 
         FilterChipRow(

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol.ui.skills.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -231,15 +232,16 @@ private fun SkillCard(
         modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
         colors =
             CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface,
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
             ),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(
-                modifier = Modifier.weight(1f).padding(16.dp),
+                modifier = Modifier.weight(1f).padding(horizontal = 12.dp, vertical = 10.dp),
             ) {
                 // ── Top row: name + source badge + toggle ──
                 Row(

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
@@ -5,12 +5,12 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -25,7 +25,6 @@ import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -57,7 +56,6 @@ import com.m57.hermescontrol.ui.common.LoadingState
 import com.m57.hermescontrol.ui.common.NavIcon
 import com.m57.hermescontrol.ui.common.SearchBar
 import com.m57.hermescontrol.ui.common.SkeletonListState
-import com.m57.hermescontrol.ui.common.listContentPadding
 import com.m57.hermescontrol.ui.common.listItemSpacing
 import com.m57.hermescontrol.ui.common.toDetailRows
 import com.m57.hermescontrol.ui.skills.CATEGORY_ALL

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
@@ -23,10 +23,14 @@ import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -121,17 +125,23 @@ internal fun InstalledSkillsView(
             placeholder = stringResource(R.string.skills_search_placeholder),
         )
 
-        FilterChipRow(
-            chips =
-                listOf(
-                    SkillFilter.ALL_STATUSES,
-                    SkillFilter.ENABLED,
-                    SkillFilter.DISABLED,
-                ),
-            selectedChip = selectedStatus,
-            onChipSelected = onStatusChange,
-            chipLabel = { chip -> Text(stringResource(chip.labelRes)) },
-        )
+        @OptIn(ExperimentalMaterial3Api::class)
+        SingleChoiceSegmentedButtonRow(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 4.dp),
+        ) {
+            SkillFilter.entries.forEachIndexed { index, filter ->
+                SegmentedButton(
+                    selected = selectedStatus == filter,
+                    onClick = { onStatusChange(filter) },
+                    shape = SegmentedButtonDefaults.itemShape(index = index, count = SkillFilter.entries.size),
+                ) {
+                    Text(stringResource(filter.labelRes))
+                }
+            }
+        }
 
         if (categories.isNotEmpty() || sources.isNotEmpty()) {
             FilterChipRow(

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
@@ -121,25 +121,17 @@ internal fun InstalledSkillsView(
             placeholder = stringResource(R.string.skills_search_placeholder),
         )
 
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 4.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            FilterChipRow(
-                chips =
-                    listOf(
-                        SkillFilter.ALL_STATUSES,
-                        SkillFilter.ENABLED,
-                        SkillFilter.DISABLED,
-                    ),
-                selectedChip = selectedStatus,
-                onChipSelected = onStatusChange,
-                chipLabel = { chip -> Text(stringResource(chip.labelRes)) },
-            )
-        }
+        FilterChipRow(
+            chips =
+                listOf(
+                    SkillFilter.ALL_STATUSES,
+                    SkillFilter.ENABLED,
+                    SkillFilter.DISABLED,
+                ),
+            selectedChip = selectedStatus,
+            onChipSelected = onStatusChange,
+            chipLabel = { chip -> Text(stringResource(chip.labelRes)) },
+        )
 
         if (categories.isNotEmpty() || sources.isNotEmpty()) {
             FilterChipRow(
@@ -197,7 +189,8 @@ internal fun InstalledSkillsView(
 
             else -> {
                 LazyColumn(
-                    modifier = Modifier.padding(listContentPadding),
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = listContentPadding,
                     verticalArrangement = listItemSpacing,
                 ) {
                     itemsIndexed(
@@ -244,7 +237,7 @@ private fun SkillCard(
     onClick: () -> Unit,
 ) {
     Card(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).clickable(onClick = onClick),
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
         colors =
             CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surface,

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
@@ -122,17 +122,22 @@ internal fun InstalledSkillsView(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
         )
 
-        FilterChipRow(
-            chips =
-                listOf(
-                    SkillFilter.ALL_STATUSES,
-                    SkillFilter.ENABLED,
-                    SkillFilter.DISABLED,
-                ),
-            selectedChip = selectedStatus,
-            onChipSelected = onStatusChange,
-            chipLabel = { chip -> Text(stringResource(chip.labelRes)) },
-        )
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            SkillFilter.entries.forEach { filter ->
+                FilterChip(
+                    selected = selectedStatus == filter,
+                    onClick = { onStatusChange(filter) },
+                    label = { Text(stringResource(filter.labelRes)) },
+                )
+            }
+        }
 
         if (categories.isNotEmpty() || sources.isNotEmpty()) {
             FilterChipRow(

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
@@ -23,14 +23,10 @@ import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -123,25 +119,20 @@ internal fun InstalledSkillsView(
             query = query,
             onQueryChange = onQueryChange,
             placeholder = stringResource(R.string.skills_search_placeholder),
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
         )
 
-        @OptIn(ExperimentalMaterial3Api::class)
-        SingleChoiceSegmentedButtonRow(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 4.dp),
-        ) {
-            SkillFilter.entries.forEachIndexed { index, filter ->
-                SegmentedButton(
-                    selected = selectedStatus == filter,
-                    onClick = { onStatusChange(filter) },
-                    shape = SegmentedButtonDefaults.itemShape(index = index, count = SkillFilter.entries.size),
-                ) {
-                    Text(stringResource(filter.labelRes))
-                }
-            }
-        }
+        FilterChipRow(
+            chips =
+                listOf(
+                    SkillFilter.ALL_STATUSES,
+                    SkillFilter.ENABLED,
+                    SkillFilter.DISABLED,
+                ),
+            selectedChip = selectedStatus,
+            onChipSelected = onStatusChange,
+            chipLabel = { chip -> Text(stringResource(chip.labelRes)) },
+        )
 
         if (categories.isNotEmpty() || sources.isNotEmpty()) {
             FilterChipRow(
@@ -150,31 +141,17 @@ internal fun InstalledSkillsView(
                 onChipSelected = onCategoryChange,
             )
             if (sources.isNotEmpty()) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 2.dp),
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    FilterChip(
-                        selected = sourceFilter == null,
-                        onClick = { onSetSourceFilter(null) },
-                        label = {
-                            Text(
-                                stringResource(R.string.skills_source_all),
-                                style = MaterialTheme.typography.labelSmall,
-                            )
-                        },
-                    )
-                    sources.forEach { source ->
-                        FilterChip(
-                            selected = sourceFilter == source,
-                            onClick = { onSetSourceFilter(if (sourceFilter == source) null else source) },
-                            label = { Text(source, style = MaterialTheme.typography.labelSmall) },
+                FilterChipRow(
+                    chips = listOf<String?>(null) + sources,
+                    selectedChip = sourceFilter,
+                    onChipSelected = onSetSourceFilter,
+                    chipLabel = { source ->
+                        Text(
+                            text = source ?: stringResource(R.string.skills_source_all),
+                            style = MaterialTheme.typography.labelSmall,
                         )
-                    }
-                }
+                    },
+                )
             }
         }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/components/InstalledSkillsTab.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -120,7 +121,7 @@ internal fun InstalledSkillsView(
             query = query,
             onQueryChange = onQueryChange,
             placeholder = stringResource(R.string.skills_search_placeholder),
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
         )
 
         FilterChipRow(
@@ -181,8 +182,8 @@ internal fun InstalledSkillsView(
 
             else -> {
                 LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = listContentPadding,
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 8.dp),
                     verticalArrangement = listItemSpacing,
                 ) {
                     itemsIndexed(
@@ -241,7 +242,7 @@ private fun SkillCard(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(
-                modifier = Modifier.weight(1f).padding(horizontal = 12.dp, vertical = 10.dp),
+                modifier = Modifier.weight(1f).padding(horizontal = 8.dp, vertical = 8.dp),
             ) {
                 // ── Top row: name + source badge + toggle ──
                 Row(


### PR DESCRIPTION
## Summary
- Upgraded view mode switcher (`Installed` vs `Hub`) to an M3 `SingleChoiceSegmentedButtonRow`.
- Fixed status filter chips alignment (`All Statuses`, `Enabled`, `Disabled`) by removing redundant outer row padding wrapper.
- Cleaned up double horizontal padding (32dp -> 16dp) on `SkillCard` and `HubSkillCard` by properly setting `contentPadding` on `LazyColumn`.

## Changes
- `SkillsScreen.kt`: Switched `Installed` vs `Hub` chips to `SingleChoiceSegmentedButtonRow` + `SegmentedButton`.
- `InstalledSkillsTab.kt`: Aligned status filter chips with 16dp screen edge and fixed card padding.
- `HubSkillsTab.kt`: Fixed `LazyColumn` `contentPadding` and card width margins.