### PR TITLE
fix(settings): clarify active saved profile contrast and border

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/theme/presets/CatppuccinScheme.kt
+++ b/app/src/main/java/com/m57/hermescontrol/theme/presets/CatppuccinScheme.kt
@@ -49,8 +49,8 @@ val CatppuccinLightColorScheme =
     lightColorScheme(
         primary = Color(0xFF8839EF), // Mauve
         onPrimary = Color(0xFFEFF1F5), // Base
-        primaryContainer = Color(0xFFCCD0DA), // Surface 0
-        onPrimaryContainer = Color(0xFF4C4F69), // Text
+        primaryContainer = Color(0xFFE6CAFA), // Light Mauve Container
+        onPrimaryContainer = Color(0xFF380075),
         inversePrimary = Color(0xFFCBA6F7), // Mocha Mauve
         secondary = Color(0xFF1E66F5), // Blue
         onSecondary = Color(0xFFEFF1F5), // Base

--- a/app/src/main/java/com/m57/hermescontrol/theme/presets/MonochromeScheme.kt
+++ b/app/src/main/java/com/m57/hermescontrol/theme/presets/MonochromeScheme.kt
@@ -10,7 +10,7 @@ val MonochromeDarkColorScheme =
     darkColorScheme(
         primary = Color.White,
         onPrimary = Color.Black,
-        primaryContainer = Color(0xFF2B2B2B),
+        primaryContainer = Color(0xFF404040),
         onPrimaryContainer = Color.White,
         inversePrimary = Color(0xFF121212),
         secondary = Color(0xFFB0B0B0),
@@ -49,7 +49,7 @@ val MonochromeLightColorScheme =
     lightColorScheme(
         primary = Color.Black,
         onPrimary = Color.White,
-        primaryContainer = Color(0xFFE0E0E0),
+        primaryContainer = Color(0xFFC8C8C8),
         onPrimaryContainer = Color.Black,
         inversePrimary = Color(0xFFE0E0E0),
         secondary = Color(0xFF4A4A4A),

--- a/app/src/main/java/com/m57/hermescontrol/ui/settings/components/ConnectionSection.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/settings/components/ConnectionSection.kt
@@ -3,6 +3,7 @@ package com.m57.hermescontrol.ui.settings.components
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -69,11 +70,17 @@ internal fun ConnectionSection(
                         CardDefaults.cardColors(
                             containerColor =
                                 if (isActive) {
-                                    MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f)
+                                    MaterialTheme.colorScheme.primaryContainer
                                 } else {
                                     MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)
                                 },
                         ),
+                    border =
+                        if (isActive) {
+                            BorderStroke(1.5.dp, MaterialTheme.colorScheme.primary)
+                        } else {
+                            BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
+                        },
                     elevation = CardDefaults.cardElevation(0.dp),
                 ) {
                     Row(
@@ -83,13 +90,27 @@ internal fun ConnectionSection(
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
                                 text = profile.name,
-                                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                                style =
+                                    MaterialTheme.typography.bodyMedium.copy(
+                                        fontWeight = if (isActive) FontWeight.Bold else FontWeight.Medium,
+                                    ),
+                                color =
+                                    if (isActive) {
+                                        MaterialTheme.colorScheme.onPrimaryContainer
+                                    } else {
+                                        MaterialTheme.colorScheme.onSurface
+                                    },
                             )
                             Text(
                                 text = profile.resolveBaseUrl(state.baseUrl),
                                 style =
                                     MaterialTheme.typography.bodySmall.copy(
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        color =
+                                            if (isActive) {
+                                                MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                                            } else {
+                                                MaterialTheme.colorScheme.onSurfaceVariant
+                                            },
                                     ),
                             )
                         }
@@ -101,6 +122,12 @@ internal fun ConnectionSection(
                                     imageVector = Icons.Filled.Edit,
                                     contentDescription = stringResource(R.string.settings_action_edit_profile),
                                     modifier = Modifier.size(18.dp),
+                                    tint =
+                                        if (isActive) {
+                                            MaterialTheme.colorScheme.onPrimaryContainer
+                                        } else {
+                                            MaterialTheme.colorScheme.onSurfaceVariant
+                                        },
                                 )
                             }
                             IconButton(


### PR DESCRIPTION
Fixes active saved connection profile visibility in Catppuccin light mode and Monochrome light/dark modes by updating primaryContainer contrast and adding a primary border stroke.