### PR TITLE
fix(auth): use ServerEndpoint in relogin() to fix HTTPS/proxy 404 (#802)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -2887,9 +2887,7 @@ class ChatViewModel(
         onResult: (Boolean, String?) -> Unit,
     ) {
         viewModelScope.launch(Dispatchers.IO) {
-            val host = AuthManager.getHost()
-            val port = AuthManager.getPort()
-            val baseUrl = "http://$host:$port"
+            val endpoint = AuthManager.endpointForBuild()
             val jsonMediaType = "application/json; charset=utf-8".toMediaType()
             val jsonBody =
                 JSONObject()
@@ -2910,7 +2908,7 @@ class ChatViewModel(
                 val loginReq =
                     Request
                         .Builder()
-                        .url("$baseUrl/auth/password-login")
+                        .url(endpoint.resolve("auth/password-login").toString())
                         .header("Content-Type", "application/json")
                         .post(jsonBody.toRequestBody(jsonMediaType))
                         .build()
@@ -2939,7 +2937,7 @@ class ChatViewModel(
                 val ticketReq =
                     Request
                         .Builder()
-                        .url("$baseUrl/api/auth/ws-ticket")
+                        .url(endpoint.resolve("api/auth/ws-ticket").toString())
                         .post("{}".toRequestBody(jsonMediaType))
                         .build()
                 ticketClient.newCall(ticketReq).execute().use { ticketResp ->


### PR DESCRIPTION
## Fixes #802

Re-login after session expiry failed with `HTTP error code: 404` on HTTPS or reverse-proxied servers.

### Root cause
`ChatViewModel.relogin()` built the login URL manually from `AuthManager.getHost()`/`getPort()`:
```kotlin
val baseUrl = "http://$host:$port"   // hardcodes scheme, drops path prefix
```
This drops the **scheme** (`https://` → `http://`) and any reverse-proxy **path prefix**, so the URL was wrong and the server returned 404. Every other auth call site uses `ServerEndpoint`; `relogin()` was the only one bypassing it — which is why "remove connection + re-add" worked (it re-parses via `ServerEndpoint.parseForBuild()`) but re-login did not.

### Fix
Replace the manual host/port/baseUrl construction with `AuthManager.endpointForBuild().resolve(...)`, mirroring `AuthLoginViewModel.connectBasicAuth()`:
```kotlin
val endpoint = AuthManager.endpointForBuild()
.url(endpoint.resolve("auth/password-login").toString())
.url(endpoint.resolve("api/auth/ws-ticket").toString())
```

### Verification
- Reproduced the hardcoded URL against `main` (ChatViewModel.kt:2877-2879).
- Confirmed `endpointForBuild()` + `resolve()` exist and match the fresh-login path.
- ktlint passes on the edited file.
- Behavior unchanged for plain `http://host:port` connections; HTTPS + proxied deployments now resolve correctly.

Closes #802.