### PR TITLE
fix(chat): stop crash when expanding reasoning card with Show full

### DIFF
--- a/app/src/androidTest/java/com/m57/hermescontrol/ui/chat/components/ReasoningCardTest.kt
+++ b/app/src/androidTest/java/com/m57/hermescontrol/ui/chat/components/ReasoningCardTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
 import org.junit.Rule
@@ -54,11 +55,13 @@ class ReasoningCardTest {
 
         // "Show full" lifts the cap — must NOT crash the layout pass.
         composeTestRule.onNodeWithText("Show full").performClick()
-        composeTestRule.onNodeWithText("Show less").assertIsDisplayed()
+        // The card now grows taller than the viewport, so the toggle button
+        // sits below the fold — scroll it into view before asserting/clicking.
+        composeTestRule.onNodeWithText("Show less").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("Show less").performClick()
 
         // And back down again.
-        composeTestRule.onNodeWithText("Show less").performClick()
-        composeTestRule.onNodeWithText("Show full").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Show full").performScrollTo().assertIsDisplayed()
     }
 
     @Test

--- a/app/src/androidTest/java/com/m57/hermescontrol/ui/chat/components/ReasoningCardTest.kt
+++ b/app/src/androidTest/java/com/m57/hermescontrol/ui/chat/components/ReasoningCardTest.kt
@@ -1,0 +1,71 @@
+package com.m57.hermescontrol.ui.chat.components
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression tests for the ReasoningCard "Show full" crash (issue #882).
+ *
+ * Inside a LazyColumn item the main axis is unbounded, so a verticalScroll
+ * measured with an infinite max height throws
+ * IllegalStateException ("Vertically scrollable component was measured with an
+ * infinity maximum height constraints"). The old implementation passed
+ * `heightIn(max = Dp.Unspecified)` once "Show full" was tapped, which lifted
+ * the cap entirely and reproduced exactly that crash.
+ */
+@RunWith(AndroidJUnit4::class)
+@MediumTest
+class ReasoningCardTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    /** Long enough to overflow the ~40%-of-screen collapsed cap (~22 lines). */
+    private val longReasoning =
+        buildString {
+            repeat(60) { index -> appendLine("reasoning line $index") }
+        }
+
+    private fun renderInLazyColumn(reasoningText: String) {
+        composeTestRule.setContent {
+            LazyColumn {
+                item(key = "reasoning") {
+                    ReasoningCard(reasoningText = reasoningText)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun showFull_insideLazyColumn_doesNotCrash() {
+        renderInLazyColumn(longReasoning)
+
+        // Expand the card.
+        composeTestRule.onNodeWithTag("reasoning_card").performClick()
+        composeTestRule.onNodeWithText("Show full").assertIsDisplayed()
+
+        // "Show full" lifts the cap — must NOT crash the layout pass.
+        composeTestRule.onNodeWithText("Show full").performClick()
+        composeTestRule.onNodeWithText("Show less").assertIsDisplayed()
+
+        // And back down again.
+        composeTestRule.onNodeWithText("Show less").performClick()
+        composeTestRule.onNodeWithText("Show full").assertIsDisplayed()
+    }
+
+    @Test
+    fun shortReasoning_noOverflow_noShowFullButton() {
+        renderInLazyColumn("short reasoning")
+
+        composeTestRule.onNodeWithTag("reasoning_card").performClick()
+        composeTestRule.onNodeWithText("Show full").assertDoesNotExist()
+    }
+}

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/MessageCards.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/MessageCards.kt
@@ -73,7 +73,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.m57.hermescontrol.R
@@ -176,19 +175,26 @@ fun ReasoningCard(
             }
             AnimatedVisibility(visible = expanded) {
                 Column {
-                    Column(
+                    Text(
+                        text = reasoningText,
+                        style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier =
                             Modifier
-                                .heightIn(max = if (fullHeight) Dp.Unspecified else capHeight)
-                                .verticalScroll(scrollState),
-                    ) {
-                        Text(
-                            text = reasoningText,
-                            style = MaterialTheme.typography.bodySmall.copy(fontFamily = FontFamily.Monospace),
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(top = 4.dp),
-                        )
-                    }
+                                .padding(top = 4.dp)
+                                .then(
+                                    if (!fullHeight) {
+                                        // Capped at ~40% of the screen with internal scroll.
+                                        Modifier.heightIn(max = capHeight).verticalScroll(scrollState)
+                                    } else {
+                                        // "Show full": render the whole trace at natural height.
+                                        // A scrollable must NEVER be measured with an infinite
+                                        // max height — inside a LazyColumn item (unbounded main
+                                        // axis) that combination throws IllegalStateException.
+                                        Modifier
+                                    },
+                                ),
+                    )
                     if (isStreaming) {
                         ReasoningPulsingDot(modifier = Modifier.padding(top = 6.dp))
                     }


### PR DESCRIPTION
Fixes #883.

## Problem

Tapping **Show full** on an expanded 🧠 reasoning card crashed the app:

```
IllegalStateException: Vertically scrollable component was measured with an
infinity maximum height constraints, which is disallowed.
```

## Root cause

`ReasoningCard` (`app/src/main/java/com/m57/hermescontrol/ui/chat/components/MessageCards.kt`) applied `heightIn(max = Dp.Unspecified)` when "Show full" was active, on a `verticalScroll` container. Both call sites (`FullBleedChatList.kt:153`, `FullBleedAgentMessage.kt:98`) sit inside a `LazyColumn` item, where the main axis is measured with an **unbounded** max height. The collapsed cap (~40% screen) is finite, so it worked — but `Dp.Unspecified` = no max, so the scrollable got measured with infinite max height and Compose threw on the next layout pass.

## Fix

When "Show full" is active the scroll wrapper is dropped entirely, so the trace renders at its natural height (legal inside a LazyColumn item — only scrollables forbid infinite max). Scroll cap + `verticalScroll` apply only in capped mode; scroll position is preserved when toggling back to "Show less".

## Verification

- Regression test `ReasoningCardTest` (instrumented): renders the card inside a `LazyColumn` item and walks the exact crash path — expand → Show full → Show less — plus a no-overflow case asserting the button stays hidden.
- Local: `ktlintCheck` clean, `testDebugUnitTest` 962/962 pass, androidTest source compiles.