### PR TITLE
fix(chat): open the selected history session

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -1781,45 +1781,16 @@ class ChatViewModel(
         val title = _uiState.value.sessions.find { it.id == sessionId }?.title ?: "Hermes"
         val generation = resetSessionState(sessionId, title, isLoading = true)
         viewModelScope.launch {
-            // Desktop parity (issue #787): a branched session's "current" row
-            // is its newest child leaf (/model, /branch) — resume THAT instead
-            // of the stale parent. Best-effort: on any failure (404 for a
-            // missing session, network blip) fall back to the requested id.
-            val effectiveId = resolveLatestDescendant(sessionId) ?: sessionId
-            val effectiveGeneration =
-                if (effectiveId != sessionId) {
-                    resetSessionState(effectiveId, title, isLoading = true)
-                } else {
-                    generation
-                }
             // Warm-cache fast-path (desktop parity): paint the cached Room
             // transcript immediately so the screen never sits blank, then load
             // the fresh server transcript in parallel. If the cache is empty
             // the spinner stays up until the server page lands.
-            loadCachedMessages(effectiveId, effectiveGeneration)
+            loadCachedMessages(sessionId, generation)
             // Resume the selected desktop session and hydrate its transcript.
-            resumeSession(effectiveId, effectiveGeneration)
+            resumeSession(sessionId, generation)
             loadSessions()
         }
     }
-
-    /**
-     * Resolve the newest descendant of a session (issue #787, desktop parity).
-     * A branched session continues in a child leaf; resuming the parent would
-     * open a stale branch. Returns null on any failure (sessions without
-     * descendants report `changed=false`; missing sessions 404) so callers
-     * fall back to the requested id.
-     */
-    private suspend fun resolveLatestDescendant(sessionId: String): String? =
-        withContext(ioDispatcher) {
-            val result =
-                runCatching {
-                    safeApiCall { ApiClient.hermesApi.getLatestDescendant(sessionId) }
-                }.getOrNull()
-            (result as? NetworkResult.Success)?.data
-                ?.takeIf { it.changed }
-                ?.session_id
-        }
 
     private fun loadCachedMessages(
         sessionId: String,

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -1258,9 +1258,17 @@ class ChatViewModelTest {
     // ── Session switch ───────────────────────────────────────────────────────
 
     @Test
-    fun testSwitchSession() =
+    fun testSwitchSession_opensSelectedHistorySessionInsteadOfLatestDescendant() =
         runTest {
             val (viewModel, sessionId) = createViewModelWithSession()
+            coEvery { ApiClient.hermesApi.getLatestDescendant("session-456") } returns
+                retrofit2.Response.success(
+                    com.m57.hermescontrol.data.model.LatestDescendantResponse(
+                        requested_session_id = "session-456",
+                        session_id = "unrelated-descendant",
+                        changed = true,
+                    ),
+                )
 
             viewModel.switchSession("session-456")
             advanceUntilIdle()


### PR DESCRIPTION
## What

- Resume the exact session selected from History.
- Stop replacing that selection with the latest descendant.
- Add a regression test where the descendant endpoint points elsewhere.

## Why

The latest-descendant behavior added in #841 can open a different branch than the row the user selected, making the chosen conversation appear incomplete or wrong.

## Verification

- `./gradlew testDebugUnitTest --tests 'com.m57.hermescontrol.ui.chat.ChatViewModelTest.testSwitchSession*'`
- `./gradlew ktlintCheck checkColorLiterals testDebugUnitTest`
