### PR TITLE
Adopt /api/health REST route (issue #713)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/model/HealthStatus.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/HealthStatus.kt
@@ -1,0 +1,17 @@
+package com.m57.hermescontrol.data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Backend liveness probe, mirrored from `GET /api/health` (hermes_cli/web_server.py).
+ *
+ * A lightweight alternative to `/api/status` — no gateway PID / remote-health
+ * probe, no profile scope. `authRequired` tells the client which auth scheme the
+ * gateway expects (gated/OAuth vs loopback token) before attempting a real call.
+ */
+@Serializable
+data class HealthStatus(
+    val ok: Boolean = false,
+    val version: String? = null,
+    val authRequired: Boolean? = null,
+)

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -29,6 +29,7 @@ import com.m57.hermescontrol.data.model.EnvVarDeleteRequest
 import com.m57.hermescontrol.data.model.EnvVarRevealRequest
 import com.m57.hermescontrol.data.model.EnvVarRevealResponse
 import com.m57.hermescontrol.data.model.EnvVarUpdate
+import com.m57.hermescontrol.data.model.HealthStatus
 import com.m57.hermescontrol.data.model.HookResponse
 import com.m57.hermescontrol.data.model.KanbanBoardResponse
 import com.m57.hermescontrol.data.model.KanbanBoardsResponse
@@ -122,6 +123,9 @@ interface HermesApiService {
 
     @GET("api/status")
     suspend fun getStatus(): Response<StatusResponse>
+
+    @GET("api/health")
+    suspend fun getHealth(): Response<HealthStatus>
 
     @GET("api/sessions")
     suspend fun getSessions(

--- a/app/src/main/java/com/m57/hermescontrol/ui/connect/ConnectScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/connect/ConnectScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -314,6 +315,43 @@ fun ConnectScreen(
                             },
                             modifier = Modifier.fillMaxWidth(),
                         )
+                    }
+                }
+
+                // Backend health read-out (issue #713): cheap /api/health probe.
+                // Shows version + auth mode when reachable; nothing when null.
+                state.health?.let { health ->
+                    val authMode =
+                        if (health.authRequired == true) {
+                            stringResource(R.string.connect_health_auth_gated)
+                        } else {
+                            stringResource(R.string.connect_health_auth_token)
+                        }
+                    Surface(
+                        color = MaterialTheme.colorScheme.surfaceContainer,
+                        shape = MaterialTheme.shapes.medium,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(12.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Text(
+                                text = stringResource(R.string.connect_health_title),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Text(
+                                text =
+                                    stringResource(
+                                        R.string.connect_health_body,
+                                        health.version ?: "?",
+                                        authMode,
+                                    ),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/m57/hermescontrol/ui/connect/ConnectViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/connect/ConnectViewModel.kt
@@ -8,6 +8,7 @@ import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.config.ConnectionProfile
 import com.m57.hermescontrol.data.config.resolveBaseUrl
 import com.m57.hermescontrol.data.local.AuthManager
+import com.m57.hermescontrol.data.model.HealthStatus
 import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.CleartextPolicy
 import com.m57.hermescontrol.data.remote.NetworkError
@@ -33,6 +34,7 @@ data class ConnectUiState(
     val saveProfile: Boolean = false,
     val profiles: List<ConnectionProfile> = emptyList(),
     val selectedProfile: ConnectionProfile? = null,
+    val health: HealthStatus? = null,
 )
 
 class ConnectViewModel(
@@ -59,6 +61,29 @@ class ConnectViewModel(
                 selectedProfile = selectedProfile,
                 profileName = selectedProfile?.name ?: "",
             )
+        }
+        loadHealth()
+    }
+
+    /**
+     * Cheap liveness probe (issue #713): GET /api/health against the current
+     * URL/token. Surfaces backend version + auth mode on the connection screen
+     * without the heavier /api/status payload. Best-effort: failures are silent
+     * (health stays null and the screen simply shows no read-out).
+     */
+    fun loadHealth() {
+        val state = _uiState.value
+        val endpoint = runCatching { ServerEndpoint.parseForBuild(state.baseUrl) }.getOrNull()
+        if (endpoint == null || state.token.isBlank()) return
+        viewModelScope.launch {
+            val result =
+                withContext(Dispatchers.IO) {
+                    val tempApi = ApiClient.createTempService(endpoint.baseUrl.toString(), state.token)
+                    safeApiCall { tempApi.getHealth() }
+                }
+            if (result is NetworkResult.Success) {
+                _uiState.update { it.copy(health = result.data) }
+            }
         }
     }
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -179,6 +179,10 @@
     <!-- Connect Screen -->
     <string name="connect_selected_profile">프로필: %1$s</string>
     <string name="connect_action_select_profile">저장된 프로필 선택</string>
+    <string name="connect_health_title">백엔드 상태</string>
+    <string name="connect_health_body">Hermes %1$s · %2$s</string>
+    <string name="connect_health_auth_gated">게이트(OAuth)</string>
+    <string name="connect_health_auth_token">토큰</string>
 
     <!-- Connect Error Messages -->
     <string name="connect_error_token_required">토큰이 필요합니다</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,6 +207,10 @@
     <!-- Connect Screen -->
     <string name="connect_selected_profile">Profile: %1$s</string>
     <string name="connect_action_select_profile">Select Saved Profile</string>
+    <string name="connect_health_title">Backend health</string>
+    <string name="connect_health_body">Hermes %1$s · %2$s</string>
+    <string name="connect_health_auth_gated">Gated (OAuth)</string>
+    <string name="connect_health_auth_token">Token</string>
 
     <!-- Connect Error Messages -->
     <string name="connect_error_token_required">Token is required</string>


### PR DESCRIPTION
## Closes #713

Adopts the backend's `GET /api/health` as a cheap liveness probe on the **Connection screen** (chosen scope: passive read-out, not touching the WS reconnect path).

### What it does
- `HermesApiService.getHealth()` — `GET /api/health`
- `HealthStatus` model (`ok`, `version`, `authRequired`)
- `ConnectViewModel.loadHealth()` — probes on screen open against the current URL/token via the same temp-service pattern as `connect()`; best-effort (silent on failure, `health` stays null → no card)
- `ConnectScreen` — a read-only health card: "Hermes <version> · <Token | Gated (OAuth)>", shown only when reachable

### Why this scope (not the full reconnect-path use)
The app already knows liveness via the WS `ConnectionStatus` state machine. Rewiring reconnect to pre-flight `/api/health` is a bigger, riskier change to connection logic you already rely on — deferred. This gives a real, missing read-out (backend **version** + **auth mode**) with ~zero risk.

### Verified
- ktlint 1.2.1 clean
- `./gradlew assembleDebug` BUILD SUCCESSFUL locally (real compile)
- Backend contract read from `hermes_cli/web_server.py` @ `6ad632bf9` (`/api/health` → `{ok, version, auth_required}`)

No backend change.