### PR TITLE
fix(chat): route back navigation to history

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/Navigation.kt
+++ b/app/src/main/java/com/m57/hermescontrol/Navigation.kt
@@ -1,5 +1,6 @@
 package com.m57.hermescontrol
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -155,6 +156,10 @@ fun MainNavigation(sessionId: String? = null) {
         }
 
     val openDrawer: () -> Unit = { scope.launch { drawerState.open() } }
+
+    BackHandler(enabled = currentScreen == ChatScreen && backStack.size == 1) {
+        NavigationController.goBack()
+    }
 
     CompositionLocalProvider(LocalDrawerGestureController provides gestureController) {
         ModalNavigationDrawer(

--- a/app/src/main/java/com/m57/hermescontrol/NavigationController.kt
+++ b/app/src/main/java/com/m57/hermescontrol/NavigationController.kt
@@ -58,6 +58,10 @@ object NavigationController {
      */
     fun goBack(fallback: NavKey = ChatScreen) {
         val stack = backStack ?: return
+        if (stack.lastOrNull() == ChatScreen) {
+            resetTo(HistoryScreen)
+            return
+        }
         if (stack.size > 1) {
             stack.removeLastOrNull()
         } else if (stack.size == 1) {

--- a/app/src/test/java/com/m57/hermescontrol/NavigationControllerTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/NavigationControllerTest.kt
@@ -162,6 +162,17 @@ class NavigationControllerTest {
     }
 
     @Test
+    fun `goBack from chat opens history`() {
+        val backStack = NavBackStack<NavKey>(ChatScreen)
+        NavigationController.backStack = backStack
+
+        NavigationController.goBack()
+
+        assertEquals(1, backStack.size)
+        assertEquals(HistoryScreen, backStack.lastOrNull())
+    }
+
+    @Test
     fun `goBack falls back to default screen when stack has one item`() {
         val backStack = NavBackStack<NavKey>(ProfilesScreen)
         NavigationController.backStack = backStack


### PR DESCRIPTION
## Summary
- route Android Back from Chat to History through the shared navigation controller
- handle the root-chat back stack used by physical and gesture navigation
- add a navigation regression test and verify the flow on a Samsung SM-S948B

## Verification
- `./gradlew testDebugUnitTest --tests com.m57.hermescontrol.NavigationControllerTest ktlintCheck checkColorLiterals assembleRelease`
- device: History → session → Back → History
