### PR TITLE
fix(chat): replace bubble and screen gradients with flat colors

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatBubble.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatBubble.kt
@@ -50,7 +50,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.ClipEntry
@@ -201,19 +200,9 @@ private fun UserBubble(
                 .padding(horizontal = 8.dp, vertical = 2.dp),
         contentAlignment = Alignment.CenterEnd,
     ) {
-        val gradientBrush =
-            Brush.linearGradient(
-                colors =
-                    listOf(
-                        MaterialTheme.colorScheme.primary,
-                        MaterialTheme.colorScheme.secondary,
-                    ),
-            )
         val primary = MaterialTheme.colorScheme.primary
-        val secondary = MaterialTheme.colorScheme.secondary
-        val avgLuminance = (primary.luminance() + secondary.luminance()) / 2f
         val userBubbleTextColor =
-            if (avgLuminance > 0.5f) {
+            if (primary.luminance() > 0.5f) {
                 if (MaterialTheme.colorScheme.onPrimary.luminance() < 0.5f) {
                     MaterialTheme.colorScheme.onPrimary
                 } else {
@@ -238,7 +227,7 @@ private fun UserBubble(
                                 bottomStart = 16.dp,
                                 bottomEnd = 4.dp,
                             ),
-                        ).background(brush = gradientBrush)
+                        ).background(color = primary)
                         .testTag("chat_bubble_user"),
                 color = Color.Transparent,
                 tonalElevation = 0.dp,

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -58,7 +58,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -400,16 +399,6 @@ fun ChatScreen(
         viewModel = viewModel,
     )
 
-    val backgroundGradient =
-        Brush.verticalGradient(
-            colors =
-                listOf(
-                    MaterialTheme.colorScheme.background,
-                    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
-                    MaterialTheme.colorScheme.primary.copy(alpha = 0.05f),
-                ),
-        )
-
     HermesScaffold(
         modifier = modifier,
         pinTopBar = true,
@@ -479,7 +468,7 @@ fun ChatScreen(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .background(backgroundGradient)
+                    .background(MaterialTheme.colorScheme.background)
                     .imePadding(),
         ) {
             ChatConnectionBanner(


### PR DESCRIPTION
Removes the two decorative gradients from chat:

- **User bubble**: linear gradient (primary → secondary) → solid `colorScheme.primary`. The bubble text color logic (was averaging both gradient colors' luminance) now keys off primary's luminance alone — same contrast guarantees, simpler.
- **Chat screen background**: vertical gradient (background → surfaceVariant → primary 5%) → solid `colorScheme.background`. Screens now sit flat on the theme surface.

Left untouched: the loading shimmer in StateViews (animated brush, not a color gradient).

Verified: ktlint + testDebugUnitTest (867 tests, 0 failures) + assembleDebug — BUILD SUCCESSFUL.