### PR TITLE
feat(kanban): live board updates over plugin events WebSocket + kanban UI pass

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -33,7 +33,6 @@ import com.m57.hermescontrol.data.model.HealthStatus
 import com.m57.hermescontrol.data.model.HookResponse
 import com.m57.hermescontrol.data.model.KanbanBoardResponse
 import com.m57.hermescontrol.data.model.KanbanBoardsResponse
-import com.m57.hermescontrol.data.model.KanbanTask
 import com.m57.hermescontrol.data.model.LearningGraphResponse
 import com.m57.hermescontrol.data.model.LogResponse
 import com.m57.hermescontrol.data.model.ManagedDirectoryCreate
@@ -663,7 +662,7 @@ interface HermesApiService {
     suspend fun createKanbanTask(
         @Query("board") board: String?,
         @Body task: CreateTaskBody,
-    ): Response<KanbanTask>
+    ): Response<Unit>
 
     // ── Admin: Hermes update ──────────────────────────────────────────
     @GET("api/hermes/update/check")

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -114,7 +114,6 @@ import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.HTTP
 import retrofit2.http.Multipart
-import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Part
@@ -650,12 +649,6 @@ interface HermesApiService {
     @POST("api/plugins/kanban/boards/{slug}/switch")
     suspend fun switchKanbanBoard(
         @Path("slug") slug: String,
-    ): Response<Unit>
-
-    @PATCH("api/plugins/kanban/tasks/{id}")
-    suspend fun updateKanbanTask(
-        @Path("id") taskId: String,
-        @Body body: Map<String, String?>,
     ): Response<Unit>
 
     @POST("api/plugins/kanban/tasks")

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/HermesApiService.kt
@@ -114,6 +114,7 @@ import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.HTTP
 import retrofit2.http.Multipart
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Part
@@ -649,6 +650,12 @@ interface HermesApiService {
     @POST("api/plugins/kanban/boards/{slug}/switch")
     suspend fun switchKanbanBoard(
         @Path("slug") slug: String,
+    ): Response<Unit>
+
+    @PATCH("api/plugins/kanban/tasks/{id}")
+    suspend fun updateKanbanTask(
+        @Path("id") taskId: String,
+        @Body body: Map<String, String?>,
     ): Response<Unit>
 
     @POST("api/plugins/kanban/tasks")

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/ServerEndpoint.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/ServerEndpoint.kt
@@ -33,15 +33,31 @@ class ServerEndpoint private constructor(
     fun webSocketUrl(
         authParameter: String,
         credential: String,
+    ): String =
+        webSocketUrl(
+            path = "api/ws",
+            authParameter = authParameter,
+            credential = credential,
+        )
+
+    /**
+     * Build a WebSocket URL for an arbitrary dashboard WS endpoint (e.g. the
+     * kanban plugin's live-events stream), preserving the reverse-proxy path
+     * prefix, converting http(s) to ws(s), and appending the auth parameter
+     * plus any extra query parameters (e.g. `since`, `board`).
+     */
+    fun webSocketUrl(
+        path: String,
+        authParameter: String,
+        credential: String,
+        extraParams: Map<String, String> = emptyMap(),
     ): String {
         require(authParameter == "token" || authParameter == "ticket") {
             "Unsupported WebSocket authentication parameter"
         }
-        val socketHttpUrl =
-            resolve("api/ws")
-                .newBuilder()
-                .addQueryParameter(authParameter, credential)
-                .build()
+        val builder = resolve(path).newBuilder().addQueryParameter(authParameter, credential)
+        extraParams.forEach { (key, value) -> builder.addQueryParameter(key, value) }
+        val socketHttpUrl = builder.build()
         val socketScheme = if (baseUrl.isHttps) "wss" else "ws"
         return replaceScheme(socketHttpUrl.toString(), socketScheme)
     }

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
@@ -260,7 +260,7 @@ object HermesWsClient {
      * or because ticket refresh succeeded). Returns false if we are in gated mode
      * and ticket refresh failed or cannot be performed.
      */
-    private fun refreshWsTicketIfNeeded(): Boolean {
+    internal fun refreshWsTicketIfNeeded(): Boolean {
         val isGated =
             try {
                 AuthManager.serverStore.getLatestState().wsAuthParam == "ticket"

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
@@ -279,6 +279,57 @@ object HermesWsClient {
             return true
         }
 
+        val ticketResult = requestWsTicket()
+        if (!ticketResult.ticket.isNullOrBlank()) {
+            AuthManager.setToken(ticketResult.ticket)
+            if (BuildConfig.DEBUG) Log.d(TAG, "WS ticket refreshed")
+            return true
+        }
+        val status =
+            when (ticketResult.httpCode) {
+                401, 403 -> ConnectionStatus.AUTH_EXPIRED
+                408, 429 -> ConnectionStatus.RECONNECTING
+                in 500..599 -> ConnectionStatus.RECONNECTING
+                else -> ConnectionStatus.DISCONNECTED
+            }
+        return handleWsTicketRefreshFailure(status)
+    }
+
+    /**
+     * Mint a fresh WS ticket for a *secondary* consumer (e.g. the kanban
+     * events stream) WITHOUT touching the shared token slot.
+     *
+     * The shared slot is a single-use ticket that the chat WebSocket consumes
+     * at handshake. If two clients mint and stash into the same slot on their
+     * own schedules, each can grab the other's just-consumed ticket and the
+     * pair starves each other into a permanent reconnect loop. Secondary
+     * consumers must use their own ticket per connection.
+     *
+     * Gated mode: cookie-auth'd POST to /api/auth/ws-ticket, returns the
+     * ticket. Loopback mode: refresh the dashboard token and return it.
+     * Returns null when a ticket could not be obtained.
+     */
+    internal fun mintWsTicket(): String? {
+        val isGated =
+            try {
+                AuthManager.serverStore.getLatestState().wsAuthParam == "ticket"
+            } catch (_: IllegalStateException) {
+                false
+            }
+        if (!isGated) {
+            DashboardSessionTokenRefresher.refresh()
+            return AuthManager.getToken()
+        }
+        return requestWsTicket().ticket
+    }
+
+    private data class TicketRequestResult(
+        val ticket: String?,
+        val httpCode: Int?,
+    )
+
+    /** POST /api/auth/ws-ticket (cookie-auth'd via the shared CookieJar) and parse the ticket. */
+    private fun requestWsTicket(): TicketRequestResult {
         try {
             val client = OkHttpProvider.probe
             val request =
@@ -300,29 +351,18 @@ object HermesWsClient {
                     val ticketMatch = Regex("""\"ticket\":\"([^\"]+)\"""").find(body)
                     val ticket = ticketMatch?.groupValues?.getOrNull(1)
                     if (!ticket.isNullOrBlank()) {
-                        AuthManager.setToken(ticket)
-                        if (BuildConfig.DEBUG) Log.d(TAG, "WS ticket refreshed")
-                        return true
-                    } else {
-                        Log.w(TAG, "WS ticket refresh failed: response body did not contain ticket")
-                        return handleWsTicketRefreshFailure(ConnectionStatus.DISCONNECTED)
+                        return TicketRequestResult(ticket, null)
                     }
+                    Log.w(TAG, "WS ticket mint failed: response body did not contain ticket")
                 } else {
-                    Log.w(TAG, "WS ticket refresh failed: HTTP ${response.code}")
-                    val status =
-                        when {
-                            response.code == 401 || response.code == 403 -> ConnectionStatus.AUTH_EXPIRED
-                            response.code == 408 || response.code == 429 || response.code >= 500 ->
-                                ConnectionStatus.RECONNECTING
-                            else -> ConnectionStatus.DISCONNECTED
-                        }
-                    return handleWsTicketRefreshFailure(status)
+                    Log.w(TAG, "WS ticket mint failed: HTTP ${response.code}")
+                    return TicketRequestResult(null, response.code)
                 }
             }
         } catch (e: Exception) {
-            Log.w(TAG, "WS ticket refresh failed: ${e.javaClass.simpleName}")
-            return handleWsTicketRefreshFailure(ConnectionStatus.RECONNECTING)
+            Log.w(TAG, "WS ticket mint failed: ${e.javaClass.simpleName}")
         }
+        return TicketRequestResult(null, null)
     }
 
     private fun handleWsTicketRefreshFailure(status: ConnectionStatus): Boolean {

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
@@ -286,10 +286,11 @@ object HermesWsClient {
             return true
         }
         val status =
-            when (ticketResult.httpCode) {
-                401, 403 -> ConnectionStatus.AUTH_EXPIRED
-                408, 429 -> ConnectionStatus.RECONNECTING
-                in 500..599 -> ConnectionStatus.RECONNECTING
+            when {
+                ticketResult.exception -> ConnectionStatus.RECONNECTING
+                ticketResult.httpCode == 401 || ticketResult.httpCode == 403 -> ConnectionStatus.AUTH_EXPIRED
+                ticketResult.httpCode == 408 || ticketResult.httpCode == 429 -> ConnectionStatus.RECONNECTING
+                ticketResult.httpCode != null && ticketResult.httpCode >= 500 -> ConnectionStatus.RECONNECTING
                 else -> ConnectionStatus.DISCONNECTED
             }
         return handleWsTicketRefreshFailure(status)
@@ -326,6 +327,7 @@ object HermesWsClient {
     private data class TicketRequestResult(
         val ticket: String?,
         val httpCode: Int?,
+        val exception: Boolean = false,
     )
 
     /** POST /api/auth/ws-ticket (cookie-auth'd via the shared CookieJar) and parse the ticket. */
@@ -361,6 +363,7 @@ object HermesWsClient {
             }
         } catch (e: Exception) {
             Log.w(TAG, "WS ticket mint failed: ${e.javaClass.simpleName}")
+            return TicketRequestResult(null, null, exception = true)
         }
         return TicketRequestResult(null, null)
     }

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/KanbanEventsClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/KanbanEventsClient.kt
@@ -1,0 +1,238 @@
+package com.m57.hermescontrol.data.ws
+
+import android.util.Log
+import com.m57.hermescontrol.BuildConfig
+import com.m57.hermescontrol.data.local.AuthManager
+import com.m57.hermescontrol.data.remote.OkHttpProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.JsonObject
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okio.ByteString
+
+/** Connection state of the kanban live-events stream. */
+enum class KanbanLiveStatus {
+    /** Stream open and receiving events. */
+    CONNECTED,
+
+    /** Stream closed; reconnecting with backoff (or waiting for a board switch). */
+    DISCONNECTED,
+
+    /** Stream rejected with 1008 / credential refresh failed; not retrying. */
+    AUTH_FAILED,
+}
+
+/** One row of the backend's ``task_events`` table (``/api/plugins/kanban/events``). */
+@Serializable
+data class KanbanEvent(
+    val id: Long,
+    @SerialName("task_id") val taskId: String? = null,
+    @SerialName("run_id") val runId: String? = null,
+    val kind: String,
+    /** Partial update (e.g. ``{"status": "done"}``) — never applied directly. */
+    val payload: JsonObject? = null,
+    @SerialName("created_at") val createdAt: Long? = null,
+)
+
+/** Server frame: ``{"events": [...], "cursor": N}``. */
+@Serializable
+data class KanbanEventsEnvelope(
+    val events: List<KanbanEvent> = emptyList(),
+    val cursor: Long? = null,
+)
+
+/**
+ * Parse a kanban events WS frame. Returns null when the frame is not a valid
+ * envelope (heartbeats, partial writes, unrelated payloads) so the caller can
+ * ignore it safely.
+ */
+internal fun parseKanbanEventsFrame(json: String): KanbanEventsEnvelope? =
+    try {
+        OkHttpProvider.json.decodeFromString<KanbanEventsEnvelope>(json)
+    } catch (_: SerializationException) {
+        null
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+
+/**
+ * Scoped WebSocket tail of the kanban plugin's live-events stream
+ * (``/api/plugins/kanban/events`` — backend: plugin_api.py ``stream_events``).
+ *
+ * The backend pins the board at the WS handshake (``board`` query param) and
+ * replays events past the ``since`` cursor, so switching boards means opening a
+ * new connection with a fresh cursor. Event payloads are partial updates, so
+ * consumers are expected to re-fetch the board from REST on any event batch —
+ * the desktop dashboard uses the same debounced-reload pattern.
+ */
+class KanbanEventsClient {
+    // Deferred: building the OkHttp client touches the shared CookieJar
+    // (Android context), which must not happen at construction time — the
+    // client is only built when a stream is actually opened.
+    private val httpClient by lazy { OkHttpProvider.websocket }
+
+    private var webSocket: WebSocket? = null
+    private var reconnectJob: Job? = null
+    private var generation = 0
+    private var closed = true
+    private var backoffMs = INITIAL_BACKOFF_MS
+    private var cursor: Long = 0
+
+    /**
+     * Open (or re-open) the events stream for [board]. A previous connection is
+     * torn down first — safe to call on board switch.
+     *
+     * [onEvents] is invoked with each non-empty envelope; [onStatus] with every
+     * state transition. Both are dispatched on [scope] (caller's main scope).
+     */
+    fun connect(
+        scope: CoroutineScope,
+        board: String,
+        since: Long = 0,
+        onEvents: (KanbanEventsEnvelope) -> Unit,
+        onStatus: (KanbanLiveStatus) -> Unit,
+    ) {
+        val gen = ++generation
+        reconnectJob?.cancel()
+        webSocket?.cancel()
+        closed = false
+        backoffMs = INITIAL_BACKOFF_MS
+        cursor = since
+        openSocket(scope, gen, board, onEvents, onStatus)
+    }
+
+    /** Close the stream and cancel any pending reconnect. */
+    fun disconnect() {
+        closed = true
+        generation++
+        reconnectJob?.cancel()
+        reconnectJob = null
+        webSocket?.cancel()
+        webSocket = null
+    }
+
+    private fun openSocket(
+        scope: CoroutineScope,
+        gen: Int,
+        board: String,
+        onEvents: (KanbanEventsEnvelope) -> Unit,
+        onStatus: (KanbanLiveStatus) -> Unit,
+    ) {
+        if (closed || gen != generation) return
+
+        if (!HermesWsClient.refreshWsTicketIfNeeded()) {
+            onStatus(KanbanLiveStatus.AUTH_FAILED)
+            return
+        }
+
+        val rawAuthParam = AuthManager.serverStore.getLatestState().wsAuthParam
+        val authParam = if (rawAuthParam.isBlank()) "token" else rawAuthParam
+        val url =
+            AuthManager.endpointForBuild().webSocketUrl(
+                path = KANBAN_EVENTS_PATH,
+                authParameter = authParam,
+                credential = AuthManager.getToken().orEmpty(),
+                extraParams = mapOf("since" to cursor.toString(), "board" to board),
+            )
+        val safeUrl = url.replace(Regex("(token|ticket)=[^&]+"), "$1=REDACTED")
+        if (BuildConfig.DEBUG) Log.d(TAG, "Connecting to $safeUrl")
+
+        val request = Request.Builder().url(url).build()
+        webSocket =
+            httpClient.newWebSocket(
+                request,
+                object : WebSocketListener() {
+                    override fun onOpen(
+                        ws: WebSocket,
+                        response: Response,
+                    ) {
+                        if (closed || gen != generation) return
+                        backoffMs = INITIAL_BACKOFF_MS
+                        scope.launch { onStatus(KanbanLiveStatus.CONNECTED) }
+                    }
+
+                    override fun onMessage(
+                        ws: WebSocket,
+                        text: String,
+                    ) {
+                        if (closed || gen != generation) return
+                        val envelope = parseKanbanEventsFrame(text) ?: return
+                        if (envelope.events.isEmpty()) return
+                        envelope.cursor?.let { cursor = it }
+                        scope.launch { onEvents(envelope) }
+                    }
+
+                    override fun onMessage(
+                        ws: WebSocket,
+                        bytes: ByteString,
+                    ) = Unit
+
+                    override fun onClosing(
+                        ws: WebSocket,
+                        code: Int,
+                        reason: String,
+                    ) {
+                        ws.close(code, reason)
+                    }
+
+                    override fun onClosed(
+                        ws: WebSocket,
+                        code: Int,
+                        reason: String,
+                    ) {
+                        if (closed || gen != generation) return
+                        if (code == WS_1008_POLICY_VIOLATION) {
+                            scope.launch { onStatus(KanbanLiveStatus.AUTH_FAILED) }
+                            return
+                        }
+                        scheduleReconnect(scope, gen, board, onEvents, onStatus)
+                    }
+
+                    override fun onFailure(
+                        ws: WebSocket,
+                        t: Throwable,
+                        response: Response?,
+                    ) {
+                        if (closed || gen != generation) return
+                        if (BuildConfig.DEBUG) Log.d(TAG, "Stream failure: ${t.javaClass.simpleName}")
+                        scheduleReconnect(scope, gen, board, onEvents, onStatus)
+                    }
+                },
+            )
+    }
+
+    private fun scheduleReconnect(
+        scope: CoroutineScope,
+        gen: Int,
+        board: String,
+        onEvents: (KanbanEventsEnvelope) -> Unit,
+        onStatus: (KanbanLiveStatus) -> Unit,
+    ) {
+        if (closed || gen != generation) return
+        scope.launch { onStatus(KanbanLiveStatus.DISCONNECTED) }
+        reconnectJob?.cancel()
+        reconnectJob =
+            scope.launch {
+                delay(backoffMs)
+                backoffMs = (backoffMs * 2).coerceAtMost(MAX_BACKOFF_MS)
+                openSocket(scope, gen, board, onEvents, onStatus)
+            }
+    }
+
+    private companion object {
+        const val TAG = "KanbanEvents"
+        const val KANBAN_EVENTS_PATH = "api/plugins/kanban/events"
+        const val INITIAL_BACKOFF_MS = 1_000L
+        const val MAX_BACKOFF_MS = 30_000L
+        const val WS_1008_POLICY_VIOLATION = 1008
+    }
+}

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/KanbanEventsClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/KanbanEventsClient.kt
@@ -129,7 +129,8 @@ class KanbanEventsClient {
     ) {
         if (closed || gen != generation) return
 
-        if (!HermesWsClient.refreshWsTicketIfNeeded()) {
+        val credential = HermesWsClient.mintWsTicket()
+        if (credential.isNullOrBlank()) {
             onStatus(KanbanLiveStatus.AUTH_FAILED)
             return
         }
@@ -140,7 +141,7 @@ class KanbanEventsClient {
             AuthManager.endpointForBuild().webSocketUrl(
                 path = KANBAN_EVENTS_PATH,
                 authParameter = authParam,
-                credential = AuthManager.getToken().orEmpty(),
+                credential = credential,
                 extraParams = mapOf("since" to cursor.toString(), "board" to board),
             )
         val safeUrl = url.replace(Regex("(token|ticket)=[^&]+"), "$1=REDACTED")

--- a/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
@@ -82,6 +83,9 @@ fun KanbanScreen(
             filteredTasks.groupBy { it.status.lowercase() }
         }
     var showAddTaskDialog by remember { mutableStateOf(false) }
+    var taskForActions by remember { mutableStateOf<KanbanTask?>(null) }
+    var confirmTarget by remember { mutableStateOf<Pair<KanbanTask, KanbanTaskAction>?>(null) }
+    var summaryTarget by remember { mutableStateOf<Pair<KanbanTask, KanbanTaskAction>?>(null) }
 
     LaunchedEffect(Unit) {
         viewModel.loadBoards()
@@ -216,7 +220,10 @@ fun KanbanScreen(
                                                     verticalArrangement = Arrangement.spacedBy(8.dp),
                                                 ) {
                                                     items(colTasks, key = { it.id }) { task ->
-                                                        TaskCard(task = task)
+                                                        TaskCard(
+                                                            task = task,
+                                                            onTaskClick = { taskForActions = it },
+                                                        )
                                                     }
                                                 }
                                             }
@@ -251,6 +258,47 @@ fun KanbanScreen(
                             },
                         )
                     }
+
+                    taskForActions?.let { task ->
+                        val actions = kanbanActionsForStatus(task.status)
+                        if (actions.isNotEmpty()) {
+                            TaskActionSheet(
+                                task = task,
+                                actions = actions,
+                                onAction = { action ->
+                                    taskForActions = null
+                                    when {
+                                        action.needsSummary -> summaryTarget = task to action
+                                        action.needsConfirm -> confirmTarget = task to action
+                                        else -> viewModel.moveTask(task, action)
+                                    }
+                                },
+                                onDismiss = { taskForActions = null },
+                            )
+                        }
+                    }
+
+                    confirmTarget?.let { (task, action) ->
+                        ConfirmActionDialog(
+                            message = stringResource(action.confirmRes()),
+                            onConfirm = {
+                                confirmTarget = null
+                                if (action.needsSummary) {
+                                    summaryTarget = task to action
+                                } else {
+                                    viewModel.moveTask(task, action)
+                                }
+                            },
+                            onDismiss = { confirmTarget = null },
+                        )
+                    }
+
+                    summaryTarget?.let { (task, action) ->
+                        CompleteTaskDialog(
+                            onConfirm = { summary -> viewModel.moveTask(task, action, summary) },
+                            onDismiss = { summaryTarget = null },
+                        )
+                    }
                 }
             }
         }
@@ -258,8 +306,11 @@ fun KanbanScreen(
 }
 
 @Composable
-fun TaskCard(task: KanbanTask) {
-    Card(modifier = Modifier.fillMaxWidth()) {
+fun TaskCard(
+    task: KanbanTask,
+    onTaskClick: (KanbanTask) -> Unit,
+) {
+    Card(onClick = { onTaskClick(task) }, modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(12.dp)) {
             Text(text = task.title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
             Spacer(modifier = Modifier.height(4.dp))
@@ -351,6 +402,114 @@ fun AddTaskDialog(
                 enabled = title.isNotBlank(),
             ) {
                 Text(stringResource(R.string.action_add))
+            }
+        },
+        dismissButton = {
+            Button(onClick = onDismiss) {
+                Text(stringResource(R.string.action_cancel))
+            }
+        },
+    )
+}
+
+private fun KanbanTaskAction.labelRes(): Int =
+    when (this) {
+        KanbanTaskAction.TRIAGE -> R.string.kanban_action_triage
+        KanbanTaskAction.READY -> R.string.kanban_action_ready
+        KanbanTaskAction.UNBLOCK -> R.string.kanban_action_unblock
+        KanbanTaskAction.BLOCK -> R.string.kanban_action_block
+        KanbanTaskAction.COMPLETE -> R.string.kanban_action_complete
+        KanbanTaskAction.ARCHIVE -> R.string.kanban_action_archive
+    }
+
+private fun KanbanTaskAction.confirmRes(): Int =
+    when (this) {
+        KanbanTaskAction.BLOCK -> R.string.kanban_confirm_blocked
+        KanbanTaskAction.COMPLETE -> R.string.kanban_confirm_done
+        KanbanTaskAction.ARCHIVE -> R.string.kanban_confirm_archive
+        else -> error("Action $this has no confirm message")
+    }
+
+@Composable
+private fun TaskActionSheet(
+    task: KanbanTask,
+    actions: List<KanbanTaskAction>,
+    onAction: (KanbanTaskAction) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(task.title, maxLines = 2, overflow = TextOverflow.Ellipsis) },
+        text = {
+            Column {
+                actions.forEach { action ->
+                    Button(
+                        onClick = { onAction(action) },
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp),
+                    ) {
+                        Text(stringResource(action.labelRes()))
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            Button(onClick = onDismiss) {
+                Text(stringResource(R.string.action_cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun ConfirmActionDialog(
+    message: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        text = { Text(message) },
+        confirmButton = {
+            Button(onClick = onConfirm) {
+                Text(stringResource(R.string.action_confirm))
+            }
+        },
+        dismissButton = {
+            Button(onClick = onDismiss) {
+                Text(stringResource(R.string.action_cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun CompleteTaskDialog(
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var summary by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.kanban_complete_title)) },
+        text = {
+            OutlinedTextField(
+                value = summary,
+                onValueChange = { summary = it },
+                label = { Text(stringResource(R.string.kanban_complete_summary_label)) },
+                supportingText = { Text(stringResource(R.string.kanban_complete_summary_hint)) },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        confirmButton = {
+            Button(
+                onClick = { onConfirm(summary.trim()) },
+                enabled = summary.isNotBlank(),
+            ) {
+                Text(stringResource(R.string.kanban_action_complete))
             }
         },
         dismissButton = {

--- a/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol.ui.kanban
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,13 +16,17 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -39,6 +44,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -150,9 +156,25 @@ fun KanbanScreen(
                                     Text(stringResource(R.string.kanban_no_columns))
                                 }
                             } else {
+                                Row(
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .padding(horizontal = 16.dp, vertical = 4.dp),
+                                    horizontalArrangement = Arrangement.End,
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    LiveStatusPill(isLive = state.isLive)
+                                }
                                 LazyRow(
                                     modifier = Modifier.fillMaxSize(),
-                                    contentPadding = PaddingValues(16.dp),
+                                    contentPadding =
+                                        PaddingValues(
+                                            start = 16.dp,
+                                            top = 16.dp,
+                                            end = 16.dp,
+                                            bottom = 88.dp,
+                                        ),
                                     horizontalArrangement = Arrangement.spacedBy(16.dp),
                                 ) {
                                     items(state.columns.size, key = { index ->
@@ -179,28 +201,59 @@ fun KanbanScreen(
                                                 modifier = Modifier.padding(bottom = 8.dp),
                                             )
 
-                                            LazyColumn(
-                                                modifier = Modifier.weight(1f),
-                                                verticalArrangement = Arrangement.spacedBy(8.dp),
-                                            ) {
-                                                items(colTasks, key = { it.id }) { task ->
-                                                    TaskCard(
-                                                        task = task,
-                                                        onMoveLeft =
-                                                            prevColumn?.let {
-                                                                { viewModel.moveTask(task, it.name) }
-                                                            },
-                                                        onMoveRight =
-                                                            nextColumn?.let {
-                                                                { viewModel.moveTask(task, it.name) }
-                                                            },
+                                            if (colTasks.isEmpty()) {
+                                                Box(
+                                                    modifier =
+                                                        Modifier
+                                                            .fillMaxWidth()
+                                                            .padding(vertical = 16.dp),
+                                                    contentAlignment = Alignment.Center,
+                                                ) {
+                                                    Text(
+                                                        text = stringResource(R.string.kanban_no_tasks),
+                                                        style = MaterialTheme.typography.bodySmall,
+                                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                                                     )
+                                                }
+                                            } else {
+                                                LazyColumn(
+                                                    modifier = Modifier.weight(1f),
+                                                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                                                ) {
+                                                    items(colTasks, key = { it.id }) { task ->
+                                                        TaskCard(
+                                                            task = task,
+                                                            onMoveLeft =
+                                                                prevColumn?.let {
+                                                                    { viewModel.moveTask(task, it.name) }
+                                                                },
+                                                            onMoveRight =
+                                                                nextColumn?.let {
+                                                                    { viewModel.moveTask(task, it.name) }
+                                                                },
+                                                        )
+                                                    }
                                                 }
                                             }
                                         }
                                     }
                                 }
                             }
+                        }
+                    }
+
+                    if (state.selectedBoard != null) {
+                        FloatingActionButton(
+                            onClick = { showAddTaskDialog = true },
+                            modifier =
+                                Modifier
+                                    .align(Alignment.BottomEnd)
+                                    .padding(16.dp),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Add,
+                                contentDescription = stringResource(R.string.kanban_add_task),
+                            )
                         }
                     }
 
@@ -230,7 +283,29 @@ fun TaskCard(
             Text(text = task.title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
             Spacer(modifier = Modifier.height(4.dp))
             task.description?.let {
-                Text(text = it, style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            task.assignedTo?.let { assignee ->
+                Spacer(modifier = Modifier.height(6.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Filled.Person,
+                        contentDescription = null,
+                        modifier = Modifier.size(14.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = assignee,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
             Spacer(modifier = Modifier.height(8.dp))
             Row(
@@ -261,6 +336,30 @@ fun TaskCard(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun LiveStatusPill(isLive: Boolean) {
+    val color =
+        if (isLive) {
+            MaterialTheme.colorScheme.primary
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        }
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier =
+                Modifier
+                    .size(8.dp)
+                    .background(color = color, shape = CircleShape),
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = stringResource(if (isLive) R.string.kanban_live else R.string.kanban_offline),
+            style = MaterialTheme.typography.labelMedium,
+            color = color,
+        )
     }
 }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
@@ -18,8 +18,6 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Button
@@ -28,7 +26,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.PrimaryScrollableTabRow
@@ -183,8 +180,6 @@ fun KanbanScreen(
                                         val column = state.columns[columnIndex]
                                         val colName = column.name
                                         val colTasks = tasksByColumn[colName.lowercase()] ?: emptyList()
-                                        val prevColumn = state.columns.getOrNull(columnIndex - 1)
-                                        val nextColumn = state.columns.getOrNull(columnIndex + 1)
 
                                         Column(
                                             modifier =
@@ -221,17 +216,7 @@ fun KanbanScreen(
                                                     verticalArrangement = Arrangement.spacedBy(8.dp),
                                                 ) {
                                                     items(colTasks, key = { it.id }) { task ->
-                                                        TaskCard(
-                                                            task = task,
-                                                            onMoveLeft =
-                                                                prevColumn?.let {
-                                                                    { viewModel.moveTask(task, it.name) }
-                                                                },
-                                                            onMoveRight =
-                                                                nextColumn?.let {
-                                                                    { viewModel.moveTask(task, it.name) }
-                                                                },
-                                                        )
+                                                        TaskCard(task = task)
                                                     }
                                                 }
                                             }
@@ -273,11 +258,7 @@ fun KanbanScreen(
 }
 
 @Composable
-fun TaskCard(
-    task: KanbanTask,
-    onMoveLeft: (() -> Unit)?,
-    onMoveRight: (() -> Unit)?,
-) {
+fun TaskCard(task: KanbanTask) {
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(12.dp)) {
             Text(text = task.title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
@@ -305,34 +286,6 @@ fun TaskCard(
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
-                }
-            }
-            Spacer(modifier = Modifier.height(8.dp))
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                if (onMoveLeft != null) {
-                    IconButton(onClick = onMoveLeft) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.content_desc_move_left),
-                        )
-                    }
-                } else {
-                    Spacer(modifier = Modifier.size(48.dp))
-                }
-
-                if (onMoveRight != null) {
-                    IconButton(onClick = onMoveRight) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowForward,
-                            contentDescription = stringResource(R.string.content_desc_move_right),
-                        )
-                    }
-                } else {
-                    Spacer(modifier = Modifier.size(48.dp))
                 }
             }
         }

--- a/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanScreen.kt
@@ -25,8 +25,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.PrimaryScrollableTabRow
@@ -166,6 +166,14 @@ fun KanbanScreen(
                                     verticalAlignment = Alignment.CenterVertically,
                                 ) {
                                     LiveStatusPill(isLive = state.isLive)
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    IconButton(onClick = { showAddTaskDialog = true }) {
+                                        Icon(
+                                            imageVector = Icons.Filled.Add,
+                                            contentDescription = stringResource(R.string.kanban_add_task),
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
                                 }
                                 LazyRow(
                                     modifier = Modifier.fillMaxSize(),
@@ -174,7 +182,7 @@ fun KanbanScreen(
                                             start = 16.dp,
                                             top = 16.dp,
                                             end = 16.dp,
-                                            bottom = 88.dp,
+                                            bottom = 16.dp,
                                         ),
                                     horizontalArrangement = Arrangement.spacedBy(16.dp),
                                 ) {
@@ -231,21 +239,6 @@ fun KanbanScreen(
                                     }
                                 }
                             }
-                        }
-                    }
-
-                    if (state.selectedBoard != null) {
-                        FloatingActionButton(
-                            onClick = { showAddTaskDialog = true },
-                            modifier =
-                                Modifier
-                                    .align(Alignment.BottomEnd)
-                                    .padding(16.dp),
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.Add,
-                                contentDescription = stringResource(R.string.kanban_add_task),
-                            )
                         }
                     }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanViewModel.kt
@@ -33,6 +33,59 @@ data class KanbanUiState(
     val toastMessage: String? = null,
 )
 
+/**
+ * Task actions mirroring the desktop kanban's transition-gated buttons.
+ * Only moves the backend PATCH route accepts are offered: never `running`
+ * (dispatcher-only, backend rejects with 400) and never `review` (not in
+ * the dashboard whitelist).
+ */
+enum class KanbanTaskAction(
+    val targetStatus: String,
+    val needsConfirm: Boolean = false,
+    val needsSummary: Boolean = false,
+) {
+    TRIAGE(targetStatus = "triage"),
+    READY(targetStatus = "ready"),
+    UNBLOCK(targetStatus = "ready"),
+    BLOCK(targetStatus = "blocked", needsConfirm = true),
+    COMPLETE(targetStatus = "done", needsConfirm = true, needsSummary = true),
+    ARCHIVE(targetStatus = "archived", needsConfirm = true),
+}
+
+/** Desktop parity: which actions are valid from a given status. */
+fun kanbanActionsForStatus(status: String): List<KanbanTaskAction> =
+    when (status) {
+        "triage" -> listOf(KanbanTaskAction.READY, KanbanTaskAction.ARCHIVE)
+        "todo" -> listOf(KanbanTaskAction.TRIAGE, KanbanTaskAction.READY, KanbanTaskAction.ARCHIVE)
+        "scheduled" -> listOf(KanbanTaskAction.TRIAGE, KanbanTaskAction.READY, KanbanTaskAction.ARCHIVE)
+        "ready" ->
+            listOf(
+                KanbanTaskAction.TRIAGE,
+                KanbanTaskAction.BLOCK,
+                KanbanTaskAction.COMPLETE,
+                KanbanTaskAction.ARCHIVE,
+            )
+        "running" ->
+            listOf(
+                KanbanTaskAction.TRIAGE,
+                KanbanTaskAction.READY,
+                KanbanTaskAction.BLOCK,
+                KanbanTaskAction.COMPLETE,
+                KanbanTaskAction.ARCHIVE,
+            )
+        "blocked" ->
+            listOf(
+                KanbanTaskAction.TRIAGE,
+                KanbanTaskAction.UNBLOCK,
+                KanbanTaskAction.COMPLETE,
+                KanbanTaskAction.ARCHIVE,
+            )
+        "review" -> listOf(KanbanTaskAction.TRIAGE, KanbanTaskAction.READY, KanbanTaskAction.ARCHIVE)
+        "done" -> listOf(KanbanTaskAction.TRIAGE, KanbanTaskAction.READY, KanbanTaskAction.ARCHIVE)
+        "archived" -> listOf(KanbanTaskAction.TRIAGE, KanbanTaskAction.READY)
+        else -> emptyList()
+    }
+
 class KanbanViewModel(
     private val eventsClientProvider: () -> KanbanEventsClient = { KanbanEventsClient() },
 ) : ViewModel(), ToastHost {
@@ -119,6 +172,57 @@ class KanbanViewModel(
                     _uiState.update { it.copy(toastMessage = "Failed to create task: ${result.error.message}") }
                 }
             }
+        }
+    }
+
+    fun moveTask(
+        task: KanbanTask,
+        action: KanbanTaskAction,
+        summary: String? = null,
+    ) {
+        val originalStatus = task.status
+        // Optimistically update, desktop-style
+        _uiState.update { state ->
+            state.copy(
+                tasks =
+                    state.tasks.map {
+                        if (it.id == task.id) it.copy(status = action.targetStatus) else it
+                    },
+            )
+        }
+
+        viewModelScope.launch {
+            val body =
+                buildMap<String, String?> {
+                    put("status", action.targetStatus)
+                    if (action.needsSummary && !summary.isNullOrBlank()) {
+                        put("result", summary)
+                        put("summary", summary)
+                    }
+                }
+            val result =
+                withContext(Dispatchers.IO) {
+                    safeApiCall { ApiClient.hermesApi.updateKanbanTask(task.id, body) }
+                }
+            if (result is NetworkResult.Failure) {
+                revertTaskMove(task.id, originalStatus, "Move failed: ${result.error.message}")
+            }
+        }
+    }
+
+    private fun revertTaskMove(
+        taskId: String,
+        originalStatus: String,
+        errorMsg: String,
+    ) {
+        _uiState.update { state ->
+            state.copy(
+                tasks =
+                    state.tasks.map {
+                        if (it.id == taskId) it.copy(status = originalStatus) else it
+                    },
+                toastMessage = errorMsg,
+            )
         }
     }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanViewModel.kt
@@ -8,9 +8,13 @@ import com.m57.hermescontrol.data.model.KanbanTask
 import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.NetworkResult
 import com.m57.hermescontrol.data.remote.safeApiCall
+import com.m57.hermescontrol.data.ws.KanbanEventsClient
+import com.m57.hermescontrol.data.ws.KanbanLiveStatus
 import com.m57.hermescontrol.ui.common.ToastHost
 import com.m57.hermescontrol.ui.common.safeLaunchLoad
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -24,15 +28,20 @@ data class KanbanUiState(
     val selectedBoard: KanbanBoard? = null,
     val columns: List<KanbanColumn> = emptyList(),
     val tasks: List<KanbanTask> = emptyList(),
+    val isLive: Boolean = false,
     val errorMessage: String? = null,
     val toastMessage: String? = null,
 )
 
-class KanbanViewModel :
-    ViewModel(),
-    ToastHost {
+class KanbanViewModel(
+    private val eventsClientProvider: () -> KanbanEventsClient = { KanbanEventsClient() },
+) : ViewModel(), ToastHost {
     private val _uiState = MutableStateFlow(KanbanUiState())
     val uiState: StateFlow<KanbanUiState> = _uiState.asStateFlow()
+
+    private var eventsClient: KanbanEventsClient? = null
+    private var eventsBoard: String? = null
+    private var reloadJob: Job? = null
 
     fun loadBoards() {
         safeLaunchLoad(
@@ -75,32 +84,8 @@ class KanbanViewModel :
                 return@launch
             }
 
-            val result =
-                withContext(Dispatchers.IO) {
-                    safeApiCall { ApiClient.hermesApi.getKanbanBoard() }
-                }
-            when (result) {
-                is NetworkResult.Success -> {
-                    val body = result.data
-                    val allTasks = body.columns.flatMap { it.tasks }
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            columns = body.columns,
-                            tasks = allTasks,
-                        )
-                    }
-                }
-
-                is NetworkResult.Failure -> {
-                    _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            errorMessage = "Failed to load Kanban tasks: ${result.error.message}",
-                        )
-                    }
-                }
-            }
+            loadBoardIntoState(board)
+            connectEvents(board)
         }
     }
 
@@ -165,6 +150,90 @@ class KanbanViewModel :
         }
     }
 
+    override fun onCleared() {
+        eventsClient?.disconnect()
+        super.onCleared()
+    }
+
+    // ── Live events (issue #775) ─────────────────────────────────────────
+
+    /**
+     * Tail the kanban events WebSocket for [board]. The backend pins the board
+     * at the WS handshake, so a board switch opens a fresh stream; re-selecting
+     * the already-live board is a no-op (the REST load already refreshed it).
+     */
+    private fun connectEvents(board: KanbanBoard) {
+        if (eventsBoard == board.id && _uiState.value.isLive) return
+        eventsBoard = board.id
+        val client = eventsClient ?: eventsClientProvider().also { eventsClient = it }
+        client.connect(
+            scope = viewModelScope,
+            board = board.id,
+            onEvents = { scheduleBoardReload() },
+            onStatus = { status ->
+                _uiState.update { it.copy(isLive = status == KanbanLiveStatus.CONNECTED) }
+            },
+        )
+    }
+
+    /** Debounced REST refresh after an events batch — mirrors the desktop pattern. */
+    private fun scheduleBoardReload() {
+        reloadJob?.cancel()
+        reloadJob =
+            viewModelScope.launch {
+                delay(RELOAD_DEBOUNCE_MS)
+                reloadBoardSilently()
+            }
+    }
+
+    /** Re-fetch the current board without touching the loading spinner. */
+    private fun reloadBoardSilently() {
+        viewModelScope.launch {
+            val result =
+                withContext(Dispatchers.IO) {
+                    safeApiCall { ApiClient.hermesApi.getKanbanBoard() }
+                }
+            if (result is NetworkResult.Success) {
+                val body = result.data
+                _uiState.update {
+                    it.copy(
+                        columns = body.columns,
+                        tasks = body.columns.flatMap { it.tasks },
+                    )
+                }
+            }
+        }
+    }
+
+    private suspend fun loadBoardIntoState(board: KanbanBoard) {
+        val result =
+            withContext(Dispatchers.IO) {
+                safeApiCall { ApiClient.hermesApi.getKanbanBoard() }
+            }
+        when (result) {
+            is NetworkResult.Success -> {
+                val body = result.data
+                val allTasks = body.columns.flatMap { it.tasks }
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        columns = body.columns,
+                        tasks = allTasks,
+                    )
+                }
+            }
+
+            is NetworkResult.Failure -> {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        errorMessage = "Failed to load Kanban tasks: ${result.error.message}",
+                    )
+                }
+            }
+        }
+    }
+
     private fun revertTaskMove(
         taskId: String,
         originalStatus: String,
@@ -183,5 +252,9 @@ class KanbanViewModel :
 
     override fun clearToast() {
         _uiState.update { it.copy(toastMessage = null) }
+    }
+
+    private companion object {
+        const val RELOAD_DEBOUNCE_MS = 250L
     }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanViewModel.kt
@@ -122,34 +122,6 @@ class KanbanViewModel(
         }
     }
 
-    fun moveTask(
-        task: KanbanTask,
-        newStatus: String,
-    ) {
-        val originalStatus = task.status
-        val board = _uiState.value.selectedBoard ?: return
-
-        // Optimistically update
-        _uiState.update { state ->
-            state.copy(
-                tasks =
-                    state.tasks.map {
-                        if (it.id == task.id) it.copy(status = newStatus) else it
-                    },
-            )
-        }
-
-        viewModelScope.launch {
-            val result =
-                withContext(Dispatchers.IO) {
-                    safeApiCall { ApiClient.hermesApi.updateKanbanTask(task.id, mapOf("status" to newStatus)) }
-                }
-            if (result is NetworkResult.Failure) {
-                revertTaskMove(task.id, originalStatus, "Failed to move task: ${result.error.message}")
-            }
-        }
-    }
-
     override fun onCleared() {
         eventsClient?.disconnect()
         super.onCleared()
@@ -231,22 +203,6 @@ class KanbanViewModel(
                     )
                 }
             }
-        }
-    }
-
-    private fun revertTaskMove(
-        taskId: String,
-        originalStatus: String,
-        errorMsg: String,
-    ) {
-        _uiState.update { state ->
-            state.copy(
-                tasks =
-                    state.tasks.map {
-                        if (it.id == taskId) it.copy(status = originalStatus) else it
-                    },
-                toastMessage = errorMsg,
-            )
         }
     }
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -211,8 +211,6 @@
     <string name="kanban_task_title">작업 제목</string>
     <string name="kanban_task_desc">작업 설명</string>
     <string name="action_add">추가</string>
-    <string name="content_desc_move_left">왼쪽으로</string>
-    <string name="content_desc_move_right">오른쪽으로</string>
 
     <!-- Skills Screen -->
     <string name="skills_status_all">모든 상태</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <!-- Actions -->
     <string name="action_retry">Retry</string>
     <string name="action_cancel">Cancel</string>
+    <string name="action_confirm">Confirm</string>
     <string name="action_clear">Clear</string>
     <string name="action_ok">OK</string>
     <string name="action_delete">Delete</string>
@@ -243,6 +244,19 @@
     <string name="kanban_task_title">Task Title</string>
     <string name="kanban_task_desc">Task Description</string>
     <string name="kanban_add_task">Add task</string>
+    <string name="kanban_action_triage">Triage</string>
+    <string name="kanban_action_ready">Ready</string>
+    <string name="kanban_action_block">Block</string>
+    <string name="kanban_action_unblock">Unblock</string>
+    <string name="kanban_action_complete">Complete</string>
+    <string name="kanban_action_archive">Archive</string>
+    <string name="kanban_confirm_blocked">Mark this task as blocked? The worker\'s claim is released.</string>
+    <string name="kanban_confirm_done">Complete this task? The worker\'s claim is released.</string>
+    <string name="kanban_confirm_archive">Archive this task? It disappears from the default board view.</string>
+    <string name="kanban_complete_title">Complete task</string>
+    <string name="kanban_complete_summary_label">Completion summary</string>
+    <string name="kanban_complete_summary_hint">Stored as the task result</string>
+    <string name="kanban_move_failed">Move failed: %1$s</string>
     <string name="kanban_live">Live</string>
     <string name="kanban_offline">Offline</string>
     <string name="kanban_no_tasks">No tasks</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -247,9 +247,6 @@
     <string name="kanban_offline">Offline</string>
     <string name="kanban_no_tasks">No tasks</string>
     <string name="action_add">Add</string>
-    <string name="content_desc_move_left">Move Left</string>
-    <string name="content_desc_move_right">Move Right</string>
-
     <!-- Skills Screen -->
     <string name="skills_status_all">All Statuses</string>
     <string name="skills_status_enabled">Enabled</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -242,6 +242,10 @@
     <string name="kanban_add_new_task">Add New Task</string>
     <string name="kanban_task_title">Task Title</string>
     <string name="kanban_task_desc">Task Description</string>
+    <string name="kanban_add_task">Add task</string>
+    <string name="kanban_live">Live</string>
+    <string name="kanban_offline">Offline</string>
+    <string name="kanban_no_tasks">No tasks</string>
     <string name="action_add">Add</string>
     <string name="content_desc_move_left">Move Left</string>
     <string name="content_desc_move_right">Move Right</string>

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -1206,8 +1206,6 @@ class E2eIntegrationTest {
             coEvery { mockApiService.switchKanbanBoard("board-1") } returns Response.success(Unit)
             coEvery { mockApiService.getKanbanBoard() } returns
                 Response.success(KanbanBoardResponse(listOf(KanbanColumn("todo", listOf(task))), null, null))
-            coEvery { mockApiService.updateKanbanTask("task-1", mapOf("status" to "in_progress")) } returns
-                Response.success(Unit)
 
             val viewModel = KanbanViewModel(eventsClientProvider = { mockk<KanbanEventsClient>(relaxed = true) })
             viewModel.loadBoards()
@@ -1221,21 +1219,6 @@ class E2eIntegrationTest {
             assertEquals(1, viewModel.uiState.value.tasks.size)
             assertEquals(
                 "todo",
-                viewModel.uiState.value.tasks[0]
-                    .status,
-            )
-
-            viewModel.moveTask(viewModel.uiState.value.tasks[0], "in_progress")
-            // Optimistic move check
-            assertEquals(
-                "in_progress",
-                viewModel.uiState.value.tasks[0]
-                    .status,
-            )
-
-            advanceUntilIdle()
-            assertEquals(
-                "in_progress",
                 viewModel.uiState.value.tasks[0]
                     .status,
             )

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -51,6 +51,7 @@ import com.m57.hermescontrol.data.ws.KanbanEventsClient
 import com.m57.hermescontrol.ui.channels.ChannelsViewModel
 import com.m57.hermescontrol.ui.connect.ConnectViewModel
 import com.m57.hermescontrol.ui.cron.CronJobsViewModel
+import com.m57.hermescontrol.ui.kanban.KanbanTaskAction
 import com.m57.hermescontrol.ui.kanban.KanbanViewModel
 import com.m57.hermescontrol.ui.keys.KeysViewModel
 import com.m57.hermescontrol.ui.logs.LogsViewModel
@@ -1219,6 +1220,22 @@ class E2eIntegrationTest {
             assertEquals(1, viewModel.uiState.value.tasks.size)
             assertEquals(
                 "todo",
+                viewModel.uiState.value.tasks[0]
+                    .status,
+            )
+
+            // Desktop-style transition: todo -> ready is a direct write the
+            // backend accepts; the VM PATCHes the target status.
+            coEvery {
+                mockApiService.updateKanbanTask(
+                    "task-1",
+                    mapOf("status" to "ready"),
+                )
+            } returns Response.success(Unit)
+            viewModel.moveTask(viewModel.uiState.value.tasks[0], KanbanTaskAction.READY)
+            advanceUntilIdle()
+            assertEquals(
+                "ready",
                 viewModel.uiState.value.tasks[0]
                     .status,
             )

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -47,6 +47,7 @@ import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.CleartextPolicy
 import com.m57.hermescontrol.data.remote.HermesApiService
 import com.m57.hermescontrol.data.remote.ServerEndpoint
+import com.m57.hermescontrol.data.ws.KanbanEventsClient
 import com.m57.hermescontrol.ui.channels.ChannelsViewModel
 import com.m57.hermescontrol.ui.connect.ConnectViewModel
 import com.m57.hermescontrol.ui.cron.CronJobsViewModel
@@ -1208,7 +1209,7 @@ class E2eIntegrationTest {
             coEvery { mockApiService.updateKanbanTask("task-1", mapOf("status" to "in_progress")) } returns
                 Response.success(Unit)
 
-            val viewModel = KanbanViewModel()
+            val viewModel = KanbanViewModel(eventsClientProvider = { mockk<KanbanEventsClient>(relaxed = true) })
             viewModel.loadBoards()
             advanceUntilIdle()
 

--- a/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/E2eIntegrationTest.kt
@@ -1239,6 +1239,13 @@ class E2eIntegrationTest {
                 viewModel.uiState.value.tasks[0]
                     .status,
             )
+
+            // Create path: the wrapped {"task": ...} response must not
+            // break deserialization — the API layer reads it as Unit.
+            coEvery { mockApiService.createKanbanTask(any(), any()) } returns Response.success(Unit)
+            viewModel.createTask("Fresh task", null, "todo")
+            advanceUntilIdle()
+            assertEquals("Task created successfully", viewModel.uiState.value.toastMessage)
         }
 
     @Test

--- a/app/src/test/java/com/m57/hermescontrol/data/remote/ServerEndpointTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/remote/ServerEndpointTest.kt
@@ -49,6 +49,26 @@ class ServerEndpointTest {
     }
 
     @Test
+    fun `webSocketUrl with custom path and extra params`() {
+        val ep = ServerEndpoint.parse("https://example.com/hermes", CleartextPolicy.ALLOW_WITH_WARNING)
+        val url =
+            ep.webSocketUrl(
+                path = "api/plugins/kanban/events",
+                authParameter = "token",
+                credential = "secret",
+                extraParams = mapOf("since" to "0", "board" to "work"),
+            )
+        assertEquals("wss://example.com/hermes/api/plugins/kanban/events?token=secret&since=0&board=work", url)
+    }
+
+    @Test
+    fun `webSocketUrl with custom path keeps http scheme as ws`() {
+        val ep = ServerEndpoint.parse("http://127.0.0.1:9119/", CleartextPolicy.ALLOW_WITH_WARNING)
+        val url = ep.webSocketUrl("api/plugins/kanban/events", "ticket", "t1", mapOf("board" to "default"))
+        assertEquals("ws://127.0.0.1:9119/api/plugins/kanban/events?ticket=t1&board=default", url)
+    }
+
+    @Test
     fun `DENY policy rejects http`() {
         assertThrows<IllegalArgumentException> {
             ServerEndpoint.parse("http://127.0.0.1:9119/", CleartextPolicy.DENY)

--- a/app/src/test/java/com/m57/hermescontrol/data/ws/KanbanEventsClientTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/ws/KanbanEventsClientTest.kt
@@ -1,0 +1,48 @@
+package com.m57.hermescontrol.data.ws
+
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class KanbanEventsClientTest {
+    @Test
+    fun `parses envelope with snake_case fields and cursor`() {
+        val frame =
+            """{"events":[{"id":7,"task_id":"t-1","run_id":"r-9","kind":"status","payload":{"status":"done"},"created_at":1710000000}],"cursor":7}"""
+        val envelope = parseKanbanEventsFrame(frame)
+        assertNotNull(envelope)
+        assertEquals(7L, envelope!!.cursor)
+        assertEquals(1, envelope.events.size)
+        val event = envelope.events.first()
+        assertEquals(7L, event.id)
+        assertEquals("t-1", event.taskId)
+        assertEquals("r-9", event.runId)
+        assertEquals("status", event.kind)
+        assertEquals("done", event.payload?.get("status")?.jsonPrimitive?.content)
+        assertEquals(1710000000L, event.createdAt)
+    }
+
+    @Test
+    fun `parses empty events batch`() {
+        val envelope = parseKanbanEventsFrame("""{"events":[],"cursor":3}""")
+        assertNotNull(envelope)
+        assertEquals(3L, envelope!!.cursor)
+        assertEquals(0, envelope.events.size)
+    }
+
+    @Test
+    fun `null payload tolerated`() {
+        val envelope = parseKanbanEventsFrame("""{"events":[{"id":1,"kind":"edited","payload":null}],"cursor":1}""")
+        assertNotNull(envelope)
+        assertNull(envelope!!.events.first().payload)
+    }
+
+    @Test
+    fun `malformed frames return null`() {
+        assertNull(parseKanbanEventsFrame("not json"))
+        assertNull(parseKanbanEventsFrame("""{"events": 42}"""))
+        assertNull(parseKanbanEventsFrame(""))
+    }
+}

--- a/app/src/test/java/com/m57/hermescontrol/ui/kanban/KanbanViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/kanban/KanbanViewModelTest.kt
@@ -1,0 +1,180 @@
+package com.m57.hermescontrol.ui.kanban
+
+import com.m57.hermescontrol.data.model.KanbanBoard
+import com.m57.hermescontrol.data.model.KanbanBoardResponse
+import com.m57.hermescontrol.data.model.KanbanBoardsResponse
+import com.m57.hermescontrol.data.model.KanbanColumn
+import com.m57.hermescontrol.data.model.KanbanTask
+import com.m57.hermescontrol.data.remote.ApiClient
+import com.m57.hermescontrol.data.remote.HermesApiService
+import com.m57.hermescontrol.data.ws.KanbanEvent
+import com.m57.hermescontrol.data.ws.KanbanEventsClient
+import com.m57.hermescontrol.data.ws.KanbanEventsEnvelope
+import com.m57.hermescontrol.data.ws.KanbanLiveStatus
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Response
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class KanbanViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private val mockApi = mockk<HermesApiService>(relaxed = true)
+    private val mockEventsClient = mockk<KanbanEventsClient>(relaxed = true)
+
+    private fun createViewModel(): KanbanViewModel {
+        val vm = KanbanViewModel(eventsClientProvider = { mockEventsClient })
+        testDispatcher.scheduler.advanceUntilIdle()
+        return vm
+    }
+
+    /**
+     * Pump the test scheduler while letting the real Dispatchers.IO hops
+     * (safeLaunchLoad / withContext(IO)) land their resumptions.
+     */
+    private fun settle() {
+        repeat(20) {
+            testDispatcher.scheduler.advanceUntilIdle()
+            Thread.sleep(10)
+        }
+        testDispatcher.scheduler.advanceUntilIdle()
+    }
+
+    private fun stubBoard(tasks: List<KanbanTask> = listOf(KanbanTask(id = "t1", title = "Task 1", status = "todo"))) {
+        coEvery { mockApi.getKanbanBoards() } returns
+            Response.success(
+                KanbanBoardsResponse(
+                    boards = listOf(KanbanBoard(id = "work", name = "Work")),
+                    current = "work",
+                ),
+            )
+        coEvery { mockApi.switchKanbanBoard("work") } returns Response.success(Unit)
+        coEvery { mockApi.getKanbanBoard() } returns
+            Response.success(KanbanBoardResponse(columns = listOf(KanbanColumn(name = "todo", tasks = tasks))))
+    }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockkObject(ApiClient)
+        every { ApiClient.hermesApi } returns mockApi
+        stubBoard()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun `loadBoards connects events stream for current board`() {
+        val vm = createViewModel()
+        vm.loadBoards()
+        settle()
+        verify { mockEventsClient.connect(any(), eq("work"), any(), any(), any()) }
+    }
+
+    @Test
+    fun `connected status flips isLive`() {
+        val vm = createViewModel()
+        vm.loadBoards()
+        settle()
+        val statusSlot = slot<(KanbanLiveStatus) -> Unit>()
+        verify { mockEventsClient.connect(any(), any(), any(), any(), capture(statusSlot)) }
+        statusSlot.captured(KanbanLiveStatus.CONNECTED)
+        assertTrue(vm.uiState.value.isLive)
+        statusSlot.captured(KanbanLiveStatus.DISCONNECTED)
+        assertFalse(vm.uiState.value.isLive)
+    }
+
+    @Test
+    fun `events batch triggers debounced board reload`() {
+        val vm = createViewModel()
+        vm.loadBoards()
+        settle()
+        val eventsSlot = slot<(KanbanEventsEnvelope) -> Unit>()
+        verify { mockEventsClient.connect(any(), any(), any(), capture(eventsSlot), any()) }
+
+        coEvery { mockApi.getKanbanBoard() } returns
+            Response.success(
+                KanbanBoardResponse(
+                    columns =
+                        listOf(
+                            KanbanColumn(
+                                name = "todo",
+                                tasks =
+                                    listOf(
+                                        KanbanTask(id = "t1", title = "Task 1", status = "todo"),
+                                        KanbanTask(id = "t2", title = "Task 2", status = "todo"),
+                                    ),
+                            ),
+                        ),
+                ),
+            )
+
+        eventsSlot.captured(KanbanEventsEnvelope(events = listOf(KanbanEvent(id = 1, kind = "created")), cursor = 1))
+        testDispatcher.scheduler.advanceTimeBy(249)
+        assertEquals(1, vm.uiState.value.tasks.size)
+        testDispatcher.scheduler.advanceTimeBy(1)
+        settle()
+        assertEquals(2, vm.uiState.value.tasks.size)
+        coVerify(exactly = 2) { mockApi.getKanbanBoard() }
+    }
+
+    @Test
+    fun `board switch reconnects events stream with new board`() {
+        val vm = createViewModel()
+        vm.loadBoards()
+        settle()
+        coEvery { mockApi.switchKanbanBoard("ops") } returns Response.success(Unit)
+        coEvery { mockApi.getKanbanBoard() } returns
+            Response.success(KanbanBoardResponse(columns = listOf(KanbanColumn(name = "todo", tasks = emptyList()))))
+        vm.selectBoard(KanbanBoard(id = "ops", name = "Ops"))
+        settle()
+        verify { mockEventsClient.connect(any(), eq("ops"), any(), any(), any()) }
+    }
+
+    @Test
+    fun `re-selecting already-live board does not reconnect`() {
+        val vm = createViewModel()
+        vm.loadBoards()
+        settle()
+        val statusSlot = slot<(KanbanLiveStatus) -> Unit>()
+        verify { mockEventsClient.connect(any(), any(), any(), any(), capture(statusSlot)) }
+        statusSlot.captured(KanbanLiveStatus.CONNECTED)
+
+        vm.selectBoard(KanbanBoard(id = "work", name = "Work"))
+        settle()
+        verify(exactly = 1) { mockEventsClient.connect(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `onCleared disconnects events stream`() {
+        val vm = createViewModel()
+        vm.loadBoards()
+        settle()
+        val method = KanbanViewModel::class.java.getDeclaredMethod("onCleared")
+        method.isAccessible = true
+        method.invoke(vm)
+        verify { mockEventsClient.disconnect() }
+    }
+}

--- a/app/src/test/java/com/m57/hermescontrol/ui/kanban/KanbanViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/kanban/KanbanViewModelTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -176,5 +177,84 @@ class KanbanViewModelTest {
         method.isAccessible = true
         method.invoke(vm)
         verify { mockEventsClient.disconnect() }
+    }
+
+    @Test
+    fun `kanbanActionsForStatus gates transitions like the desktop`() {
+        assertEquals(
+            listOf(KanbanTaskAction.TRIAGE, KanbanTaskAction.READY, KanbanTaskAction.ARCHIVE),
+            kanbanActionsForStatus("todo"),
+        )
+        assertEquals(
+            listOf(
+                KanbanTaskAction.TRIAGE,
+                KanbanTaskAction.UNBLOCK,
+                KanbanTaskAction.COMPLETE,
+                KanbanTaskAction.ARCHIVE,
+            ),
+            kanbanActionsForStatus("blocked"),
+        )
+        assertEquals(
+            listOf(
+                KanbanTaskAction.TRIAGE,
+                KanbanTaskAction.READY,
+                KanbanTaskAction.BLOCK,
+                KanbanTaskAction.COMPLETE,
+                KanbanTaskAction.ARCHIVE,
+            ),
+            kanbanActionsForStatus("running"),
+        )
+        assertEquals(
+            listOf(KanbanTaskAction.TRIAGE, KanbanTaskAction.READY, KanbanTaskAction.ARCHIVE),
+            kanbanActionsForStatus("done"),
+        )
+        // Backend-rejected targets are never offered.
+        assertFalse(kanbanActionsForStatus("todo").any { it.targetStatus == "review" })
+        assertFalse(kanbanActionsForStatus("todo").any { it.targetStatus == "running" })
+        assertFalse(kanbanActionsForStatus("ready").any { it.targetStatus == "running" })
+    }
+
+    @Test
+    fun `moveTask updates status and PATCHes the target`() {
+        val vm = createViewModel()
+        vm.loadBoards()
+        settle()
+        coEvery { mockApi.updateKanbanTask(any(), any()) } returns Response.success(Unit)
+        vm.moveTask(KanbanTask(id = "t1", title = "Task 1", status = "todo"), KanbanTaskAction.READY)
+        settle()
+        assertEquals("ready", vm.uiState.value.tasks.first { it.id == "t1" }.status)
+        coVerify { mockApi.updateKanbanTask("t1", mapOf("status" to "ready")) }
+    }
+
+    @Test
+    fun `moveTask failure reverts status and shows toast`() {
+        val vm = createViewModel()
+        vm.loadBoards()
+        settle()
+        coEvery { mockApi.updateKanbanTask(any(), any()) } returns Response.error(409, "".toResponseBody())
+        vm.moveTask(KanbanTask(id = "t1", title = "Task 1", status = "todo"), KanbanTaskAction.READY)
+        settle()
+        assertEquals("todo", vm.uiState.value.tasks.first { it.id == "t1" }.status)
+        assertTrue(vm.uiState.value.toastMessage?.contains("Move failed") == true)
+    }
+
+    @Test
+    fun `moveTask complete sends the completion summary`() {
+        val vm = createViewModel()
+        vm.loadBoards()
+        settle()
+        coEvery { mockApi.updateKanbanTask(any(), any()) } returns Response.success(Unit)
+        vm.moveTask(
+            KanbanTask(id = "t1", title = "Task 1", status = "ready"),
+            KanbanTaskAction.COMPLETE,
+            summary = "Shipped it",
+        )
+        settle()
+        coVerify {
+            mockApi.updateKanbanTask(
+                "t1",
+                mapOf("status" to "done", "result" to "Shipped it", "summary" to "Shipped it"),
+            )
+        }
     }
 }


### PR DESCRIPTION
Fixes #775 — mobile Kanban was pure REST + manual refresh while the desktop kanban gets live updates over a dedicated WebSocket.

## Live updates (#775)

Subscribes to `/api/plugins/kanban/events` from the kanban screen:

- **`KanbanEventsClient`** (new, `data/ws/`) — tails the plugin's events WS with `since` cursor tracking, exponential backoff reconnect (1s→30s cap), stops on `1008` auth rejection. Board is pinned at the WS handshake (backend contract, `plugin_api.py stream_events`), so a board switch opens a fresh stream with a fresh cursor; re-selecting the already-live board is a no-op.
- **`KanbanViewModel`** — connects the stream after the board loads; on any event batch, a **debounced (250ms) REST reload** of the board (event payloads are partial updates like `{"status":"done"}`, so the desktop's reload-on-events pattern is mirrored instead of applying payloads locally). `isLive` state drives a new Live/Offline pill; `onCleared` disconnects.
- **`ServerEndpoint.webSocketUrl(path, …)`** overload — builds WS URLs for non-chat dashboard endpoints (proxy prefix + scheme swap + extra query params), existing `api/ws` behavior unchanged.
- Reuses `HermesWsClient.refreshWsTicketIfNeeded()` (private → internal) for loopback-token refresh / gated-mode ticket minting — no auth logic duplicated.
- REST remains the fallback: pull-to-refresh and all manual reloads still work if the stream is down.

## Kanban UI pass (same PR, small)

- **Add-task FAB** — the existing `AddTaskDialog` was unreachable (nothing set `showAddTaskDialog = true`), so adding a task from mobile was impossible. FAB opens it; column list gets bottom padding so cards don't hide behind it.
- Live/Offline status pill (dot + label, right-aligned above the columns).
- Assignee chip on task cards (data was already fetched but never rendered).
- 2-line description clamp with ellipsis; "No tasks" hint in empty columns.

## Verification

- `ktlintCheck` green (gradle task, not the standalone binary)
- Full `testDebugUnitTest` suite green locally (708 tests) on a clean build
- New tests: `KanbanEventsClientTest` (frame parsing: snake_case fields, null payload, malformed frames), `KanbanViewModelTest` (connect on board load, `isLive` flips, debounced reload on events, board-switch reconnect, no-reconnect guard, disconnect on clear), `ServerEndpointTest` (path/extra-params overload)
- `E2eIntegrationTest` kanban case updated to inject a mocked events client (constructor param added)