### PR TITLE
chore: rename launcher label to 'Hermes Mobile'

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">HermesMobile</string>
+    <string name="app_name">Hermes Mobile</string>
 
     <!-- Chat -->
     <string name="chat_send_desc">Send</string>


### PR DESCRIPTION
The app icon label on the launcher currently reads `HermesMobile` (no space). Change the `app_name` string resource to `Hermes Mobile` to match the brand name everywhere else.

- `app/src/main/res/values/strings.xml` — `app_name`: `HermesMobile` → `Hermes Mobile`
- Manifest already refs `@string/app_name`, so no manifest change needed.
- Korean locale keeps its localized label (`헤르메스`).