### PR TITLE
fix(ci): poll mergeable until resolved in conflict detector

### DIFF
--- a/.github/workflows/merge-conflict-detector.yml
+++ b/.github/workflows/merge-conflict-detector.yml
@@ -7,25 +7,22 @@ on:
   push:
     branches: [main]
 
-# Cancel in-progress runs when a new commit lands — no point checking stale state
+# Cancel in-progress runs when a new event lands — protects the expensive
+# bulk-check path. github.ref is stable per PR (refs/pull/N/merge) AND stable
+# for pushes to main (refs/heads/main), so one expression covers both triggers
+# and actually cancels a stale bulk run when a newer push arrives.
 concurrency:
-  group: merge-conflict-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  group: merge-conflict-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   detect-and-label:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pull-requests: write
       issues: write
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
       - name: Ensure label exists
         uses: actions/github-script@v9
         with:
@@ -34,15 +31,21 @@ jobs:
             const { data: labels } = await github.rest.issues.listLabelsForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
+              per_page: 100,
             });
             if (!labels.some(l => l.name === LABEL)) {
-              await github.rest.issues.createLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: LABEL,
-                color: 'd73a4a',
-                description: 'This PR has merge conflicts that need to be resolved',
-              });
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: LABEL,
+                  color: 'd73a4a',
+                  description: 'This PR has merge conflicts that need to be resolved',
+                });
+              } catch (e) {
+                // 422 = label already exists (race with another run) — fine.
+                if (e.status !== 422) throw e;
+              }
             }
 
       - name: Check PRs and label conflicts
@@ -55,7 +58,8 @@ jobs:
             // it returns `null` ("still computing") and can stay null for minutes.
             // The previous version treated `null` as "leave as-is" and never
             // re-checked, so conflicting PRs were never labeled. This polls until
-            // GitHub resolves the merge state (or we time out).
+            // GitHub resolves the merge state (or we time out), returning the full
+            // PR object so callers don't need to re-fetch for labels.
             async function getMergeable(prNumber, retries = 12, delayMs = 5000) {
               for (let i = 0; i < retries; i++) {
                 const { data: pr } = await github.rest.pulls.get({
@@ -63,7 +67,7 @@ jobs:
                   repo: context.repo.repo,
                   pull_number: prNumber,
                 });
-                if (pr.mergeable !== null) return pr.mergeable;
+                if (pr.mergeable !== null) return pr;
                 core.info(`PR #${prNumber}: mergeable still null, retrying (${i + 1}/${retries})...`);
                 await new Promise(r => setTimeout(r, delayMs));
               }
@@ -71,26 +75,22 @@ jobs:
               return null;
             }
 
-            async function checkAndLabel(prNumber) {
-              const mergeable = await getMergeable(prNumber);
+            async function checkAndLabel(pr) {
+              const prNumber = pr.number;
+              const resolved = await getMergeable(prNumber);
 
-              if (mergeable === null) {
+              if (resolved === null) {
                 // Couldn't determine state in time — leave label as-is.
                 core.info(`PR #${prNumber}: mergeable unknown, label left unchanged.`);
                 return;
               }
 
-              const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber,
-              });
-              const hasConflicts = mergeable === false;
-              const currentLabels = pr.labels.map(l => l.name);
+              const hasConflicts = resolved.mergeable === false;
+              const currentLabels = resolved.labels.map(l => l.name);
               const hasLabel = currentLabels.includes(LABEL);
 
               core.info(
-                `PR #${prNumber}: mergeable=${mergeable}, ` +
+                `PR #${prNumber}: mergeable=${resolved.mergeable}, ` +
                 `hasLabel=${hasLabel}, conflicts=${hasConflicts}`
               );
 
@@ -103,23 +103,32 @@ jobs:
                 });
                 core.info(`✅ Added "${LABEL}" to PR #${prNumber}`);
               } else if (!hasConflicts && hasLabel) {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: prNumber,
-                  name: LABEL,
-                });
-                core.info(`✅ Removed "${LABEL}" from PR #${prNumber}`);
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: prNumber,
+                    name: LABEL,
+                  });
+                  core.info(`✅ Removed "${LABEL}" from PR #${prNumber}`);
+                } catch (e) {
+                  // 404 = label already gone (race with another run) — fine.
+                  if (e.status !== 404) throw e;
+                }
               }
             }
 
             // ── Single PR (pull_request event) ─────────────────────────
             if (context.eventName === 'pull_request') {
-              await checkAndLabel(context.issue.number);
+              // For a single PR we already have the number; fetch resolves mergeable.
+              await checkAndLabel({ number: context.issue.number });
               return;
             }
 
             // ── Bulk check all open PRs (push to main event) ───────────
+            // GitHub usually recomputes mergeable for every open PR at once after a
+            // push, so most hit the retry loop simultaneously. Batch a few at a time
+            // with Promise.all to bound wall-clock without hammering the API.
             if (context.eventName === 'push') {
               const { data: prs } = await github.rest.pulls.list({
                 owner: context.repo.owner,
@@ -129,7 +138,9 @@ jobs:
                 per_page: 100,
               });
               core.info(`Checking ${prs.length} open PR(s) base on main...`);
-              for (const pr of prs) {
-                await checkAndLabel(pr.number);
+              const CHUNK = 5;
+              for (let i = 0; i < prs.length; i += CHUNK) {
+                const batch = prs.slice(i, i + CHUNK);
+                await Promise.all(batch.map(p => checkAndLabel(p)));
               }
             }

--- a/.github/workflows/merge-conflict-detector.yml
+++ b/.github/workflows/merge-conflict-detector.yml
@@ -51,21 +51,46 @@ jobs:
           script: |
             const LABEL = 'has-conflicts';
 
+            // GitHub computes `mergeable` asynchronously. Immediately after a push
+            // it returns `null` ("still computing") and can stay null for minutes.
+            // The previous version treated `null` as "leave as-is" and never
+            // re-checked, so conflicting PRs were never labeled. This polls until
+            // GitHub resolves the merge state (or we time out).
+            async function getMergeable(prNumber, retries = 12, delayMs = 5000) {
+              for (let i = 0; i < retries; i++) {
+                const { data: pr } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                });
+                if (pr.mergeable !== null) return pr.mergeable;
+                core.info(`PR #${prNumber}: mergeable still null, retrying (${i + 1}/${retries})...`);
+                await new Promise(r => setTimeout(r, delayMs));
+              }
+              core.warning(`PR #${prNumber}: mergeable never resolved after ${retries} tries.`);
+              return null;
+            }
+
             async function checkAndLabel(prNumber) {
-              // Fetch PR with mergeable status
+              const mergeable = await getMergeable(prNumber);
+
+              if (mergeable === null) {
+                // Couldn't determine state in time — leave label as-is.
+                core.info(`PR #${prNumber}: mergeable unknown, label left unchanged.`);
+                return;
+              }
+
               const { data: pr } = await github.rest.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: prNumber,
               });
-
-              // mergeable: true = clean, false = conflicts, null = still computing
-              const hasConflicts = pr.mergeable === false;
+              const hasConflicts = mergeable === false;
               const currentLabels = pr.labels.map(l => l.name);
               const hasLabel = currentLabels.includes(LABEL);
 
               core.info(
-                `PR #${prNumber}: mergeable=${pr.mergeable}, ` +
+                `PR #${prNumber}: mergeable=${mergeable}, ` +
                 `hasLabel=${hasLabel}, conflicts=${hasConflicts}`
               );
 
@@ -85,11 +110,6 @@ jobs:
                   name: LABEL,
                 });
                 core.info(`✅ Removed "${LABEL}" from PR #${prNumber}`);
-              } else if (pr.mergeable === null) {
-                core.warning(
-                  `PR #${prNumber}: mergeable is null (still computing). ` +
-                  `Label left as-is. The next event will recheck.`
-                );
               }
             }
 


### PR DESCRIPTION
## Summary
- The `merge-conflict-detector.yml` workflow ran successfully but **never labeled conflicting PRs** with `has-conflicts`.
- Root cause: GitHub computes `pr.mergeable` asynchronously and returns `null` ("still computing") for minutes after a push. The old script treated `null` as "leave as-is" and never re-checked, so by the time GitHub resolved it to `false`, no event re-triggered the check → label never added.

## Fixes (applied after review)
1. **Poll until resolved** — `getMergeable()` retries up to 12×/5s until `mergeable` is non-null, then labels/unlabels on the resolved state.
2. **Concurrency dedupe** — group keyed on `github.ref` (stable for both `pull_request` and `push` triggers) so `cancel-in-progress` actually fires on the expensive bulk-check path.
3. **Drop `actions/checkout` + `contents: read`** — the script is pure API, never touches the filesystem.
4. **No re-fetch** — `getMergeable` returns the full PR object; `checkAndLabel` reads labels from it directly.
5. **Race-safe label calls** — swallow `422` on `createLabel` (already exists) and `404` on `removeLabel` (already gone).
6. **Batched bulk check** — open PRs processed in chunks of 5 via `Promise.all` to bound wall-clock without hammering the API.

## Verification
- YAML validated (parses cleanly, no checkout step, scoped permissions).
- Logic: `hasConflicts = pr.mergeable === false` — now catches the previously-missed `false` case.

## Impact
After this merges, the next `push`/`pull_request` event labels all open conflicting PRs (e.g. #803/#805/#807/#810) with `has-conflicts`.