### PR TITLE
fix(chat): skip live-registry context RPCs until resume confirms runtime session id

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -302,6 +302,13 @@ class ChatViewModel(
                     status == ConnectionStatus.AUTH_EXPIRED
                 ) {
                     _uiState.update { it.copy(isLoading = false) }
+                    // The runtime session id is only valid while the socket
+                    // owns it — a dropped connection may mean the gateway
+                    // closed/pruned the session (or restarted, wiping the
+                    // runtime registry). Clear it so session-scoped RPCs can't
+                    // fire with a stale id and 4001 "session not found";
+                    // handleGatewayReady rebinds it on the re-resume.
+                    runtimeSessionId = null
                     // Fail any in-flight awaited RPCs so callers don't hang
                     // across the disconnect (delegated to HermesWsClient, issue #526).
                     wsClient.rejectAllPending()
@@ -1853,42 +1860,52 @@ class ChatViewModel(
             // real current prompt size (drops after compression); `context_max`
             // is the compressor's actual window. Any failure keeps the last
             // known values — never blank the meter over a transient RPC error.
-            val rpcSessionId = runtimeSessionId ?: sessionId
-            try {
-                val result =
-                    sendRpcAndAwait(
-                        WsMethods.SESSION_CONTEXT_BREAKDOWN,
-                        mapOf("session_id" to rpcSessionId),
-                    )
-                val ctx = parseContextBreakdown(result)
-                if (ctx != null) {
-                    _uiState.update { current ->
-                        current.copy(
-                            usedContextTokens =
-                                ctx.contextUsed?.takeIf { it > 0L } ?: current.usedContextTokens,
-                            fullContextTokens =
-                                ctx.contextMax?.takeIf { it > 0L } ?: current.fullContextTokens,
+            //
+            // These RPCs resolve the session against the gateway's LIVE runtime
+            // registry (_sess_nowait) — the storage session id 4001s "session
+            // not found" until session.resume has registered it. ChatScreen's
+            // sync effect fires this immediately on session switch, before the
+            // resume result lands, so skip the RPCs until resume confirms the
+            // runtime id. The REST parts below stay live (they key on the
+            // storage id).
+            val rpcSessionId = runtimeSessionId
+            if (rpcSessionId != null) {
+                try {
+                    val result =
+                        sendRpcAndAwait(
+                            WsMethods.SESSION_CONTEXT_BREAKDOWN,
+                            mapOf("session_id" to rpcSessionId),
                         )
+                    val ctx = parseContextBreakdown(result)
+                    if (ctx != null) {
+                        _uiState.update { current ->
+                            current.copy(
+                                usedContextTokens =
+                                    ctx.contextUsed?.takeIf { it > 0L } ?: current.usedContextTokens,
+                                fullContextTokens =
+                                    ctx.contextMax?.takeIf { it > 0L } ?: current.fullContextTokens,
+                            )
+                        }
                     }
+                } catch (_: Exception) {
+                    // Best-effort: RPC error/timeout/disconnect — keep last values.
                 }
-            } catch (_: Exception) {
-                // Best-effort: RPC error/timeout/disconnect — keep last values.
-            }
-            // Compression count: how many times this session has been compacted
-            // (session.usage → compressions). Feeds the "compressed ×N" badge —
-            // the same usage snapshot the desktop status bar reads.
-            try {
-                val usage =
-                    sendRpcAndAwait(
-                        WsMethods.SESSION_USAGE,
-                        mapOf("session_id" to rpcSessionId),
-                    )
-                val snapshot = parseUsageSnapshot(usage)
-                if (snapshot != null && snapshot.compressions != null) {
-                    _uiState.update { it.copy(compressionCount = snapshot.compressions) }
+                // Compression count: how many times this session has been compacted
+                // (session.usage → compressions). Feeds the "compressed ×N" badge —
+                // the same usage snapshot the desktop status bar reads.
+                try {
+                    val usage =
+                        sendRpcAndAwait(
+                            WsMethods.SESSION_USAGE,
+                            mapOf("session_id" to rpcSessionId),
+                        )
+                    val snapshot = parseUsageSnapshot(usage)
+                    if (snapshot != null && snapshot.compressions != null) {
+                        _uiState.update { it.copy(compressionCount = snapshot.compressions) }
+                    }
+                } catch (_: Exception) {
+                    // Best-effort: keep the last known badge value.
                 }
-            } catch (_: Exception) {
-                // Best-effort: keep the last known badge value.
             }
             // Detail-sheet accounting (cumulative REST counters, informational).
             val usedResult =

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -1255,6 +1255,99 @@ class ChatViewModelTest {
             assertFalse(viewModel.uiState.value.isResumeRetrying)
         }
 
+    /**
+     * Regression for the spurious "Error: JsonRpcError(code=4001, message=session
+     * not found, data=null)" snackbar when opening a session from history: the
+     * chat sync effect fires fetchContextUsage() immediately on session switch,
+     * BEFORE session.resume has registered the session on the gateway. The
+     * context/usage RPCs resolve against the gateway's LIVE runtime registry
+     * (_sess_nowait) and would 4001 on the storage id — so they must be skipped
+     * until the resume result confirms the runtime id (which is then used).
+     */
+    @Test
+    fun testSwitchSession_contextRpcSkippedUntilResumeConfirmsRuntimeId() =
+        runTest {
+            stubSession456Rests(success = true)
+
+            // Awaited live-registry RPCs (sendRpcAndAwait → HermesWsClient.request).
+            // Completed deferred so the awaits resolve; capture the params. Installed
+            // BEFORE createViewModelWithSession so the SESSION_CREATE-era
+            // fetchContextUsage() call is stubbed too (otherwise its unstubbed
+            // invocation is still recorded and pollutes the verify(exactly = 0)).
+            val paramsSlot = slot<Map<String, Any>>()
+            every {
+                HermesWsClient.request(any(), capture(paramsSlot), any())
+            } returns CompletableDeferred<Any?>(emptyMap<String, Any?>())
+
+            val (viewModel, _) = createViewModelWithSession()
+
+            // Capture the session.resume request id so its result can be delivered.
+            var resumeRequestId: String? = null
+            every { HermesWsClient.send(WsMethods.SESSION_RESUME, any(), any()) } answers {
+                reqCount++
+                val id = "resume-$reqCount"
+                arg<((String) -> Unit)?>(2)?.invoke(id)
+                resumeRequestId = id
+                id
+            }
+
+            // Switch to session-456: runtimeSessionId resets to null until the
+            // resume result lands — the storage id is not (yet) live on the
+            // gateway. ChatScreen's sync effect fires fetchContextUsage()
+            // immediately on session switch — simulate it while the resume
+            // result is still in flight. The live-registry RPCs must NOT fire
+            // with the stale storage id (the gateway would 4001).
+            viewModel.switchSession("session-456")
+            advanceUntilIdle()
+            viewModel.fetchContextUsage()
+            advanceUntilIdle()
+
+            verify(exactly = 0) {
+                HermesWsClient.request(
+                    WsMethods.SESSION_CONTEXT_BREAKDOWN,
+                    match { it["session_id"] == "session-456" },
+                    any(),
+                )
+            }
+            verify(exactly = 0) {
+                HermesWsClient.request(
+                    WsMethods.SESSION_USAGE,
+                    match { it["session_id"] == "session-456" },
+                    any(),
+                )
+            }
+
+            // Resume result lands → runtime id confirmed → the RPCs fire with it.
+            val resumeId = checkNotNull(resumeRequestId)
+            mockEventsFlow.emit(
+                WsEvent.RpcResult(
+                    resumeId,
+                    mapOf(
+                        "session_id" to "runtime-456",
+                        "resumed" to "session-456",
+                        "info" to emptyMap<String, Any?>(),
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            verify {
+                HermesWsClient.request(
+                    WsMethods.SESSION_CONTEXT_BREAKDOWN,
+                    match { it["session_id"] == "runtime-456" },
+                    any(),
+                )
+            }
+            verify {
+                HermesWsClient.request(
+                    WsMethods.SESSION_USAGE,
+                    match { it["session_id"] == "runtime-456" },
+                    any(),
+                )
+            }
+            assertEquals("runtime-456", paramsSlot.captured["session_id"])
+        }
+
     @Test
     fun testSessionResume_boundedRetry_thenExplicitError() =
         runTest {


### PR DESCRIPTION
## What
Fixes the spurious **"Error: JsonRpcError(code=4001, message=session not found, data=null)"** snackbar when opening a session from history — the session itself always loaded fine.

## Root cause (live-verified)
Opening a session fires `session.resume` (registers the runtime session on the gateway) while the transcript loads over REST. Meanwhile ChatScreen's sync effect (`ChatScreen.kt:136-147`) calls `fetchContextUsage()` **immediately** on session switch — before the resume result lands. With `runtimeSessionId` still null, the code fell back to the **storage session id** (`runtimeSessionId ?: sessionId`), and `session.context_breakdown` / `session.usage` resolve against the gateway's **live runtime registry** (`_sess_nowait`, `tui_gateway/server.py:2075`) → **4001 "session not found"**.

Replayed against the live gateway: old-id pre-resume → 4001; runtime-id post-resume → OK. The awaited failure was swallowed by `fetchContextUsage`, but the WS reducer still banners every RpcError event — hence the misleading snackbar.

## Fix
1. `fetchContextUsage()` skips the two live-registry RPCs while `runtimeSessionId == null` (pre-resume window). REST-based context fallbacks (model-info denominator, session-detail accounting) stay live.
2. `runtimeSessionId` is cleared on socket drop (DISCONNECTED/RECONNECTING/NO_NETWORK/AUTH_EXPIRED) so a stale runtime id can't 4001 after a gateway restart/reconnect — same bug family.

## Verification
- **Regression test** `testSwitchSession_contextRpcSkippedUntilResumeConfirmsRuntimeId`: no context/usage RPC fires with the storage id during the pre-resume window; after the resume result they fire with the runtime id. **Proven RED on pre-fix code, GREEN with the fix.**
- Local `ktlintCheck` ✅
- Local full unit suite: only pre-existing MockK static-mock bleed failures (4 pagination tests verified failing on pristine `origin/main`; `testAutoReconnect` is the documented run-order bleed variant).