### PR TITLE
Potential fix for code scanning alert no. 8: Use of implicit PendingIntents

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/notification/ChatNotificationService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/notification/ChatNotificationService.kt
@@ -133,6 +133,7 @@ class ChatNotificationService : Service() {
 
             val replyIntent =
                 Intent(this, NotificationReplyReceiver::class.java).apply {
+                    action = "$packageName.ACTION_NOTIFICATION_REPLY"
                     putExtra(NotificationReplyReceiver.EXTRA_SESSION_ID, sessionId)
                 }
 
@@ -141,7 +142,7 @@ class ChatNotificationService : Service() {
                     this,
                     sessionId.hashCode(),
                     replyIntent,
-                    PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+                    PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_ONE_SHOT,
                 )
 
             val action =
@@ -161,8 +162,11 @@ class ChatNotificationService : Service() {
     }
 
     private fun buildContentIntent(sessionId: String?): PendingIntent {
-        val intent = Intent(this, MainActivity::class.java)
-        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        val intent =
+            Intent(this, MainActivity::class.java).apply {
+                action = "$packageName.ACTION_OPEN_CHAT_FROM_NOTIFICATION"
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
         if (!sessionId.isNullOrBlank()) {
             intent.putExtra(NotificationReplyReceiver.EXTRA_SESSION_ID, sessionId)
         }
@@ -170,7 +174,7 @@ class ChatNotificationService : Service() {
             this,
             sessionId?.hashCode() ?: 0,
             intent,
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_ONE_SHOT,
         )
     }
 


### PR DESCRIPTION
Hardens the two notification PendingIntents (reply + content) flagged by code-scanning alert #8:
- unique explicit action on each intent (`ACTION_NOTIFICATION_REPLY` / `ACTION_OPEN_CHAT_FROM_NOTIFICATION`)
- `FLAG_ONE_SHOT` on both; `FLAG_MUTABLE` kept only on the reply path (RemoteInput requires it), `FLAG_IMMUTABLE` kept on the content intent

Also fixes the ktlint `standard:string-template` violations (redundant curly braces).