### PR TITLE
chore(nix): tidy dev shell — drop version-drift tooling, fix .gradle-home ignore, add logcat-app alias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,8 @@ local.properties
 *.swp
 *.swo
 
-# Nix / Gradle user home
-\$PWD/
-$PWD/
+# Nix / Gradle user home (per-repo GRADLE_USER_HOME from flake.nix)
+.gradle-home/
 
 ktlint
 .hermes/plans/

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
             # NDK (not needed for this project, but handy)
             includeNDK = false;
 
-            # Extra packages
+            # Extra licenses
             extraLicenses = [
               "android-googletv-license"
               "android-sdk-arm-dbt-license"
@@ -63,15 +63,6 @@
 
             # Android SDK (platforms, build-tools, platform-tools, emulator, system-images)
             androidSdk
-
-            # Kotlin compiler
-            kotlin
-
-            # Gradle
-            gradle
-
-            # Useful utilities
-            ktlint # Kotlin linter
           ];
 
           # Point everything at the Nix-managed SDK
@@ -84,17 +75,36 @@
 
           shellHook = ''
             echo " HermesControl Android dev shell"
-            echo "   Java:              $(java -version 2>&1 | head -1)"
-            echo "   Kotlin:            $(kotlin -version 2>&1)"
-            echo "   Gradle:            $(gradle --version 2>&1 | grep '^Gradle' || echo 'available')"
+            echo "   Java:         $(java -version 2>&1 | head -1)"
             echo "   ANDROID_HOME: $ANDROID_HOME"
             echo ""
 
-            # Make sure the android CLI from ~/.local/bin is on PATH
-            export PATH="$HOME/.local/bin:$PATH"
+            # Ensure Android CLI tools and local user binaries are on PATH
+            export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$HOME/.local/bin:$PATH"
 
             # Writable gradle home
             mkdir -p "$GRADLE_USER_HOME"
+
+            # ADB Screen Resolution Aliases
+            alias avd-phone='adb shell wm size 1440x3120 && adb shell wm density 500'
+            alias avd-phone-fhd='adb shell wm size 1080x2400 && adb shell wm density 420'
+
+            alias avd-tablet='adb shell wm size 1600x2560 && adb shell wm density 320'
+            alias avd-tablet-land='adb shell wm size 2560x1600 && adb shell wm density 320'
+
+            alias avd-reset='adb shell wm size reset && adb shell wm density reset'
+
+            # HermesControl app logcat (filtered to the app process only)
+            alias logcat-app='adb logcat --pid=$(adb shell pidof com.m57.hermescontrol)'
+
+            echo "Display Presets Loaded:"
+            echo "  avd-phone        -> 1440x3120 (500 DPI) [QHD+ Flagship]"
+            echo "  avd-phone-fhd    -> 1080x2400 (420 DPI) [FHD+ Flagship]"
+            echo "  avd-tablet       -> 1600x2560 (320 DPI) [Portrait Tablet]"
+            echo "  avd-tablet-land  -> 2560x1600 (320 DPI) [Landscape Tablet]"
+            echo "  avd-reset        -> Reset size & density back to AVD defaults"
+            echo "  logcat-app       -> Logcat for the HermesControl app process only"
+            echo ""
           '';
         };
       }


### PR DESCRIPTION
## What & why

Follow-up to the dev-shell review. Three fixes:

1. **Drop `gradle`, `kotlin`, `ktlint` from the dev shell `buildInputs`.** The wrapper pins Gradle 9.6.1, and the project's Kotlin/ktlint versions come from the Gradle build — the standalone binaries are different versions and create drift footguns (running `gradle` instead of `./gradlew` fails with AGP 9's Gradle requirement; standalone ktlint can pass while the CI gradle `ktlintCheck` fails). The wrapper handles all three. Banner no longer advertises their versions.
2. **Fix the `.gitignore` for the per-repo Gradle home.** The old `$PWD/` patterns were dead — gitignore doesn't expand env vars — and the real dir (`GRADLE_USER_HOME=$PWD/.gradle-home`) was unignored, so the multi-GB cache would show up as untracked noise. Replaced with `.gradle-home/`.
3. **Add `logcat-app` alias** — `adb logcat --pid=$(adb shell pidof com.m57.hermescontrol)`, filtered to the HermesControl process only. Plus the ADB screen-resolution presets and `$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator` on PATH.

## Verification

- All androidenv version pins verified to exist in current nixpkgs master `repo.json`: `platform-tools 36.0.0`, `build-tools 36.0.0`, `platform 36`, `cmdline-tools 11.0`, system images `36/google_apis` (x86_64 + arm64-v8a).
- Could not run `nix develop`/eval locally — no nix on this host, and the nix closure's glibc won't run on this kernel. Syntax validated by diff review against the known-good committed flake + interpolation/quote scan (no stray `${` inside the shellHook heredoc).
- No app code touched — Android build/CI unaffected.