### PR TITLE
fix(chat): clear clarify request on completion

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatWsEventReducer.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatWsEventReducer.kt
@@ -328,6 +328,7 @@ object ChatWsEventReducer {
                 state.copy(
                     messages = state.messages.upsertById(msg),
                     isAgentTyping = false,
+                    clarifyRequest = null,
                 ),
             effects = effects,
         )

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatWsEventReducerTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatWsEventReducerTest.kt
@@ -8,6 +8,25 @@ import org.junit.Test
 
 class ChatWsEventReducerTest {
     @Test
+    fun testMessageComplete_clearsResolvedClarifyRequest() {
+        val state =
+            ChatUiState(
+                currentSessionId = "session-1",
+                clarifyRequest = ClarifyUi("Old question", emptyList(), "clarify-1"),
+            )
+
+        val result =
+            ChatWsEventReducer.reduce(
+                state = state,
+                streamingState = StreamingState(),
+                event = WsEvent.MessageComplete("Done", "session-1"),
+                currentSessionId = "session-1",
+            )
+
+        assertEquals(null, result.state.clarifyRequest)
+    }
+
+    @Test
     fun testToolProgress_updatesProgressPreviewForMatchingRunningTool() {
         val initialMessage =
             ChatMessage(


### PR DESCRIPTION
## What

- Clear the active clarify request when the authoritative `message.complete` event arrives.
- Add a focused reducer regression test.

## Why

A resolved interactive clarify card otherwise remains visible after the turn has completed.

## Verification

- `./gradlew testDebugUnitTest --tests 'com.m57.hermescontrol.ui.chat.ChatWsEventReducerTest.testMessageComplete_clearsResolvedClarifyRequest'`
- `./gradlew ktlintCheck checkColorLiterals testDebugUnitTest`
