### PR TITLE
fix(security): validate intent action before consuming notification session id (#832)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/MainActivity.kt
+++ b/app/src/main/java/com/m57/hermescontrol/MainActivity.kt
@@ -18,6 +18,18 @@ import com.m57.hermescontrol.theme.HermesControlTheme
 import com.m57.hermescontrol.util.LocaleContextWrapper
 
 class MainActivity : ComponentActivity() {
+    companion object {
+        /**
+         * Action that identifies notification-driven "open this chat" intents.
+         * [ChatNotificationService] stamps it on the content intent; the
+         * consumer refuses anything else (issue #832 — MainActivity is
+         * exported as the launcher, so a foreign app could otherwise inject
+         * a session id via an explicit intent).
+         */
+        const val ACTION_OPEN_CHAT_FROM_NOTIFICATION =
+            "com.m57.hermescontrol.ACTION_OPEN_CHAT_FROM_NOTIFICATION"
+    }
+
     /**
      * Apply the user-selected display language before any view is inflated.
      * Reads the persisted code from [AuthManager]; an uninitialized store
@@ -62,6 +74,9 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun consumeNotificationIntent(intent: Intent?) {
+        // Issue #832: MainActivity is exported (launcher requirement) — only
+        // honor intents stamped with our own notification action.
+        if (intent?.action != ACTION_OPEN_CHAT_FROM_NOTIFICATION) return
         val sessionId = intent?.getStringExtra(NotificationReplyReceiver.EXTRA_SESSION_ID)
         intent?.removeExtra(NotificationReplyReceiver.EXTRA_SESSION_ID)
         sessionId?.takeIf { it.isNotBlank() }?.let(NavigationController::openChatSession)

--- a/app/src/main/java/com/m57/hermescontrol/notification/ChatNotificationService.kt
+++ b/app/src/main/java/com/m57/hermescontrol/notification/ChatNotificationService.kt
@@ -185,7 +185,7 @@ class ChatNotificationService : Service() {
     private fun buildContentIntent(sessionId: String?): PendingIntent {
         val intent =
             Intent(this, MainActivity::class.java).apply {
-                action = "$packageName.ACTION_OPEN_CHAT_FROM_NOTIFICATION"
+                action = MainActivity.ACTION_OPEN_CHAT_FROM_NOTIFICATION
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
             }
         if (!sessionId.isNullOrBlank()) {


### PR DESCRIPTION
Fixes #832 — exported MainActivity consumes unvalidated intent extras.

## Root cause
`MainActivity` is `exported="true"` (launcher requirement) with
`singleTop`, and `consumeNotificationIntent()` read the session-id extra
from any incoming intent without checking the intent's action — exercised
from both cold-start (`onCreate`) and warm-boot (`onNewIntent`). Any app
on the device could launch MainActivity via an explicit intent and
force-navigate to a chat screen with a crafted session id.

## Fix
- `consumeNotificationIntent()` now refuses any intent whose action is not
  the app's own notification action (`ACTION_OPEN_CHAT_FROM_NOTIFICATION`)
- Action string hoisted into a shared const on `MainActivity`'s companion;
  `ChatNotificationService` stamps the same const on the content intent —
  single source of truth, no drift possible

No data-exfiltration impact existed (session ids are random, content stays
on-device) — this closes the unvalidated-extras path on an exported
component, per Android intent-security guidance.

## Verification
Local gate: `ktlintCheck` + `testDebugUnitTest` → BUILD SUCCESSFUL, 860 tests, 0 failures.