### PR TITLE
fix(chat): image viewer icons invisible on light backgrounds

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ImageViewerDialog.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ImageViewerDialog.kt
@@ -204,7 +204,7 @@ fun ImageViewerDialog(
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = stringResource(R.string.image_viewer_close),
-                            tint = MaterialTheme.colorScheme.onPrimary,
+                            tint = MaterialTheme.colorScheme.onSurface,
                         )
                     }
                     Row {
@@ -212,21 +212,21 @@ fun ImageViewerDialog(
                             CircularProgressIndicator(
                                 modifier = Modifier.size(24.dp).padding(horizontal = 8.dp),
                                 strokeWidth = 2.dp,
-                                color = MaterialTheme.colorScheme.onPrimary,
+                                color = MaterialTheme.colorScheme.onSurface,
                             )
                         } else {
                             IconButton(onClick = onSave, enabled = !isBusy) {
                                 Icon(
                                     imageVector = Icons.Filled.Download,
                                     contentDescription = stringResource(R.string.image_viewer_save),
-                                    tint = MaterialTheme.colorScheme.onPrimary,
+                                    tint = MaterialTheme.colorScheme.onSurface,
                                 )
                             }
                             IconButton(onClick = onShare, enabled = !isBusy) {
                                 Icon(
                                     imageVector = Icons.Filled.Share,
                                     contentDescription = stringResource(R.string.image_viewer_share),
-                                    tint = MaterialTheme.colorScheme.onPrimary,
+                                    tint = MaterialTheme.colorScheme.onSurface,
                                 )
                             }
                         }


### PR DESCRIPTION
## Bug

In the fullscreen image viewer, the **Save**, **Share**, and **Close** icons (plus the busy spinner) are invisible in light mode — white icons on a light background.

## Root cause

`ImageViewerDialog.kt` tinted all viewer icons with `MaterialTheme.colorScheme.onPrimary`, but the viewer's background is `colorScheme.scrim` (a non-primary surface). `onPrimary` is designed for content on `primary` surfaces and resolves to white under the dynamic light scheme — so the icons blend into the scrim background.

## Fix

Switch the tint to `MaterialTheme.colorScheme.onSurface` — the token for content over non-primary surfaces. It resolves dark-in-light-mode / light-in-dark-mode automatically:

- close (back) icon
- save (download) icon
- share icon
- busy spinner color

## Test plan

- [ ] Open any image in the viewer in **light mode** → all 3 icons + spinner visible
- [ ] Repeat in **dark mode** → icons remain visible
- [ ] Save + Share still work