### PR TITLE
fix(mcp): stop Restart button label from being cut off

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -429,6 +430,7 @@ private fun ServerCard(
                 FilledTonalButton(
                     onClick = { viewModel.testServer(server.name) },
                     modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 10.dp),
                 ) {
                     Icon(Icons.Filled.Science, contentDescription = null, modifier = Modifier.size(16.dp))
                     Spacer(modifier = Modifier.width(spacing.xs))
@@ -437,6 +439,7 @@ private fun ServerCard(
                 FilledTonalButton(
                     onClick = { viewModel.restartServer(server.name) },
                     modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 10.dp),
                 ) {
                     Icon(Icons.Filled.RestartAlt, contentDescription = null, modifier = Modifier.size(16.dp))
                     Spacer(modifier = Modifier.width(spacing.xs))


### PR DESCRIPTION
## Summary
- MCP server cards put Test + Restart in equal-weight half-width `FilledTonalButton`s with icons
- Default Material3 content padding is 24dp horizontal, so the longer **Restart** label was getting clipped
- Tighten both action buttons to `PaddingValues(horizontal = 12.dp, vertical = 10.dp)` so the full word shows

## Test plan
- [x] Local `./gradlew :app:compileDebugKotlin ktlintCheck` green
- [ ] Open MCP tab on device → installed server card shows full **Restart** (not cut off)
- [ ] Test + Restart + delete still tappable
- [ ] CI green