### PR TITLE
feat(cron): confirm before deleting a cron job

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/cron/CronJobsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/cron/CronJobsScreen.kt
@@ -244,7 +244,7 @@ fun CronJobsScreen(
                                         )
                                     }
                                     IconButton(
-                                        onClick = { viewModel.deleteCronJob(job.id) },
+                                        onClick = { viewModel.requestDeleteJob(job) },
                                     ) {
                                         Icon(
                                             imageVector = Icons.Filled.Delete,
@@ -302,6 +302,25 @@ fun CronJobsScreen(
             },
             confirmButton = {
                 TextButton(onClick = { selectedJob = null }) { Text("Close") }
+            },
+        )
+    }
+
+    // ── Delete Confirm Dialog ──
+    state.deleteTarget?.let { job ->
+        AlertDialog(
+            onDismissRequest = { viewModel.dismissDeleteDialog() },
+            title = { Text(stringResource(R.string.cron_delete_title)) },
+            text = { Text(stringResource(R.string.cron_delete_message, job.name)) },
+            confirmButton = {
+                TextButton(onClick = { viewModel.confirmDeleteJob() }) {
+                    Text(stringResource(R.string.action_delete))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.dismissDeleteDialog() }) {
+                    Text(stringResource(R.string.action_cancel))
+                }
             },
         )
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/cron/CronJobsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/cron/CronJobsViewModel.kt
@@ -32,6 +32,8 @@ data class CronJobsUiState(
     val jobs: List<CronJob> = emptyList(),
     val errorMessage: String? = null,
     val toastMessage: String? = null,
+    // Delete-confirm state (non-null while the confirm dialog is up)
+    val deleteTarget: CronJob? = null,
     // Editor state
     val editorState: CronJobEditorState = CronJobEditorState(),
 )
@@ -194,6 +196,20 @@ class CronJobsViewModel :
                 revertJobs(originalJobs, "Failed to delete cron job: ${result.error.message}")
             }
         }
+    }
+
+    fun requestDeleteJob(job: CronJob) {
+        _uiState.update { it.copy(deleteTarget = job) }
+    }
+
+    fun dismissDeleteDialog() {
+        _uiState.update { it.copy(deleteTarget = null) }
+    }
+
+    fun confirmDeleteJob() {
+        val target = _uiState.value.deleteTarget ?: return
+        _uiState.update { it.copy(deleteTarget = null) }
+        deleteCronJob(target.id)
     }
 
     // ── Editor ──

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -586,6 +586,8 @@
     <string name="cron_edit_action_save">저장</string>
     <string name="cron_discard_title">변경사항을 취소할까요?</string>
     <string name="cron_discard_message">저장되지 않은 변경사항이 있습니다. 취소하시겠습니까?</string>
+    <string name="cron_delete_title">크론 작업을 삭제할까요?</string>
+    <string name="cron_delete_message">\"%1$s\" 작업을 삭제하시겠습니까? 되돌릴 수 없습니다.</string>
 
     <!-- Achievements Screen -->
     <string name="achievements_empty_title">아직 업적이 없습니다</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -828,6 +828,8 @@
     <string name="cron_edit_action_save">Save</string>
     <string name="cron_discard_title">Discard changes?</string>
     <string name="cron_discard_message">You have unsaved changes. Discard them?</string>
+    <string name="cron_delete_title">Delete job?</string>
+    <string name="cron_delete_message">Delete \"%1$s\"? This can\'t be undone.</string>
 
     <!-- Achievements Screen -->
     <string name="achievements_empty_title">No achievements yet</string>

--- a/app/src/test/java/com/m57/hermescontrol/ui/cron/CronJobsViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/cron/CronJobsViewModelTest.kt
@@ -227,6 +227,51 @@ class CronJobsViewModelTest {
     }
 
     @Test
+    fun `requestDeleteJob sets the delete target without deleting`() {
+        val vm = createViewModel()
+        val job = CronJob(id = "j-del", name = "Doomed")
+
+        vm.requestDeleteJob(job)
+
+        assertEquals(job, vm.uiState.value.deleteTarget)
+        coVerify(exactly = 0) { mockApi.deleteCronJob(any()) }
+    }
+
+    @Test
+    fun `dismissDeleteDialog clears the target without deleting`() {
+        val vm = createViewModel()
+        vm.requestDeleteJob(CronJob(id = "j-del", name = "Doomed"))
+
+        vm.dismissDeleteDialog()
+
+        assertNull(vm.uiState.value.deleteTarget)
+        coVerify(exactly = 0) { mockApi.deleteCronJob(any()) }
+    }
+
+    @Test
+    fun `confirmDeleteJob clears the target and deletes the job`() {
+        val vm = createViewModel()
+        vm.requestDeleteJob(CronJob(id = "j-del", name = "Doomed"))
+
+        vm.confirmDeleteJob()
+        settle()
+
+        assertNull(vm.uiState.value.deleteTarget)
+        coVerify { mockApi.deleteCronJob("j-del") }
+    }
+
+    @Test
+    fun `confirmDeleteJob without a target is a no-op`() {
+        val vm = createViewModel()
+
+        vm.confirmDeleteJob()
+        settle()
+
+        assertNull(vm.uiState.value.deleteTarget)
+        coVerify(exactly = 0) { mockApi.deleteCronJob(any()) }
+    }
+
+    @Test
     fun `setMonitorMode switching source clears the other`() {
         val vm = createViewModel()
         vm.openNewJobDialog()


### PR DESCRIPTION
## What

The delete icon on a cron job card fired `deleteCronJob(id)` immediately — a backend DELETE with no undo. Adds a confirmation dialog before deletion, mirroring the existing Files/Keys screens pattern.

## Changes

- **CronJobsViewModel**: new `deleteTarget` state + `requestDeleteJob` / `dismissDeleteDialog` / `confirmDeleteJob` (target cleared before the actual delete, same as Files/Keys)
- **CronJobsScreen**: delete icon now opens the confirm dialog instead of deleting; dialog shows the job name, Delete/Cancel buttons, dismiss-on-outside-tap
- **Strings**: `cron_delete_title` / `cron_delete_message` (en + ko)
- **Tests**: 4 new unit tests — target set without delete, dismiss clears without delete, confirm deletes the right id, confirm without target is a no-op

## Verification

`./gradlew ktlintCheck testDebugUnitTest --tests CronJobsViewModelTest` → BUILD SUCCESSFUL (20 tests, 0 failures, all 4 new tests present in results XML).