### PR TITLE
ci(release): drop CI checks job from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,60 +19,9 @@ permissions:
   packages: write
 
 jobs:
-  # ── Run full CI before building release ───────────────────────────────
-  ci:
-    name: CI Checks
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '21'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-        with:
-          validate-wrappers: true
-          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTED_KEY }}
-
-      - name: Grant Execute Permission for Gradlew
-        run: chmod +x gradlew
-
-      - name: Cache ktlint
-        id: cache-ktlint
-        uses: actions/cache@v6
-        with:
-          path: ~/.local/bin/ktlint
-          key: ktlint-1.2.1
-
-      - name: Install ktlint
-        if: steps.cache-ktlint.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/.local/bin
-          curl -sSLO https://github.com/pinterest/ktlint/releases/download/1.2.1/ktlint
-          chmod +x ktlint
-          mv ktlint ~/.local/bin/
-
-      - name: Add local bin to PATH
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: ktlintCheck
-        run: ./gradlew ktlintCheck
-
-      - name: lintDebug
-        run: ./gradlew lintDebug
-
-      - name: test
-        run: ./gradlew test
-
   # ── Build release APK ─────────────────────────────────────────────────
   build-release:
     name: Build Release APK
-    needs: ci
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Removes the redundant CI gate from the release workflow.

## What changed
- Deleted the `ci` job (ktlintCheck + lintDebug + test) from
  `.github/workflows/release.yml`
- Removed `needs: ci` from `build-release` so the release APK builds
  immediately on tag push / workflow_dispatch

## Why
CI for branches/PRs is already enforced by the `android.yml` pipeline
(which gates merges via branch protection). Re-running the same checks
again on a tag push only delays the release build. The release now
builds standalone.