### PR TITLE
feat(history): fluid infinite scroll + bigger pages for the sessions list

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -64,6 +65,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -117,6 +119,12 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import kotlin.math.abs
+
+/**
+ * Auto-load the next history page when the user scrolls to within this many
+ * items of the end — a pre-load buffer so paging feels continuous.
+ */
+private const val AUTO_LOAD_THRESHOLD = 6
 
 /**
  * Maps a session source string to a Material icon for visual identification.
@@ -747,7 +755,32 @@ fun SessionsScreen(
                             }
 
                             // ── Session list ────────────────────────────────────
+                            val listState = rememberLazyListState()
+                            // Fluid infinite scroll: once the user reaches within
+                            // AUTO_LOAD_THRESHOLD items of the end, pull the next
+                            // page automatically. Driven by real scroll position
+                            // (layoutInfo is snapshot state), so it recomputes on
+                            // every scroll — not a frozen first-composition read.
+                            val nearListEnd by remember {
+                                derivedStateOf {
+                                    val info = listState.layoutInfo
+                                    val lastVisible = info.visibleItemsInfo.lastOrNull()?.index ?: -1
+                                    lastVisible >= 0 &&
+                                        lastVisible >= info.totalItemsCount - AUTO_LOAD_THRESHOLD
+                                }
+                            }
+                            LaunchedEffect(
+                                nearListEnd,
+                                state.isLoadingMore,
+                                state.hasMore,
+                                state.isSearchMode,
+                            ) {
+                                if (nearListEnd && !state.isLoadingMore && state.hasMore && !state.isSearchMode) {
+                                    viewModel.loadMore()
+                                }
+                            }
                             LazyColumn(
+                                state = listState,
                                 modifier = Modifier.fillMaxSize(),
                                 contentPadding = listPadding,
                                 verticalArrangement = listItemSpacing,

--- a/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/sessions/SessionsViewModel.kt
@@ -120,9 +120,12 @@ class SessionsViewModel :
         )
     }
 
-    /** Page size sent to the server — matches the default the gateway uses. */
+    /**
+     * Page size sent to the server. Matches the desktop sidebar's
+     * SIDEBAR_SESSIONS_PAGE_SIZE (50); the backend caps `limit` at 100.
+     */
     private companion object {
-        const val PAGE_SIZE = 20
+        const val PAGE_SIZE = 50
         const val SEARCH_DEBOUNCE_MS = 300L
     }
 
@@ -186,7 +189,11 @@ class SessionsViewModel :
                     _uiState.update {
                         it.copy(
                             isLoadingMore = false,
-                            sessions = it.sessions + data.sessions,
+                            // distinctBy guards offset-pagination churn: if a new
+                            // session lands on top between page loads, offsets
+                            // shift and the next page can repeat an id we already
+                            // have — LazyColumn would crash on the duplicate key.
+                            sessions = (it.sessions + data.sessions).distinctBy { s -> s.id },
                             total = data.total,
                         )
                     }

--- a/app/src/test/java/com/m57/hermescontrol/ui/sessions/SessionsViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/sessions/SessionsViewModelTest.kt
@@ -1,7 +1,11 @@
 package com.m57.hermescontrol.ui.sessions
 
+import com.m57.hermescontrol.data.model.SessionInfo
+import com.m57.hermescontrol.data.model.SessionListResponse
 import com.m57.hermescontrol.data.remote.ApiClient
 import com.m57.hermescontrol.data.remote.HermesApiService
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -19,6 +23,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SessionsViewModelTest {
@@ -89,5 +94,67 @@ class SessionsViewModelTest {
             "Find the deployment logs",
             cleanSearchSnippet("{\"role\":\"user\",\"content\":\">>>Find<<< the deployment logs\"}"),
         )
+    }
+
+    @Test
+    fun `loadMore appends the next page and dedupes overlapping ids`() {
+        val vm = createViewModel()
+
+        // Page 1: 2 sessions of 3 total — hasMore stays true.
+        coEvery { mockApi.getSessions(any(), any(), any()) } returns
+            Response.success(
+                SessionListResponse(
+                    sessions = listOf(SessionInfo("s-1"), SessionInfo("s-2")),
+                    total = 3,
+                ),
+            )
+        vm.loadSessions()
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(listOf("s-1", "s-2"), vm.uiState.value.sessions.map { it.id })
+        assertTrue(vm.uiState.value.hasMore)
+        assertFalse(vm.uiState.value.isLoadingMore)
+
+        // Page 2 overlaps page 1 (offset churn: a new session landed on top
+        // between loads) — the duplicate id must not double-append.
+        coEvery { mockApi.getSessions(any(), any(), any()) } returns
+            Response.success(
+                SessionListResponse(
+                    sessions = listOf(SessionInfo("s-3"), SessionInfo("s-2")),
+                    total = 3,
+                ),
+            )
+        vm.loadMore()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("s-1", "s-2", "s-3"), vm.uiState.value.sessions.map { it.id })
+        assertEquals(3, vm.uiState.value.total)
+        assertFalse(vm.uiState.value.hasMore)
+        assertFalse(vm.uiState.value.isLoadingMore)
+    }
+
+    @Test
+    fun `loadMore is a no-op while a load is already running`() {
+        val vm = createViewModel()
+
+        coEvery { mockApi.getSessions(any(), any(), any()) } returns
+            Response.success(
+                SessionListResponse(
+                    sessions = listOf(SessionInfo("s-1")),
+                    total = 2,
+                ),
+            )
+        vm.loadSessions()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Fire two loadMore calls back-to-back before the dispatcher runs: the
+        // first sets isLoadingMore=true synchronously, the second must be dropped.
+        vm.loadMore()
+        vm.loadMore()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // loadSessions (1) + exactly one loadMore (1) = 2 API hits total.
+        coVerify(exactly = 2) { mockApi.getSessions(any(), any(), any()) }
+        assertEquals(listOf("s-1"), vm.uiState.value.sessions.map { it.id })
+        assertFalse(vm.uiState.value.isLoadingMore)
     }
 }


### PR DESCRIPTION
## What & why

The History tab loaded only 20 sessions and required tapping the tiny "Load more" text at the very bottom. This makes the list load more per page and page itself automatically:

- **Page size 20 → 50** — matches the desktop sidebar (`SIDEBAR_SESSIONS_PAGE_SIZE=50`); backend `GET /api/sessions` caps `limit` at 100 (verified in `hermes_cli/web_routers/sessions.py:58`).
- **Auto-load next page** — when the user scrolls within 6 items of the end, the next page loads automatically (pre-load buffer, feels continuous). The footer remains as a spinner while loading and a manual "Load more" fallback.
- **Offset-churn safety** — appended pages are deduped by session id. If a new session lands on top between page loads, offsets shift and the next page can repeat an id already in the list → duplicate LazyColumn key → hard crash. `distinctBy` makes that impossible.

## Scroll trigger

`derivedStateOf` over `LazyListState.layoutInfo` (real snapshot state, recomputes on every scroll — not a frozen first-composition read), keyed `LaunchedEffect` guarded by `isLoadingMore && hasMore && !isSearchMode`. Scoped inside the normal-list branch so search mode can never trigger it.

## Verification

- `./gradlew ktlintCheck` — SUCCESS
- `./gradlew testDebugUnitTest --rerun` — **964 tests, 0 failures** (includes 2 new tests: append+dedupe, in-flight no-op guard)