### PR TITLE
fix(#774): plugin rescan uses GET to match backend route

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -525,7 +525,7 @@ interface HermesApiService {
         @Path("name", encoded = true) name: String,
     ): Response<Unit>
 
-    @POST("api/dashboard/plugins/rescan")
+    @GET("api/dashboard/plugins/rescan")
     suspend fun rescanPlugins(): Response<Unit>
 
     @PUT("api/dashboard/plugin-providers")


### PR DESCRIPTION
## What
The dashboard backend registers only `GET /api/dashboard/plugins/rescan` (`hermes_cli/web_server.py:16457`) — there is no POST variant. The mobile client was calling it with `@POST`, so rescan always failed with **405 Method Not Allowed**.

## Fix
Changed `HermesApiService.rescanPlugins()` from `@POST` to `@GET`, matching the desktop contract (`web/src/lib/api.ts:973` — plain fetch → GET, which is why desktop rescan works).

## Verification
- Backend source read: only `@app.get` registered, no `api_route` with both verbs
- Desktop source read: `fetchJSON<{ ok, count }>("/api/dashboard/plugins/rescan")` → GET
- Local: `ktlintCheck` + `testDebugUnitTest` — BUILD SUCCESSFUL

Fixes #774