### PR TITLE
chore: simplify issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,53 +1,39 @@
-name: 🐛 Bug report
+name: Bug report
 description: Report a bug or unexpected behaviour
 title: '[bug] '
 labels: ['bug']
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for taking the time to report a bug! Please fill in the details below.
   - type: textarea
     id: description
     attributes:
       label: Describe the bug
-      description: A clear and concise description of what the bug is.
-      placeholder: What happened? What did you expect to happen?
+      description: What happened and what you expected instead.
     validations:
       required: true
   - type: textarea
     id: reproduction
     attributes:
       label: To reproduce
-      description: Steps to reproduce the behaviour.
+      description: Steps to trigger it.
       placeholder: |
         1. Go to '...'
         2. Tap on '...'
-        3. Scroll to '...'
-        4. See error
+        3. See error
     validations:
       required: true
-  - type: textarea
-    id: screenshots
-    attributes:
-      label: Screenshots / screen recordings
-      description: If applicable, add screenshots or a screen recording to help explain the problem.
-      placeholder: Drag & drop images here
   - type: textarea
     id: environment
     attributes:
       label: Environment
-      description: Device, OS version, app version, and Hermes dashboard version.
+      description: Device, Android version, app version.
       placeholder: |
-        - Device: e.g. Pixel 8, Samsung Galaxy S24
-        - Android version: e.g. Android 14, Android 15
-        - App version: e.g. v1.2.3, or the commit SHA
-        - Hermes dashboard version: if known
+        - Device: Pixel 8
+        - Android version: Android 15
+        - App version: v1.2.3
     validations:
       required: true
   - type: textarea
     id: additional
     attributes:
       label: Additional context
-      description: Error logs, crash reports, adb logcat output, or anything else relevant.
-      placeholder: Remove any sensitive info (tokens, hostnames) before pasting.
+      description: Logs, screenshots, or anything else relevant.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 💬 Discussion
+  - name: Discussion
     url: https://github.com/Hy4ri/hermes-mobile/discussions
     about: For questions, ideas, or general discussion

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,43 +1,24 @@
-name: ✨ Feature request
-description: Suggest an idea, enhancement, UX improvement, or refactor
+name: Feature request
+description: Suggest an idea or improvement
 title: '[enhancement] '
 labels: ['enhancement']
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for your suggestion! Please describe the feature or improvement you'd like to see.
   - type: textarea
     id: problem
     attributes:
-      label: Problem / motivation
-      description: What problem would this solve? Why is this needed?
-      placeholder: |
-        e.g. It's frustrating when ... or The app currently lacks ...
+      label: Problem
+      description: What problem does this solve?
     validations:
       required: true
   - type: textarea
     id: solution
     attributes:
       label: Proposed solution
-      description: A clear description of what you want to happen.
-      placeholder: Describe your ideal solution here.
+      description: What you want to happen.
     validations:
       required: true
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternative approaches
-      description: Any alternative solutions or features you've considered.
-      placeholder: What else could work?
-  - type: textarea
-    id: mockups
-    attributes:
-      label: Screenshots / mockups
-      description: Sketches, screenshots from other apps, or wireframes.
-      placeholder: Drag & drop images here
   - type: textarea
     id: additional
     attributes:
       label: Additional context
-      description: Any other details, links, or relevant API endpoints.
+      description: Alternatives, mockups, links, or anything else relevant.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,68 +1,19 @@
 ## Summary
 
-<!-- One-sentence summary of what this PR does. -->
+<!-- One sentence. -->
 
-Fixes #<!-- issue number -->
-
-## Type of change
-
-<!-- Check the type that applies. Delete the rest. -->
-
-- [ ] 🐛 Bug fix
-- [ ] ✨ Feature
-- [ ] 🎨 UX improvement
-- [ ] ♻️ Refactor
-- [ ] 🔧 CI / build config
-- [ ] 📝 Documentation
-- [ ] 🔒 Security
-
-## Screenshots / screen recordings
-
-<!-- Required for UI changes. Drag & drop images or link to recordings. -->
-
-_Before:_
-
-_After:_
+Fixes #
 
 ## What changed
 
-<!--
-  Describe the changes in detail — what was wrong, what was done to fix it,
-  key decisions made, trade-offs considered. For UI changes, explain the
-  reasoning behind layout, color, or interaction decisions.
--->
+<!-- What was wrong and what this PR does about it. -->
 
 ## How to test
 
-<!--
-  Steps to verify the change works correctly. Example:
-
-  1. Open the app
-  2. Navigate to …
-  3. Tap …
-  4. Verify that …
--->
+<!-- Steps to verify. -->
 
 ## Checklist
 
-- [ ] Code follows the project's style (ktlint passes)
-- [ ] No new compiler warnings introduced
-- [ ] If adding a new screen, checked that existing screens don't already cover the functionality (see `NavigationKeys.kt`/`ls ui/`)
-- [ ] Routes all navigation through `NavigationController.navigateTo()` — no raw `backStack.add()` from UI callbacks
-- [ ] Uses `HermesScaffold` instead of raw `Scaffold` for new/rewritten screens
-- [ ] Room schema directory updated if entities changed
-- [ ] Tested the change on a real device or CI APK
-- [ ] CI is green (all checks pass: ktlint, Android Lint, unit tests, build)
-
-## Related issues
-
-<!--
-  Link any related issues, PRs, or discussions.
-  e.g., Closes #N, Refs #M, Related to #P
--->
-
-## Notes for reviewers
-
-<!--
-  Any gotchas, follow-up work, or things to watch out for.
--->
+- [ ] ktlint and CI pass
+- [ ] Tested on a device or CI APK
+- [ ] Navigation goes through `NavigationController.navigateTo()`


### PR DESCRIPTION
Rewrites the issue and PR templates to be short and clear: removed emojis and trimmed sections, checklists, and welcome banners to the essentials.