### PR TITLE
🔒 Secure RemoteInput PendingIntent boundaries

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/notification/ChatNotificationService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/notification/ChatNotificationService.kt
@@ -134,6 +134,7 @@ class ChatNotificationService : Service() {
             val replyIntent =
                 Intent(this, NotificationReplyReceiver::class.java).apply {
                     action = "$packageName.ACTION_NOTIFICATION_REPLY"
+                    setPackage(packageName)
                     putExtra(NotificationReplyReceiver.EXTRA_SESSION_ID, sessionId)
                 }
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Secured a mutable `PendingIntent` used for notification direct replies in `ChatNotificationService.kt`.

⚠️ **Risk:** The potential impact if left unfixed
A mutable `PendingIntent` without strict component boundaries could theoretically allow a malicious application to intercept the intent or inject unexpected data if the implicit/explicit boundaries aren't perfectly sealed, though the risk is lower here because the class was already explicitly targeted. Static analysis scanners flag this because `FLAG_MUTABLE` requires defense-in-depth boundary setting.

🛡️ **Solution:** How the fix addresses the vulnerability
Added `setPackage(packageName)` to explicitly lock the intent's delivery exclusively to our application's package boundaries. We intentionally retained `PendingIntent.FLAG_MUTABLE` (rather than changing it to `FLAG_IMMUTABLE`) because the Android framework's `RemoteInput` mechanism strictly requires mutability to append the user's text. This satisfies the security constraint without breaking direct reply functionality.

---
*PR created automatically by Jules for task [15467658530716716281](https://jules.google.com/task/15467658530716716281) started by @Hy4ri*