### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,6 +10,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # Cancel in-progress runs when a new commit lands on the same PR branch.
 # On main (push events), each commit gets a unique group so rapid merges
 # don't cancel each other's CI runs.


### PR DESCRIPTION
Potential fix for [https://github.com/Hy4ri/hermes-mobile/security/code-scanning/1](https://github.com/Hy4ri/hermes-mobile/security/code-scanning/1)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/android.yml` (after `on:` is a common placement) to enforce least privilege for all jobs unless overridden.  
For this CI workflow, the minimal safe baseline is:

- `contents: read`

This supports `actions/checkout` and typical read-only CI operations without granting write access.  
No functional workflow behavior should change for lint/test/build steps, but security posture improves and CodeQL finding is resolved.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
