### PR TITLE
feat(chat): /resume and /history open the session history tab (issue #864)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/ws/CommandModels.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/CommandModels.kt
@@ -43,7 +43,8 @@ object CommandBlocklist {
         setOf(
             "/clear",
             "/redraw",
-            "/history",
+            // "/history" is NOT blocked — it's handled client-side (issue
+            // #864) by opening the session history tab.
             "/save",
             "/prompt",
             "/snapshot",

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -74,6 +74,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.m57.hermescontrol.HistoryScreen
 import com.m57.hermescontrol.NavigationController
 import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.Attachment
@@ -190,6 +191,15 @@ fun ChatScreen(
                 viewModel.syncCurrentSession()
                 viewModel.fetchContextUsage()
             }
+        }
+    }
+
+    // /resume · /history (issue #864): open the session history tab so the
+    // user picks a past session — client-side, no gateway round-trip.
+    LaunchedEffect(state.openHistoryRequested) {
+        if (state.openHistoryRequested) {
+            NavigationController.navigateTo(HistoryScreen)
+            viewModel.consumeOpenHistoryRequest()
         }
     }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -279,6 +279,9 @@ data class ChatUiState(
     // #865). Empty until the local store loads; commands without recorded
     // usage keep their catalog order.
     val slashUsageCounts: Map<String, Int> = emptyMap(),
+    // Transient nav request from /resume and /history (issue #864): the
+    // screen consumes it by navigating to the history tab, then clears it.
+    val openHistoryRequested: Boolean = false,
     // In-session model picker (issue #589) — surfaced when the user types /model
     // (or taps the top-bar model chip). Mirror of the global model screen's
     // picker, but the selection hot-swaps the CURRENT session via the slash path.
@@ -1433,6 +1436,13 @@ class ChatViewModel(
 
             is SlashResult.Update -> {
                 openUpdateConfirm()
+            }
+
+            is SlashResult.OpenHistory -> {
+                // Client-side: open the session history tab so the user can
+                // pick a past session to resume (issue #864) — no gateway
+                // round-trip (the backend slash worker can't answer /resume).
+                _uiState.update { it.copy(openHistoryRequested = true) }
             }
 
             is SlashResult.RpcDispatch -> {
@@ -3229,6 +3239,11 @@ class ChatViewModel(
 
     fun clearBackgroundComplete() {
         _uiState.update { it.copy(backgroundCompleteMessage = null) }
+    }
+
+    /** Consume the /resume · /history navigation request (issue #864). */
+    fun consumeOpenHistoryRequest() {
+        _uiState.update { it.copy(openHistoryRequested = false) }
     }
 
     // ── Approval flow ───────────────────────────────────────────────────

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatcher.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatcher.kt
@@ -31,6 +31,7 @@ class SlashCommandDispatcher {
             "/fork", "/branch" -> SlashResult.SessionBranch
             "/model" -> SlashResult.ModelSwitch
             "/update" -> SlashResult.Update
+            "/resume", "/history" -> SlashResult.OpenHistory
             else -> SlashResult.RpcDispatch
         }
     }
@@ -71,4 +72,12 @@ sealed class SlashResult {
      * after 45s (issue #862).
      */
     data object Update : SlashResult()
+
+    /**
+     * Open the session history tab client-side (issue #864). /resume and
+     * /history are CLI-flavored interactive commands the mobile gateway path
+     * can't answer usefully — same class of problem as /update (#862). The
+     * user picks a past session from history and resumes it from there.
+     */
+    data object OpenHistory : SlashResult()
 }

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -446,6 +446,58 @@ class ChatViewModelTest {
             }
         }
 
+    // ── /resume · /history open the history tab (issue #864) ────────────────
+
+    @Test
+    fun slashCommand_resume_requestsHistoryNavigationWithoutGateway() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+
+            viewModel.sendMessage("/resume")
+            advanceUntilIdle()
+
+            assertTrue(
+                "openHistoryRequested must be set for the screen to navigate",
+                viewModel.uiState.value.openHistoryRequested,
+            )
+            // Client-side only: no gateway round-trip for /resume.
+            verify(exactly = 0) {
+                HermesWsClient.request(WsMethods.COMMAND_DISPATCH, any(), any())
+            }
+            verify(exactly = 0) {
+                HermesWsClient.request(WsMethods.SLASH_EXEC, any(), any())
+            }
+        }
+
+    @Test
+    fun slashCommand_history_requestsHistoryNavigation() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+
+            viewModel.sendMessage("/history")
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.openHistoryRequested)
+            verify(exactly = 0) {
+                HermesWsClient.request(WsMethods.COMMAND_DISPATCH, any(), any())
+            }
+        }
+
+    @Test
+    fun consumeOpenHistoryRequest_clearsFlag() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+
+            viewModel.sendMessage("/resume")
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.openHistoryRequested)
+
+            viewModel.consumeOpenHistoryRequest()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.openHistoryRequested)
+        }
+
     @Test
     fun testSlashCommand_unknown_showsErrorMessage() =
         runTest {

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatcherTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatcherTest.kt
@@ -64,6 +64,17 @@ class SlashCommandDispatcherTest {
     }
 
     @Test
+    fun `resume and history route to OpenHistory`() {
+        // /resume and /history are CLI-flavored interactive commands the
+        // mobile gateway path can't answer — handled client-side by opening
+        // the session history tab (issue #864).
+        assertEquals(SlashResult.OpenHistory, dispatcher.dispatch("/resume"))
+        assertEquals(SlashResult.OpenHistory, dispatcher.dispatch("/RESUME"))
+        assertEquals(SlashResult.OpenHistory, dispatcher.dispatch("/history"))
+        assertEquals(SlashResult.OpenHistory, dispatcher.dispatch("/History"))
+    }
+
+    @Test
     fun `NEW uppercase still routes to NewSession`() {
         // Dispatcher lower-cases before matching, so case must not matter.
         assertEquals(SlashResult.NewSession, dispatcher.dispatch("/NEW"))


### PR DESCRIPTION
## What

`/resume` and `/history` are now handled client-side — they open the session history tab instead of hitting the gateway (where the CLI-flavored slash worker could never answer them usefully — same class of problem as /update, #862).

## How

- `SlashCommandDispatcher`: `/resume` + `/history` → new `SlashResult.OpenHistory` (mirrors SessionBranch/ModelSwitch/Update).
- `ChatViewModel`: the OpenHistory branch sets a transient `openHistoryRequested` flag (cleared via `consumeOpenHistoryRequest()`, same pattern as other transient UI flags).
- `ChatScreen`: a `LaunchedEffect` on the flag navigates via `NavigationController.navigateTo(HistoryScreen)` then clears it — zero gateway RPCs.
- `/history` removed from `CommandBlocklist.UNSUPPORTED`: it's no longer a dead command on mobile — it now works, and it reappears in the slash suggestion menu.

## Tests (ktlint green; all new tests pass)

- `SlashCommandDispatcherTest`: `resume and history route to OpenHistory` (+ case-insensitivity)
- `ChatViewModelTest` ×3: `/resume` sets the flag with NO `command.dispatch`/`slash.exec` RPC, `/history` sets the flag, consume clears it

## Note on the local gate

Local full-suite run shows 2 failures (`ChatUpdateCommandTest.applyUpdate`, `ChatViewModelTest.testSwitchSession_ignoresLateResumeErrorBeforeReducerMutation`) — **verified pre-existing on pristine `origin/main`** with an identical filtered run (same 2 tests fail there; my 4 new tests pass on the branch). Cross-class MockK static-mock bleed, run-order dependent; CI full-suite is the merge gate.

Fixes #864