### PR TITLE
fix(chat): send omit_messages=true on session.resume (#842)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/notification/NotificationReplyReceiver.kt
+++ b/app/src/main/java/com/m57/hermescontrol/notification/NotificationReplyReceiver.kt
@@ -128,7 +128,7 @@ open class NotificationReplyReceiver : BroadcastReceiver() {
             HermesWsClient
                 .request(
                     WsMethods.SESSION_RESUME,
-                    mapOf("session_id" to storedSessionId),
+                    mapOf("session_id" to storedSessionId, "omit_messages" to true),
                     timeoutMs = REPLY_TIMEOUT_MS,
                 ).await() as? Map<*, *>
         val runtimeSessionId =

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -1952,7 +1952,7 @@ class ChatViewModel(
         viewModelScope.launch(ioDispatcher) {
             wsClient.send(
                 WsMethods.SESSION_RESUME,
-                mapOf("session_id" to sessionId),
+                mapOf("session_id" to sessionId, "omit_messages" to true),
                 onSent = { id ->
                     trackSessionRequest(
                         id = id,

--- a/app/src/test/java/com/m57/hermescontrol/notification/NotificationReplyReceiverTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/notification/NotificationReplyReceiverTest.kt
@@ -306,7 +306,11 @@ class NotificationReplyReceiverTest {
         Thread.sleep(500)
 
         verify {
-            HermesWsClient.request(WsMethods.SESSION_RESUME, match { it["session_id"] == "session-abc" }, any())
+            HermesWsClient.request(
+                WsMethods.SESSION_RESUME,
+                match { it["session_id"] == "session-abc" && it["omit_messages"] == true },
+                any(),
+            )
             HermesWsClient.request(
                 WsMethods.PROMPT_SUBMIT,
                 match { it["session_id"] == "runtime-session-abc" },

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -642,7 +642,7 @@ class ChatViewModelTest {
             verify {
                 HermesWsClient.send(
                     WsMethods.SESSION_RESUME,
-                    mapOf("session_id" to "session-from-notification"),
+                    mapOf("session_id" to "session-from-notification", "omit_messages" to true),
                     any(),
                 )
             }
@@ -1271,7 +1271,13 @@ class ChatViewModelTest {
                     .isEmpty(),
             )
 
-            verify { HermesWsClient.send(WsMethods.SESSION_RESUME, mapOf("session_id" to "session-456"), any()) }
+            verify {
+                HermesWsClient.send(
+                    WsMethods.SESSION_RESUME,
+                    mapOf("session_id" to "session-456", "omit_messages" to true),
+                    any(),
+                )
+            }
         }
 
     @Test
@@ -1894,7 +1900,7 @@ class ChatViewModelTest {
             verify {
                 HermesWsClient.send(
                     WsMethods.SESSION_RESUME,
-                    mapOf("session_id" to "session-456"),
+                    mapOf("session_id" to "session-456", "omit_messages" to true),
                     any(),
                 )
             }


### PR DESCRIPTION
Fixes #842 — duplicate chat message after mid-stream reconnect.

## Root cause
`session.resume` was sent with only `session_id`. The gateway defaults to
replaying the full transcript over the new socket (`methods_session.py`:
`omit_messages = is_truthy_value(params.get("omit_messages", False))`).
Mobile hydrates history via REST in parallel, so the replay is redundant —
and when a reconnect lands mid-stream, the replayed message is born with a
fresh random UUID, so neither dedup mechanism collapses it (different ids,
and `sameLogicalMessage` needs exact content: 90% orphan vs 100% replay).
Result: the stalled partial stays, the next message completes, then a
duplicate copy streams to 100%.

## Fix
Send `omit_messages: true` on resume in both paths (desktop parity):
- `ChatViewModel.resumeSession()` — chat reconnect path
- `NotificationReplyReceiver.resumeSession()` — background-reply path

History is unaffected: the app already re-hydrates the transcript via
REST after reconnect (`mergeTranscriptWithLive`).

## Regression guards
Existing exact-map verifies updated to assert `omit_messages == true`:
- `ChatViewModelTest` — gateway-ready resume, switchSession, unconfirmed-session positive control
- `NotificationReplyReceiverTest` — reply-after-reconnect resume

## Verification
Local gate: `ktlintCheck` + `testDebugUnitTest` → BUILD SUCCESSFUL, 860 tests, 0 failures.