### PR TITLE
Adopt system.battery WS method (issue #711)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/config/ServerStoreMigration.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/config/ServerStoreMigration.kt
@@ -105,10 +105,12 @@ class ServerStoreMigration(
                     profile.copy(
                         baseUrl =
                             profile.baseUrl
-                                ?: ServerEndpoint.fromLegacy(
-                                    profile.host,
-                                    profile.port,
-                                ).baseUrl.toString(),
+                                ?: ServerEndpoint
+                                    .fromLegacy(
+                                        profile.host,
+                                        profile.port,
+                                    ).baseUrl
+                                    .toString(),
                     )
                 },
             selectedProfileId = selectedProfileId,

--- a/app/src/main/java/com/m57/hermescontrol/data/config/ServerUrlMigration.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/config/ServerUrlMigration.kt
@@ -19,19 +19,23 @@ class ServerUrlMigration : DataMigration<ServerStoreState> {
             state.copy(
                 baseUrl =
                     normalizeExisting(state.baseUrl)
-                        ?: ServerEndpoint.fromLegacy(
-                            state.host,
-                            state.port,
-                        ).baseUrl.toString(),
+                        ?: ServerEndpoint
+                            .fromLegacy(
+                                state.host,
+                                state.port,
+                            ).baseUrl
+                            .toString(),
                 connectionProfiles =
                     state.connectionProfiles.map { profile ->
                         profile.copy(
                             baseUrl =
                                 normalizeExisting(profile.baseUrl)
-                                    ?: ServerEndpoint.fromLegacy(
-                                        profile.host,
-                                        profile.port,
-                                    ).baseUrl.toString(),
+                                    ?: ServerEndpoint
+                                        .fromLegacy(
+                                            profile.host,
+                                            profile.port,
+                                        ).baseUrl
+                                        .toString(),
                         )
                     },
             )

--- a/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
@@ -427,10 +427,12 @@ object AuthManager {
 
     fun setBaseUrl(baseUrl: String) {
         val normalized =
-            ServerEndpoint.parse(
-                baseUrl,
-                CleartextPolicy.ALLOW_WITH_WARNING,
-            ).baseUrl.toString()
+            ServerEndpoint
+                .parse(
+                    baseUrl,
+                    CleartextPolicy.ALLOW_WITH_WARNING,
+                ).baseUrl
+                .toString()
         val selectedId =
             getSelectedProfileId() ?: run {
                 ensureDefaultSelected()

--- a/app/src/main/java/com/m57/hermescontrol/data/model/BatteryStatus.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/BatteryStatus.kt
@@ -1,0 +1,19 @@
+package com.m57.hermescontrol.data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Host battery read-out, mirrored from the backend's `system.battery` WS method
+ * (agent.battery.read_battery on the *backend host* — not the phone).
+ *
+ * `available: false` means the backend host has no battery (desktop/server/VM)
+ * or the read failed. The UI must treat the whole payload as "render nothing"
+ * in that case.
+ */
+@Serializable
+data class BatteryStatus(
+    val available: Boolean = false,
+    val percent: Double? = null,
+    val plugged: Boolean? = null,
+    val category: String? = null,
+)

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/CookieManager.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/CookieManager.kt
@@ -81,8 +81,7 @@ object CookieManager {
                 .expiresAt(
                     System.currentTimeMillis() +
                         10L * 365 * 24 * 60 * 60 * 1000,
-                )
-                .hostOnlyDomain(endpoint.baseUrl.host)
+                ).hostOnlyDomain(endpoint.baseUrl.host)
                 .path(endpoint.baseUrl.encodedPath)
                 .httpOnly()
         if (endpoint.baseUrl.isHttps) builder.secure()

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/ServerEndpoint.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/ServerEndpoint.kt
@@ -149,7 +149,12 @@ class ServerEndpoint private constructor(
             val converted =
                 replaceScheme(rawUrl, httpScheme).toHttpUrlOrNull()
                     ?: return "<invalid-websocket-url>"
-            val redacted = converted.newBuilder().query(null).build().toString()
+            val redacted =
+                converted
+                    .newBuilder()
+                    .query(null)
+                    .build()
+                    .toString()
             return replaceScheme(redacted, socketScheme)
         }
 

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/BillingRepository.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/BillingRepository.kt
@@ -54,17 +54,39 @@ object BillingRepository {
     @Suppress("UNCHECKED_CAST")
     private fun anyToJsonElement(value: Any?): JsonElement =
         when (value) {
-            null -> JsonNull
-            is JsonElement -> value
-            is Map<*, *> ->
+            null -> {
+                JsonNull
+            }
+
+            is JsonElement -> {
+                value
+            }
+
+            is Map<*, *> -> {
                 JsonObject(
                     (value as Map<String, Any?>).mapValues { (_, v) -> anyToJsonElement(v) },
                 )
-            is List<*> -> JsonArray(value.map { anyToJsonElement(it) })
-            is String -> JsonPrimitive(value)
-            is Boolean -> JsonPrimitive(value)
-            is Number -> JsonPrimitive(value)
-            else -> JsonPrimitive(value.toString())
+            }
+
+            is List<*> -> {
+                JsonArray(value.map { anyToJsonElement(it) })
+            }
+
+            is String -> {
+                JsonPrimitive(value)
+            }
+
+            is Boolean -> {
+                JsonPrimitive(value)
+            }
+
+            is Number -> {
+                JsonPrimitive(value)
+            }
+
+            else -> {
+                JsonPrimitive(value.toString())
+            }
         }
 
     suspend fun getSubscriptionState(): SubscriptionStateResponse? {

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -79,7 +80,7 @@ object HermesWsClient {
     @Volatile
     private var currentBackoff = INITIAL_BACKOFF_MS
 
-    private val wsScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var wsScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     @Volatile
     private var reconnectJob: Job? = null
@@ -122,20 +123,36 @@ object HermesWsClient {
             onBufferOverflow = BufferOverflow.DROP_OLDEST,
         )
 
+    @Volatile
+    private var _events: SharedFlow<WsEvent>? = null
+
     /** Collect this from ViewModels to receive all parsed [WsEvent]s. */
-    val events: SharedFlow<WsEvent> =
-        rawMessages
-            .buffer(Channel.BUFFERED)
-            .map { text ->
-                try {
-                    val rpc = OkHttpProvider.json.decodeFromString<JsonRpcResponse>(text)
-                    EventParser.parse(rpc, text)
-                } catch (e: Exception) {
-                    Log.e(TAG, "Failed to parse message", e)
-                    WsEvent.Unknown(text)
+    val events: SharedFlow<WsEvent>
+        get() {
+            var current = _events
+            if (current == null) {
+                synchronized(this) {
+                    current = _events
+                    if (current == null) {
+                        current =
+                            rawMessages
+                                .buffer(Channel.BUFFERED)
+                                .map { text ->
+                                    try {
+                                        val rpc = OkHttpProvider.json.decodeFromString<JsonRpcResponse>(text)
+                                        EventParser.parse(rpc, text)
+                                    } catch (e: Exception) {
+                                        Log.e(TAG, "Failed to parse message", e)
+                                        WsEvent.Unknown(text)
+                                    }
+                                }.flowOn(Dispatchers.Default) // CPU-bound
+                                .shareIn(wsScope, SharingStarted.Eagerly)
+                        _events = current
+                    }
                 }
-            }.flowOn(Dispatchers.Default) // CPU-bound
-            .shareIn(wsScope, SharingStarted.Eagerly)
+            }
+            return current!!
+        }
 
     // ── Connection status flow ──────────────────────────────────────────
     private val _connectionStatus = MutableStateFlow(ConnectionStatus.DISCONNECTED)
@@ -157,33 +174,42 @@ object HermesWsClient {
         _credentialWarning.value = null
     }
 
-    init {
-        // Monitor network state to trigger immediate reconnect when network is restored
-        wsScope.launch {
-            NetworkMonitor.isConnected.collect { connected ->
-                if (connected && !isConnected && !intentionalClose.get() && AuthManager.isAutoReconnect()) {
-                    Log.d(TAG, "Network restored — triggering immediate reconnect")
-                    currentBackoff = INITIAL_BACKOFF_MS
-                    reconnectJob?.cancel()
-                    openSocket()
-                }
-            }
-        }
-        // Extract credential_warning from gateway.ready / session.info payloads.
-        wsScope.launch {
-            events.collect { event ->
-                val data: Map<String, Any?>? =
-                    when (event) {
-                        is WsEvent.GatewayReady -> event.data
-                        is WsEvent.SessionInfo -> event.data
-                        else -> null
+    private var networkMonitorJob: Job? = null
+    private var credentialWarningJob: Job? = null
+
+    private fun startBackgroundListeners() {
+        networkMonitorJob?.cancel()
+        networkMonitorJob =
+            wsScope.launch {
+                NetworkMonitor.isConnected.collect { connected ->
+                    if (connected && !isConnected && !intentionalClose.get() && AuthManager.isAutoReconnect()) {
+                        Log.d(TAG, "Network restored — triggering immediate reconnect")
+                        currentBackoff = INITIAL_BACKOFF_MS
+                        reconnectJob?.cancel()
+                        openSocket()
                     }
-                val warning = data?.get("credential_warning") as? String
-                if (!warning.isNullOrBlank()) {
-                    _credentialWarning.value = warning
                 }
             }
-        }
+        credentialWarningJob?.cancel()
+        credentialWarningJob =
+            wsScope.launch {
+                events.collect { event ->
+                    val data: Map<String, Any?>? =
+                        when (event) {
+                            is WsEvent.GatewayReady -> event.data
+                            is WsEvent.SessionInfo -> event.data
+                            else -> null
+                        }
+                    val warning = data?.get("credential_warning") as? String
+                    if (!warning.isNullOrBlank()) {
+                        _credentialWarning.value = warning
+                    }
+                }
+            }
+    }
+
+    init {
+        startBackgroundListeners()
     }
 
     // ── Connection helpers ────────────────────────────────────────────────
@@ -299,10 +325,17 @@ object HermesWsClient {
         reconnectJob?.cancel()
         reconnectJob = null
         stopHealthTracking()
+        rejectAllPending()
         webSocket?.close(1000, "Client closed")
         webSocket = null
         connected.set(false)
         _connectionStatus.value = ConnectionStatus.DISCONNECTED
+
+        // Re-create wsScope and events to guarantee test isolation when Dispatchers are mocked/unmocked in unit tests
+        wsScope.cancel()
+        wsScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        _events = null
+        startBackgroundListeners()
     }
 
     // ── Awaited RPC request layer (issue #526) ─────────────────────────

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
@@ -348,6 +348,10 @@ object HermesWsClient {
         timeoutMs: Long = REQUEST_TIMEOUT_MS,
     ): CompletableDeferred<Any?> {
         val deferred = CompletableDeferred<Any?>()
+        if (!connected.get()) {
+            deferred.completeExceptionally(HermesRpcException("WebSocket not connected"))
+            return deferred
+        }
         val id =
             send(method, params) { reqId ->
                 pendingCalls[reqId] = PendingCall(method, deferred)

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/SystemRepository.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/SystemRepository.kt
@@ -67,7 +67,11 @@ object SystemRepository {
         } catch (e: Exception) {
             // Fail OPEN to "no battery" on any RPC error, decode failure, or
             // timeout — never let a bad/headless payload crash the System screen.
-            if (BuildConfig.DEBUG) Log.w(TAG, "system.battery failed: ${e.message}")
+            try {
+                if (BuildConfig.DEBUG) Log.w(TAG, "system.battery failed: ${e.message}")
+            } catch (_: Throwable) {
+                // Ignore log failures in unmocked JVM unit tests
+            }
             BatteryStatus(available = false)
         }
 

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/SystemRepository.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/SystemRepository.kt
@@ -61,6 +61,7 @@ object SystemRepository {
      */
     suspend fun getBatteryStatus(): BatteryStatus =
         try {
+            if (!HermesWsClient.isConnected) return BatteryStatus(available = false)
             val result = HermesWsClient.request(WsMethods.SYSTEM_BATTERY).await()
             decode<BatteryStatus>(result) ?: BatteryStatus(available = false)
         } catch (e: Exception) {

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/SystemRepository.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/SystemRepository.kt
@@ -39,17 +39,39 @@ object SystemRepository {
     @Suppress("UNCHECKED_CAST")
     private fun anyToJsonElement(value: Any?): JsonElement =
         when (value) {
-            null -> JsonNull
-            is JsonElement -> value
-            is Map<*, *> ->
+            null -> {
+                JsonNull
+            }
+
+            is JsonElement -> {
+                value
+            }
+
+            is Map<*, *> -> {
                 JsonObject(
                     (value as Map<String, Any?>).mapValues { (_, v) -> anyToJsonElement(v) },
                 )
-            is List<*> -> JsonArray(value.map { anyToJsonElement(it) })
-            is String -> JsonPrimitive(value)
-            is Boolean -> JsonPrimitive(value)
-            is Number -> JsonPrimitive(value)
-            else -> JsonPrimitive(value.toString())
+            }
+
+            is List<*> -> {
+                JsonArray(value.map { anyToJsonElement(it) })
+            }
+
+            is String -> {
+                JsonPrimitive(value)
+            }
+
+            is Boolean -> {
+                JsonPrimitive(value)
+            }
+
+            is Number -> {
+                JsonPrimitive(value)
+            }
+
+            else -> {
+                JsonPrimitive(value.toString())
+            }
         }
 
     /**

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/SystemRepository.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/SystemRepository.kt
@@ -1,0 +1,74 @@
+package com.m57.hermescontrol.data.ws
+
+import android.util.Log
+import com.m57.hermescontrol.BuildConfig
+import com.m57.hermescontrol.data.model.BatteryStatus
+import com.m57.hermescontrol.data.remote.OkHttpProvider
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.serializer
+
+/**
+ * Client for the system WebSocket RPC surface (issue #711).
+ *
+ * Mirrors [BillingRepository]: every call returns the backend `result` payload
+ * decoded into a typed model, or throws [HermesWsClient.HermesRpcException] on
+ * an RPC error. [HermesWsClient] hands `result` back already converted via
+ * `JsonElement.toAny()` (a `Map<String, Any?>`), so [decode] normalizes both
+ * shapes before deserializing.
+ */
+object SystemRepository {
+    private val json get() = OkHttpProvider.json
+
+    @Suppress("UNCHECKED_CAST")
+    private inline fun <reified T> decode(result: Any?): T? {
+        if (result == null) return null
+        val element: JsonElement =
+            when (result) {
+                is JsonElement -> result
+                is Map<*, *> -> anyToJsonElement(result)
+                is List<*> -> JsonArray(result.map { anyToJsonElement(it) })
+                else -> JsonPrimitive(result.toString())
+            }
+        return json.decodeFromJsonElement(serializer<T>(), element)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun anyToJsonElement(value: Any?): JsonElement =
+        when (value) {
+            null -> JsonNull
+            is JsonElement -> value
+            is Map<*, *> ->
+                JsonObject(
+                    (value as Map<String, Any?>).mapValues { (_, v) -> anyToJsonElement(v) },
+                )
+            is List<*> -> JsonArray(value.map { anyToJsonElement(it) })
+            is String -> JsonPrimitive(value)
+            is Boolean -> JsonPrimitive(value)
+            is Number -> JsonPrimitive(value)
+            else -> JsonPrimitive(value.toString())
+        }
+
+    /**
+     * Fetch the backend host battery status via `system.battery`.
+     *
+     * Fails OPEN to `available: false` on any RPC error / timeout — matching the
+     * backend's own semantics, so a headless host (desktop/server/VM) is treated
+     * identically to "no battery" and the UI renders nothing.
+     */
+    suspend fun getBatteryStatus(): BatteryStatus =
+        try {
+            val result = HermesWsClient.request(WsMethods.SYSTEM_BATTERY).await()
+            decode<BatteryStatus>(result) ?: BatteryStatus(available = false)
+        } catch (e: Exception) {
+            // Fail OPEN to "no battery" on any RPC error, decode failure, or
+            // timeout — never let a bad/headless payload crash the System screen.
+            if (BuildConfig.DEBUG) Log.w(TAG, "system.battery failed: ${e.message}")
+            BatteryStatus(available = false)
+        }
+
+    private const val TAG = "SystemRepository"
+}

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/WsMethods.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/WsMethods.kt
@@ -14,6 +14,9 @@ object WsMethods {
     const val SESSION_TITLE = "session.title"
     const val SESSION_BRANCH = "session.branch"
 
+    // ── System ─────────────────────────────────────────────────────────
+    const val SYSTEM_BATTERY = "system.battery"
+
     // ── Interaction ───────────────────────────────────────────────────────
     const val PROMPT_SUBMIT = "prompt.submit"
     const val CLARIFY_RESPOND = "clarify.respond"

--- a/app/src/main/java/com/m57/hermescontrol/ui/achievements/AchievementsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/achievements/AchievementsViewModel.kt
@@ -39,7 +39,9 @@ data class AchievementsUiState(
     val toastMessage: String? = null,
 )
 
-class AchievementsViewModel : ViewModel(), ToastHost {
+class AchievementsViewModel :
+    ViewModel(),
+    ToastHost {
     private val _uiState = MutableStateFlow(AchievementsUiState())
     val uiState: StateFlow<AchievementsUiState> = _uiState.asStateFlow()
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/analytics/AnalyticsScreen.kt
@@ -211,8 +211,8 @@ private fun AnalyticsContent(
                 }
             } else if ((usage?.by_model ?: emptyList()).isNotEmpty()) {
                 itemsIndexed(usage?.by_model ?: emptyList(), key = {
-                        index,
-                        it,
+                    index,
+                    it,
                     ->
                     "usage_${it.model}_$index"
                 }) { _, entry ->
@@ -233,8 +233,8 @@ private fun AnalyticsContent(
         if (selectedSectionTab == 1) {
             if ((usage?.skills?.top_skills ?: emptyList()).isNotEmpty()) {
                 itemsIndexed(usage?.skills?.top_skills ?: emptyList(), key = {
-                        index,
-                        it,
+                    index,
+                    it,
                     ->
                     "skill_${it.skill}_$index"
                 }) { _, skill ->

--- a/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingViewModel.kt
@@ -162,11 +162,21 @@ class BillingViewModel : ViewModel() {
                     }
                     val msg =
                         when {
-                            resp.requires_action == true && resp.recovery_url != null ->
+                            resp.requires_action == true && resp.recovery_url != null -> {
                                 "Action required — open: ${resp.recovery_url}"
-                            resp.payment_failed == true -> resp.message ?: "Payment failed"
-                            resp.ok == true -> "Upgrade successful"
-                            else -> resp.message ?: "Upgrade requested"
+                            }
+
+                            resp.payment_failed == true -> {
+                                resp.message ?: "Payment failed"
+                            }
+
+                            resp.ok == true -> {
+                                "Upgrade successful"
+                            }
+
+                            else -> {
+                                resp.message ?: "Upgrade requested"
+                            }
                         }
                     _uiState.update { it.copy(isActionInFlight = false, actionMessage = msg) }
                     load()

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -1008,10 +1008,11 @@ class ChatViewModel(
                 // #576). For those we fall back to slash.exec, which runs the
                 // full COMMAND_REGISTRY through the worker.
                 val result =
-                    wsClient.request(
-                        WsMethods.COMMAND_DISPATCH,
-                        mapOf("name" to name, "arg" to arg, "session_id" to sessionId),
-                    ).await()
+                    wsClient
+                        .request(
+                            WsMethods.COMMAND_DISPATCH,
+                            mapOf("name" to name, "arg" to arg, "session_id" to sessionId),
+                        ).await()
                 handleDispatchResult(result)
             } catch (e: HermesWsClient.HermesRpcException) {
                 val msg = e.message.orEmpty()
@@ -1024,13 +1025,14 @@ class ChatViewModel(
                     // which routes the full CLI command set through the worker.
                     try {
                         val result =
-                            wsClient.request(
-                                WsMethods.SLASH_EXEC,
-                                mapOf(
-                                    "command" to "/$name${if (arg.isNotEmpty()) " $arg" else ""}",
-                                    "session_id" to sessionId,
-                                ),
-                            ).await()
+                            wsClient
+                                .request(
+                                    WsMethods.SLASH_EXEC,
+                                    mapOf(
+                                        "command" to "/$name${if (arg.isNotEmpty()) " $arg" else ""}",
+                                        "session_id" to sessionId,
+                                    ),
+                                ).await()
                         val output = (result as? Map<*, *>)?.get("output") as? String
                         if (!output.isNullOrBlank()) addAssistantMessage(output)
                     } catch (e2: HermesWsClient.HermesRpcException) {

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ComposerToolbar.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ComposerToolbar.kt
@@ -200,8 +200,8 @@ fun ComposerToolbar(
  *              "xhigh", "max", "ultra", or null for model default.
  * @return Display string such as "None", "Low", "XHigh", "Ultra", etc.
  */
-private fun buildReasoningLabel(level: String?): String {
-    return when (level) {
+private fun buildReasoningLabel(level: String?): String =
+    when (level) {
         null -> "Med"
         "none" -> "None"
         "minimal" -> "Minimal"
@@ -213,4 +213,3 @@ private fun buildReasoningLabel(level: String?): String {
         "ultra" -> "Ultra"
         else -> level
     }
-}

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/MessageCards.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/MessageCards.kt
@@ -350,7 +350,10 @@ internal fun highlightSyntax(code: String): AnnotatedString =
         }
     }
 
-private data class TokenPattern(val regex: Regex, val color: Color)
+private data class TokenPattern(
+    val regex: Regex,
+    val color: Color,
+)
 
 private fun copyToClipboard(
     context: Context,

--- a/app/src/main/java/com/m57/hermescontrol/ui/common/StateViews.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/common/StateViews.kt
@@ -207,7 +207,11 @@ private fun shimmerBrush(): Brush {
     val base = MaterialTheme.colorScheme.surfaceVariant
     val highlight = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
     val transition = rememberInfiniteTransition(label = "shimmer")
-    val widthPx = with(LocalDensity.current) { LocalConfiguration.current.screenWidthDp.dp.toPx() }
+    val widthPx =
+        with(LocalDensity.current) {
+            LocalConfiguration.current.screenWidthDp.dp
+                .toPx()
+        }
     val offset by transition.animateFloat(
         initialValue = -widthPx,
         targetValue = widthPx,

--- a/app/src/main/java/com/m57/hermescontrol/ui/model/ModelViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/ModelViewModel.kt
@@ -535,7 +535,9 @@ class ModelViewModel :
                             return@launch
                         }
 
-                        is NetworkResult.Success -> activeProfileNameResResult.data.active
+                        is NetworkResult.Success -> {
+                            activeProfileNameResResult.data.active
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/process/ProcessesViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/process/ProcessesViewModel.kt
@@ -24,7 +24,9 @@ data class ProcessesUiState(
     val sessionId: String? = null,
 )
 
-class ProcessesViewModel : ViewModel(), ToastHost {
+class ProcessesViewModel :
+    ViewModel(),
+    ToastHost {
     private val _uiState = MutableStateFlow(ProcessesUiState())
     val uiState: StateFlow<ProcessesUiState> = _uiState.asStateFlow()
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsViewModel.kt
@@ -53,7 +53,9 @@ data class SessionsUiState(
     val isSearchMode: Boolean get() = searchQuery.isNotBlank()
 }
 
-class SessionsViewModel : ViewModel(), ToastHost {
+class SessionsViewModel :
+    ViewModel(),
+    ToastHost {
     private val _uiState = MutableStateFlow(SessionsUiState())
     val uiState: StateFlow<SessionsUiState> = _uiState.asStateFlow()
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/system/SystemScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/system/SystemScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Backup
+import androidx.compose.material.icons.filled.BatteryFull
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.CloudDownload
@@ -442,6 +443,35 @@ private fun LazyListScope.hostSection(
                                 icon = Icons.Filled.Storage,
                                 modifier = Modifier.weight(1f),
                             )
+                        }
+                        state.battery?.let { batt ->
+                            // Only show a real reading. Hide on headless hosts
+                            // (available:false) and on the psutil phantom where a
+                            // server exposes a fake power_supply at exactly 0% with
+                            // no plug info — that's not a real battery.
+                            val hasRealReading =
+                                batt.available &&
+                                    batt.percent != null &&
+                                    !(batt.percent == 0.0 && batt.plugged == null)
+                            if (hasRealReading) {
+                                val plugged = batt.plugged == true
+                                val label = stringResource(R.string.system_label_battery)
+                                val value =
+                                    if (plugged) {
+                                        stringResource(
+                                            R.string.system_label_battery_plugged,
+                                            batt.percent?.toInt() ?: 0,
+                                        )
+                                    } else {
+                                        "${batt.percent?.toInt() ?: 0}%"
+                                    }
+                                StatCard(
+                                    label = label,
+                                    value = value,
+                                    icon = Icons.Filled.BatteryFull,
+                                    modifier = Modifier.weight(1f),
+                                )
+                            }
                         }
                     }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/system/SystemViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/system/SystemViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.m57.hermescontrol.BuildConfig
 import com.m57.hermescontrol.data.model.ActionResponse
 import com.m57.hermescontrol.data.model.ActionStatusResponse
+import com.m57.hermescontrol.data.model.BatteryStatus
 import com.m57.hermescontrol.data.model.CheckpointsResponse
 import com.m57.hermescontrol.data.model.CredentialPoolProvider
 import com.m57.hermescontrol.data.model.CuratorResponse
@@ -20,6 +21,7 @@ import com.m57.hermescontrol.data.model.UpdateCheckResponse
 import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.NetworkResult
 import com.m57.hermescontrol.data.remote.safeApiCall
+import com.m57.hermescontrol.data.ws.SystemRepository
 import com.m57.hermescontrol.ui.common.ToastHost
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -37,6 +39,7 @@ import kotlinx.coroutines.withContext
 data class SystemUiState(
     val isLoading: Boolean = false,
     val stats: SystemStatsResponse? = null,
+    val battery: BatteryStatus? = null,
     val portal: PortalResponse? = null,
     val curator: CuratorResponse? = null,
     val memory: MemoryResponse? = null,
@@ -81,12 +84,14 @@ class SystemViewModel :
     ToastHost {
     companion object {
         private const val TAG = "SystemViewModel"
+        private const val BATTERY_POLL_MS = 60_000L
     }
 
     private val _uiState = MutableStateFlow(SystemUiState())
     val uiState: StateFlow<SystemUiState> = _uiState.asStateFlow()
 
     private var actionPollingJob: Job? = null
+    private var batteryPollingJob: Job? = null
 
     // ── Full parallel data load ────────────────────────────────────────
 
@@ -106,6 +111,8 @@ class SystemViewModel :
                 val updateDeferred =
                     async(Dispatchers.IO) { safeApiCall { ApiClient.hermesApi.checkHermesUpdate(false) } }
                 val doctorDeferred = async(Dispatchers.IO) { safeApiCall { ApiClient.hermesApi.runDoctor() } }
+                val batteryDeferred =
+                    async(Dispatchers.IO) { SystemRepository.getBatteryStatus() }
 
                 val statsResult = statsDeferred.await()
                 val statusResult = statusDeferred.await()
@@ -117,6 +124,7 @@ class SystemViewModel :
                 val hooksResult = hooksDeferred.await()
                 val updateResult = updateDeferred.await()
                 val doctorResult = doctorDeferred.await()
+                val batteryResult = batteryDeferred.await()
 
                 _uiState.update { state ->
                     state.copy(
@@ -132,6 +140,7 @@ class SystemViewModel :
                         hooks = (hooksResult as? NetworkResult.Success)?.data,
                         updateInfo = (updateResult as? NetworkResult.Success)?.data,
                         doctorReport = (doctorResult as? NetworkResult.Success)?.data,
+                        battery = batteryResult,
                         errorMessage = null,
                     )
                 }
@@ -205,6 +214,40 @@ class SystemViewModel :
             }
         }
     }
+
+    // ── Battery (WS method `system.battery`) ──────────────────────────
+
+    /**
+     * Fetch the backend host battery once (issue #711). If a battery is present
+     * we start a periodic poll (~60s, matching the TUI idle refresh); if the
+     * host is headless (`available: false`) we never poll again — no point
+     * spamming `system.battery` on a desktop/server/VM.
+     */
+    fun loadBattery() {
+        batteryPollingJob?.cancel()
+        batteryPollingJob =
+            viewModelScope.launch {
+                val status = fetchBatteryOnce()
+                _uiState.update { it.copy(battery = status) }
+                if (status.available) {
+                    batteryPollingJob =
+                        launch {
+                            while (isActive) {
+                                delay(BATTERY_POLL_MS)
+                                val refreshed = fetchBatteryOnce()
+                                _uiState.update { it.copy(battery = refreshed) }
+                                // Stop polling if the battery disappeared (e.g. host changed).
+                                if (!refreshed.available) break
+                            }
+                        }
+                }
+            }
+    }
+
+    private suspend fun fetchBatteryOnce(): BatteryStatus =
+        withContext(Dispatchers.IO) {
+            SystemRepository.getBatteryStatus()
+        }
 
     // ── Gateway actions ────────────────────────────────────────────────
 

--- a/app/src/main/java/com/m57/hermescontrol/util/LocaleContextWrapper.kt
+++ b/app/src/main/java/com/m57/hermescontrol/util/LocaleContextWrapper.kt
@@ -25,20 +25,28 @@ object LocaleContextWrapper {
      */
     fun localeForCode(code: String): Locale =
         when {
-            code.isEmpty() || code == SYSTEM_LANGUAGE -> Locale.getDefault()
+            code.isEmpty() || code == SYSTEM_LANGUAGE -> {
+                Locale.getDefault()
+            }
+
             code.contains("-r", ignoreCase = true) -> {
                 val parts = code.split("-r", ignoreCase = true)
                 Locale(parts[0], parts.getOrElse(1) { "" })
             }
+
             code.contains("-") -> {
                 val parts = code.split("-")
                 Locale(parts[0], parts.getOrElse(1) { "" })
             }
+
             code.contains("_") -> {
                 val parts = code.split("_")
                 Locale(parts[0], parts.getOrElse(1) { "" })
             }
-            else -> Locale(code)
+
+            else -> {
+                Locale(code)
+            }
         }
 
     /**

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -267,6 +267,8 @@
     <string name="system_label_disk">디스크</string>
     <string name="system_label_uptime">가동 시간</string>
     <string name="system_label_load_avg">부하 평균</string>
+    <string name="system_label_battery">배터리</string>
+    <string name="system_label_battery_plugged">%1$d%% ⚡</string>
     <string name="system_label_cores">코어</string>
     <string name="system_label_used_total_percent">%1$s / %2$s (%3$s%%)</string>
     <string name="system_psutil_warning">CPU/메모리/디스크 정보를 보려면 psutil을 설치하세요.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -298,6 +298,8 @@
     <string name="system_label_disk">Disk</string>
     <string name="system_label_uptime">Uptime</string>
     <string name="system_label_load_avg">Load avg</string>
+    <string name="system_label_battery">Battery</string>
+    <string name="system_label_battery_plugged">%1$d%% ⚡</string>
     <string name="system_label_cores">cores</string>
     <string name="system_label_used_total_percent">%1$s / %2$s (%3$s%%)</string>
     <string name="system_psutil_warning">Install the psutil extra for CPU / memory / disk metrics.</string>

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import com.m57.hermescontrol.data.local.AuthManager
+import com.m57.hermescontrol.data.ws.HermesWsClient
 import com.m57.hermescontrol.data.model.ActionResponse
 import com.m57.hermescontrol.data.model.ActiveProfileResponse
 import com.m57.hermescontrol.data.model.AuxiliaryModelsResponse
@@ -83,7 +84,10 @@ class E2eIntegrationTest {
         mockkStatic(Dispatchers::class)
         val testMainDispatcher = Dispatchers.Main
         every { Dispatchers.IO } returns testDispatcher
+        every { Dispatchers.Default } returns testDispatcher
         every { Dispatchers.Main } returns testMainDispatcher
+
+        HermesWsClient.disconnect()
 
         mockkObject(AuthManager)
         mockkObject(ApiClient)

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import com.m57.hermescontrol.data.local.AuthManager
-import com.m57.hermescontrol.data.ws.HermesWsClient
 import com.m57.hermescontrol.data.model.ActionResponse
 import com.m57.hermescontrol.data.model.ActiveProfileResponse
 import com.m57.hermescontrol.data.model.AuxiliaryModelsResponse
@@ -48,6 +47,7 @@ import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.CleartextPolicy
 import com.m57.hermescontrol.data.remote.HermesApiService
 import com.m57.hermescontrol.data.remote.ServerEndpoint
+import com.m57.hermescontrol.data.ws.HermesWsClient
 import com.m57.hermescontrol.ui.channels.ChannelsViewModel
 import com.m57.hermescontrol.ui.connect.ConnectViewModel
 import com.m57.hermescontrol.ui.cron.CronJobsViewModel

--- a/app/src/test/java/com/m57/hermescontrol/data/local/ChatMessageMapperTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/local/ChatMessageMapperTest.kt
@@ -92,18 +92,17 @@ class ChatMessageMapperTest {
         assertNull(createEntityWithToolStatus(null).toUiModel().toolStatus)
     }
 
-    private fun createEntityWithRole(role: String): ChatMessageEntity {
-        return ChatMessageEntity(
+    private fun createEntityWithRole(role: String): ChatMessageEntity =
+        ChatMessageEntity(
             id = "id",
             sessionId = "session",
             role = role,
             content = "content",
             timestamp = 0L,
         )
-    }
 
-    private fun createEntityWithToolStatus(status: String?): ChatMessageEntity {
-        return ChatMessageEntity(
+    private fun createEntityWithToolStatus(status: String?): ChatMessageEntity =
+        ChatMessageEntity(
             id = "id",
             sessionId = "session",
             role = "TOOL",
@@ -111,7 +110,6 @@ class ChatMessageMapperTest {
             timestamp = 0L,
             toolStatus = status,
         )
-    }
 
     @Test
     fun entityToUiModelCarriesReasoningText() {

--- a/app/src/test/java/com/m57/hermescontrol/data/remote/CallExtTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/remote/CallExtTest.kt
@@ -22,7 +22,8 @@ class CallExtTest {
             val call = mockk<Call>()
             val request = Request.Builder().url("http://localhost").build()
             val response =
-                Response.Builder()
+                Response
+                    .Builder()
                     .request(request)
                     .protocol(Protocol.HTTP_1_1)
                     .code(200)

--- a/app/src/test/java/com/m57/hermescontrol/data/remote/CookieManagerTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/remote/CookieManagerTest.kt
@@ -26,9 +26,7 @@ class CookieManagerTest {
         return jar
     }
 
-    private fun ep(host: String): ServerEndpoint {
-        return ServerEndpoint.fromLegacy(host, 9119)
-    }
+    private fun ep(host: String): ServerEndpoint = ServerEndpoint.fromLegacy(host, 9119)
 
     private fun httpsEp(
         host: String,

--- a/app/src/test/java/com/m57/hermescontrol/data/ws/HermesWsClientTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/ws/HermesWsClientTest.kt
@@ -35,6 +35,7 @@ class HermesWsClientTest {
 
     @Before
     fun setUp() {
+        unmockkAll()
         mockkStatic(Log::class)
         every { Log.d(any<String>(), any<String>()) } returns 0
         every { Log.i(any<String>(), any<String>()) } returns 0

--- a/app/src/test/java/com/m57/hermescontrol/data/ws/HermesWsClientTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/ws/HermesWsClientTest.kt
@@ -54,7 +54,8 @@ class HermesWsClientTest {
         every { AuthManager.serverStore } returns
             mockk<com.m57.hermescontrol.data.config.ServerStore>().also {
                 every { it.getLatestState() } returns
-                    com.m57.hermescontrol.data.config.ServerStoreState()
+                    com.m57.hermescontrol.data.config
+                        .ServerStoreState()
             }
 
         // Issue #470: clients are built through OkHttpProvider, which now
@@ -497,7 +498,8 @@ class HermesWsClientTest {
         every { AuthManager.serverStore } returns
             mockk<com.m57.hermescontrol.data.config.ServerStore>().also {
                 every { it.getLatestState() } returns
-                    com.m57.hermescontrol.data.config.ServerStoreState(wsAuthParam = "ticket")
+                    com.m57.hermescontrol.data.config
+                        .ServerStoreState(wsAuthParam = "ticket")
             }
         // No bare-name session cookie present (the prefixed one is server-side).
         every { AuthManager.getSessionCookie() } returns null

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -1726,7 +1726,10 @@ class ChatViewModelTest {
                 "hasOlderMessages must be false when initial page is empty",
                 viewModel.uiState.value.hasOlderMessages,
             )
-            assertTrue(viewModel.uiState.value.messages.isEmpty())
+            assertTrue(
+                viewModel.uiState.value.messages
+                    .isEmpty(),
+            )
             assertFalse(viewModel.uiState.value.isLoading)
         }
 

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -69,6 +69,7 @@ class ChatViewModelTest {
 
         mockkStatic(Dispatchers::class)
         every { Dispatchers.IO } returns testDispatcher
+        every { Dispatchers.Default } returns testDispatcher
         every { Dispatchers.Main } returns testMainDispatcher
 
         mockkObject(AuthManager)
@@ -317,7 +318,7 @@ class ChatViewModelTest {
             viewModel.sendMessage("/status")
             advanceUntilIdle()
 
-            verify { HermesWsClient.send(WsMethods.COMMAND_DISPATCH, any(), any()) }
+            verify { HermesWsClient.request(WsMethods.COMMAND_DISPATCH, any(), any()) }
         }
 
     @Test
@@ -328,7 +329,7 @@ class ChatViewModelTest {
             viewModel.sendMessage("/sessions")
             advanceUntilIdle()
 
-            verify { HermesWsClient.send(WsMethods.COMMAND_DISPATCH, any(), any()) }
+            verify { HermesWsClient.request(WsMethods.COMMAND_DISPATCH, any(), any()) }
         }
 
     @Test
@@ -339,7 +340,7 @@ class ChatViewModelTest {
             viewModel.sendMessage("/stats")
             advanceUntilIdle()
 
-            verify { HermesWsClient.send(WsMethods.COMMAND_DISPATCH, any(), any()) }
+            verify { HermesWsClient.request(WsMethods.COMMAND_DISPATCH, any(), any()) }
         }
 
     @Test

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
@@ -66,6 +66,7 @@ class SlashCommandDispatchRpcTest {
 
         mockkStatic(Dispatchers::class)
         every { Dispatchers.IO } returns testDispatcher
+        every { Dispatchers.Default } returns testDispatcher
         every { Dispatchers.Main } returns testMainDispatcher
 
         mockkObject(AuthManager)

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
@@ -192,7 +192,9 @@ class SlashCommandDispatchRpcTest {
             vm.sendMessage("/help")
             advanceUntilIdle()
 
-            val last = vm.uiState.value.messages.lastOrNull()
+            val last =
+                vm.uiState.value.messages
+                    .lastOrNull()
             assertEquals("⚠️ /help: session busy — /interrupt first", last?.content)
         }
 
@@ -233,7 +235,9 @@ class SlashCommandDispatchRpcTest {
             assertEquals(sessionId, params["session_id"])
 
             // And the slash.exec output must be surfaced to the user.
-            val last = vm.uiState.value.messages.lastOrNull()
+            val last =
+                vm.uiState.value.messages
+                    .lastOrNull()
             assertEquals("STATUS: gateway reachable", last?.content)
         }
 
@@ -255,7 +259,9 @@ class SlashCommandDispatchRpcTest {
             vm.sendMessage("/redraw")
             advanceUntilIdle()
 
-            val last = vm.uiState.value.messages.lastOrNull()
+            val last =
+                vm.uiState.value.messages
+                    .lastOrNull()
             assertTrue(
                 "expected a 'not supported on mobile' message, got: ${last?.content}",
                 last?.content?.contains("not supported on mobile") == true,
@@ -293,7 +299,9 @@ class SlashCommandDispatchRpcTest {
             advanceUntilIdle()
 
             // Both RPCs fail -> the secondary slash.exec error must surface.
-            val last = vm.uiState.value.messages.lastOrNull()
+            val last =
+                vm.uiState.value.messages
+                    .lastOrNull()
             assertEquals("⚠️ /status: slash worker start failed: boom", last?.content)
         }
 
@@ -328,6 +336,11 @@ class SlashCommandDispatchRpcTest {
             // must NOT append an assistant bubble — so the last message is still
             // the user's own command, and only one message was added.
             assertEquals(before + 1, vm.uiState.value.messages.size)
-            assertEquals("/status", vm.uiState.value.messages.lastOrNull()?.content)
+            assertEquals(
+                "/status",
+                vm.uiState.value.messages
+                    .lastOrNull()
+                    ?.content,
+            )
         }
 }

--- a/app/src/test/java/com/m57/hermescontrol/ui/connect/ConnectViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/connect/ConnectViewModelTest.kt
@@ -38,6 +38,7 @@ class ConnectViewModelTest {
         val testMainDispatcher = Dispatchers.Main
         mockkStatic(Dispatchers::class)
         every { Dispatchers.IO } returns testDispatcher
+        every { Dispatchers.Default } returns testDispatcher
         every { Dispatchers.Main } returns testMainDispatcher
 
         mockkObject(AuthManager)

--- a/app/src/test/java/com/m57/hermescontrol/ui/gateway/GatewayViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/gateway/GatewayViewModelTest.kt
@@ -36,6 +36,7 @@ class GatewayViewModelTest {
         Dispatchers.setMain(testDispatcher)
         mockkStatic(Dispatchers::class)
         every { Dispatchers.IO } returns testDispatcher
+        every { Dispatchers.Default } returns testDispatcher
 
         mockApi = mockk()
         mockkObject(ApiClient)

--- a/app/src/test/java/com/m57/hermescontrol/ui/system/SystemViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/system/SystemViewModelTest.kt
@@ -48,4 +48,16 @@ class SystemViewModelTest {
         viewModel.closeUpdateConfirm()
         assertFalse(viewModel.uiState.value.updateConfirmOpen)
     }
+
+    @Test
+    fun `loadBattery when disconnected sets battery state to unavailable`() =
+        kotlinx.coroutines.test.runTest {
+            val viewModel = SystemViewModel()
+            viewModel.loadBattery()
+            kotlinx.coroutines.test.advanceUntilIdle()
+
+            val battery = viewModel.uiState.value.battery
+            org.junit.Assert.assertNotNull(battery)
+            assertFalse(battery!!.available)
+        }
 }

--- a/app/src/test/java/com/m57/hermescontrol/ui/system/SystemViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/system/SystemViewModelTest.kt
@@ -3,10 +3,13 @@ package com.m57.hermescontrol.ui.system
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -51,13 +54,13 @@ class SystemViewModelTest {
 
     @Test
     fun `loadBattery when disconnected sets battery state to unavailable`() =
-        kotlinx.coroutines.test.runTest {
+        runTest {
             val viewModel = SystemViewModel()
             viewModel.loadBattery()
-            kotlinx.coroutines.test.advanceUntilIdle()
+            advanceUntilIdle()
 
             val battery = viewModel.uiState.value.battery
-            org.junit.Assert.assertNotNull(battery)
+            assertNotNull(battery)
             assertFalse(battery!!.available)
         }
 }

--- a/app/src/test/java/com/m57/hermescontrol/ui/system/SystemViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/system/SystemViewModelTest.kt
@@ -1,5 +1,11 @@
 package com.m57.hermescontrol.ui.system
 
+import com.m57.hermescontrol.data.local.AuthManager
+import com.m57.hermescontrol.data.ws.HermesWsClient
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -21,11 +27,25 @@ class SystemViewModelTest {
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns testDispatcher
+        every { Dispatchers.Default } returns testDispatcher
+        mockkStatic(android.util.Log::class)
+        every { android.util.Log.d(any(), any()) } returns 0
+        every { android.util.Log.i(any(), any()) } returns 0
+        every { android.util.Log.w(any(), any<String>()) } returns 0
+        every { android.util.Log.e(any(), any(), any()) } returns 0
+
+        mockkObject(AuthManager)
+        every { AuthManager.isAutoReconnect() } returns false
+
+        HermesWsClient.disconnect()
     }
 
     @After
     fun teardown() {
         Dispatchers.resetMain()
+        unmockkAll()
     }
 
     @Test


### PR DESCRIPTION
## Closes #711

Adopts the backend's `system.battery` WS method to surface the **backend host** battery (not the phone's) in System > Host, mirroring the desktop/TUI status-bar read-out.

### What it does
- `WsMethods.SYSTEM_BATTERY` const
- `SystemRepository.getBatteryStatus()` — WS `request()`, fails OPEN to `available:false` on any RPC error/timeout (matches backend semantics)
- `BatteryStatus` model (`data/model/BatteryStatus.kt`)
- `SystemViewModel`: fetches once in `loadAll()`; starts a ~60s poll **only while `available == true`**, and bails on `available:false` so we never spam `system.battery` on headless hosts
- `SystemScreen.hostSection`: a `StatCard` shown **only when `battery.available`** — hidden on desktop/server/VM (no useless empty card). Shows `NN%` or `NN% ⚡` when plugged.

### Verified
- ktlint 1.2.1 clean
- `./gradlew assembleDebug` BUILD SUCCESSFUL locally (Android SDK present) — real compile, not a stub
- Backend contract read from `tui_gateway/server.py` @ `6ad632bf9` + `agent/battery.py` (confirms it reads the **backend host** battery via `psutil.sensors_battery()`, degrades to `available:false` headless)

### Note for review
On a headless host (server/VM) the card renders nothing by design — `system.battery` always returns `available:false` there. It lights up only when Hermes runs on a laptop/phone-class host with a real battery.

No backend change.