### PR TITLE
fix(mcp): make Add Server + Catalog headers read distinctly from buttons

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -67,7 +68,6 @@ import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.HermesScaffold
 import com.m57.hermescontrol.ui.common.NavIcon
 import com.m57.hermescontrol.ui.common.SearchBar
-import com.m57.hermescontrol.ui.common.SectionHeader
 import com.m57.hermescontrol.ui.common.SkeletonListState
 import com.m57.hermescontrol.ui.common.StatusBadge
 import com.m57.hermescontrol.ui.common.StatusBadgeType
@@ -205,6 +205,42 @@ fun McpServersScreen(
     }
 }
 
+// ── Section header (MCP-specific: distinct icon + neutral title so it reads
+// as a header, not a button) ──────────────────────────────────────────────
+@Composable
+private fun McpSectionHeader(
+    icon: ImageVector,
+    title: String,
+    trailing: (@Composable () -> Unit)? = null,
+) {
+    val spacing = LocalSpacing.current
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = spacing.md, vertical = spacing.sm),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.width(spacing.sm))
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+        trailing?.invoke()
+    }
+}
+
 // ── Sections ──────────────────────────────────────────────────────
 
 @Composable
@@ -213,7 +249,8 @@ private fun AddServerSection(
     viewModel: McpServersViewModel,
     spacing: com.m57.hermescontrol.theme.Spacing,
 ) {
-    SectionHeader(
+    McpSectionHeader(
+        icon = Icons.Filled.Add,
         title = stringResource(R.string.mcp_servers_add_server),
         trailing = {
             TextButton(onClick = { viewModel.toggleAddForm() }) {
@@ -569,7 +606,8 @@ private fun CatalogSection(
 ) {
     val catalogExpanded = remember { mutableStateOf(false) }
 
-    SectionHeader(
+    McpSectionHeader(
+        icon = Icons.Filled.Storage,
         title = stringResource(R.string.mcp_servers_section_catalog),
         trailing = {
             TextButton(onClick = {

--- a/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/mcp/McpServersScreen.kt
@@ -1,6 +1,7 @@
 package com.m57.hermescontrol.ui.mcp
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -16,6 +17,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -25,6 +27,7 @@ import androidx.compose.material.icons.filled.RestartAlt
 import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -218,7 +221,10 @@ private fun McpSectionHeader(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(horizontal = spacing.md, vertical = spacing.sm),
+                .background(
+                    color = MaterialTheme.colorScheme.surfaceContainerLow,
+                    shape = RoundedCornerShape(12.dp),
+                ).padding(horizontal = spacing.md, vertical = spacing.sm),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -253,7 +259,14 @@ private fun AddServerSection(
         icon = Icons.Filled.Add,
         title = stringResource(R.string.mcp_servers_add_server),
         trailing = {
-            TextButton(onClick = { viewModel.toggleAddForm() }) {
+            TextButton(
+                onClick = { viewModel.toggleAddForm() },
+                colors =
+                    ButtonDefaults.textButtonColors(
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    ),
+            ) {
                 Text(if (state.showAddForm) "Hide" else "New")
             }
         },
@@ -610,12 +623,19 @@ private fun CatalogSection(
         icon = Icons.Filled.Storage,
         title = stringResource(R.string.mcp_servers_section_catalog),
         trailing = {
-            TextButton(onClick = {
-                catalogExpanded.value = !catalogExpanded.value
-                if (catalogExpanded.value && state.catalogEntries.isEmpty() && !state.catalogLoading) {
-                    viewModel.loadCatalog()
-                }
-            }) {
+            TextButton(
+                onClick = {
+                    catalogExpanded.value = !catalogExpanded.value
+                    if (catalogExpanded.value && state.catalogEntries.isEmpty() && !state.catalogLoading) {
+                        viewModel.loadCatalog()
+                    }
+                },
+                colors =
+                    ButtonDefaults.textButtonColors(
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    ),
+            ) {
                 Text(if (catalogExpanded.value) "Hide" else "Browse")
             }
         },


### PR DESCRIPTION
## Summary
- Both MCP section headers reused the shared `SectionHeader`, which paints the title in `primary` + bold — so the "Add Server" / "Catalog" rows looked like tappable buttons sitting next to their trailing `TextButton` ("New" / "Browse").
- Add a scoped `McpSectionHeader` with a **distinct leading icon** per section (➕ `Icons.Filled.Add` for Add Server, 🗄 `Icons.Filled.Storage` for Catalog) and a **neutral `onSurface` bold** title (instead of `primary`), so they clearly read as section headers and look different from each other.
- Scoped to `McpServersScreen.kt` — the shared `SectionHeader` is untouched, so other screens keep their current look.

## Test plan
- [x] Local `./gradlew :app:compileDebugKotlin ktlintCheck` green
- [x] Open MCP tab → "Add Server" header shows ➕, "Catalog" header shows 🗄, neither looks like a button
- [x] Trailing New/Browse still works
- [x] CI green