### PR TITLE
fix(chat): /queue submits with queued=true so the backend queues instead of redirecting

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
@@ -716,10 +716,21 @@ object HermesWsClient {
         sessionId: String,
         text: String,
         onSent: ((String) -> Unit)? = null,
+        queued: Boolean = false,
     ): String {
+        val params =
+            buildMap {
+                put("session_id", sessionId)
+                put("text", text)
+                // Explicit queue semantics: the gateway's busy-input policy
+                // forces "run after, never interrupt" when prompt.submit
+                // carries queued=true (hermes-agent methods_prompt.py
+                // _handle_busy_submit) — used by /queue.
+                if (queued) put("queued", true)
+            }
         return send(
             method = WsMethods.PROMPT_SUBMIT,
-            params = mapOf("session_id" to sessionId, "text" to text),
+            params = params,
             onSent = onSent,
         )
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -1396,7 +1396,14 @@ class ChatViewModel(
     fun clearAttachments() = attachmentsDelegate.clearAttachments()
 
     private fun handleSlashCommand(command: String) {
-        val userMsg = ChatMessage(role = MessageRole.USER, content = command)
+        // Classify FIRST (pure logic) — /queue's optimistic bubble must show
+        // the queued TEXT (prefix stripped, see QueuePrompt.displayContent) so
+        // it matches the server echo and the transcript sync dedupes instead
+        // of rendering a duplicate below its answer.
+        val result = slashDispatcher.dispatch(command)
+        val displayContent =
+            if (result is SlashResult.QueuePrompt) result.displayContent else command
+        val userMsg = ChatMessage(role = MessageRole.USER, content = displayContent)
         val sessionId = _uiState.value.currentSessionId
 
         _uiState.update { it.copy(messages = it.messages + userMsg) }
@@ -1428,7 +1435,7 @@ class ChatViewModel(
             slashUsageStore.recordUse(commandName)
         }
 
-        when (val result = slashDispatcher.dispatch(command)) {
+        when (result) {
             is SlashResult.Interrupt -> {
                 interruptSession()
             }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -1456,10 +1456,32 @@ class ChatViewModel(
                 _uiState.update { it.copy(openHistoryRequested = true) }
             }
 
+            is SlashResult.QueuePrompt -> {
+                handleQueueCommand(command)
+            }
+
             is SlashResult.RpcDispatch -> {
                 dispatchViaRpc(command)
             }
         }
+    }
+
+    /**
+     * Queue a prompt to run after the current turn (backend contract
+     * `prompt.submit` `queued=true` — hermes-agent methods_prompt.py:147,
+     * _handle_busy_submit). The gateway then enqueues it as the next turn
+     * and NEVER redirects/interrupts the live turn, regardless of
+     * `display.busy_input_mode`. Intercepted client-side because the
+     * `command.dispatch` `queue` shim only echoes the text back as a plain
+     * submit, which loses the queued flag and hijacks the live turn.
+     */
+    private fun handleQueueCommand(command: String) {
+        val arg = command.split(" ", limit = 2).getOrElse(1) { "" }.trim()
+        if (arg.isBlank()) {
+            addAssistantMessage("usage: /queue <prompt>")
+            return
+        }
+        submitPrompt(arg, queued = true)
     }
 
     // ── Update from chat (issue #862) ────────────────────────────────────
@@ -1634,9 +1656,12 @@ class ChatViewModel(
     /**
      * Submits [text] as a prompt to the current session via WS, without
      * adding a duplicate user message. Used by [handleDispatchResult] when
-     * a slash command resolves to a normal user prompt (e.g. `/queue` → "help me").
+     * a slash command resolves to a normal user prompt (e.g. `/init` → "Scan this repo").
      */
-    private fun submitPrompt(text: String) {
+    private fun submitPrompt(
+        text: String,
+        queued: Boolean = false,
+    ) {
         if (text.isBlank()) return
         val sessionId = runtimeSessionId ?: return
         _uiState.update { it.copy(isAgentTyping = true) }
@@ -1645,6 +1670,7 @@ class ChatViewModel(
                 sessionId,
                 text,
                 onSent = { id -> trackRequest(id, WsMethods.PROMPT_SUBMIT) },
+                queued = queued,
             )
         }
     }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatcher.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatcher.kt
@@ -31,6 +31,7 @@ class SlashCommandDispatcher {
             "/fork", "/branch" -> SlashResult.SessionBranch
             "/model" -> SlashResult.ModelSwitch
             "/update" -> SlashResult.Update
+            "/queue", "/q" -> SlashResult.QueuePrompt
             "/resume", "/history" -> SlashResult.OpenHistory
             else -> SlashResult.RpcDispatch
         }
@@ -80,4 +81,15 @@ sealed class SlashResult {
      * user picks a past session from history and resumes it from there.
      */
     data object OpenHistory : SlashResult()
+
+    /**
+     * Queue a prompt to run after the current turn. NOT command.dispatch —
+     * the backend's `queue` shim (methods_tools.py) only echoes the text back
+     * as a `send` payload that re-submits as a normal prompt, losing the
+     * queue semantics (a busy session then REDIRECTS the live turn instead —
+     * verified on-device). The ViewModel submits directly via `prompt.submit`
+     * with `queued=true`, which the gateway honors as "run after, never
+     * interrupt" regardless of `display.busy_input_mode`.
+     */
+    data object QueuePrompt : SlashResult()
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatcher.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatcher.kt
@@ -31,7 +31,16 @@ class SlashCommandDispatcher {
             "/fork", "/branch" -> SlashResult.SessionBranch
             "/model" -> SlashResult.ModelSwitch
             "/update" -> SlashResult.Update
-            "/queue", "/q" -> SlashResult.QueuePrompt
+            "/queue", "/q" -> {
+                val arg = command.split(" ", limit = 2).getOrElse(1) { "" }.trim()
+                // Bubble shows the queued TEXT (prefix stripped) so the
+                // optimistic user message matches the server echo exactly —
+                // otherwise the transcript sync keeps both copies (logical
+                // dedupe can't match "/queue foo" vs "foo") and the echoed
+                // bubble lands below its answer. Bare command keeps the raw
+                // text so the usage message has something to sit under.
+                SlashResult.QueuePrompt(displayContent = arg.ifBlank { command })
+            }
             "/resume", "/history" -> SlashResult.OpenHistory
             else -> SlashResult.RpcDispatch
         }
@@ -90,6 +99,11 @@ sealed class SlashResult {
      * verified on-device). The ViewModel submits directly via `prompt.submit`
      * with `queued=true`, which the gateway honors as "run after, never
      * interrupt" regardless of `display.busy_input_mode`.
+     *
+     * [displayContent] is the optimistic user-bubble text: the queued text
+     * with the command prefix stripped (or the raw command when there is no
+     * argument). Matching the server echo verbatim lets the transcript sync
+     * dedupe the two copies of the same logical message.
      */
-    data object QueuePrompt : SlashResult()
+    data class QueuePrompt(val displayContent: String) : SlashResult()
 }

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatUpdateCommandTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatUpdateCommandTest.kt
@@ -114,7 +114,7 @@ class ChatUpdateCommandTest {
             arg<((String) -> Unit)?>(2)?.invoke(id)
             id
         }
-        every { HermesWsClient.sendMessage(any(), any(), any()) } answers {
+        every { HermesWsClient.sendMessage(any(), any(), any(), any()) } answers {
             reqCount++
             val id = "req-msg-$reqCount"
             arg<((String) -> Unit)?>(2)?.invoke(id)

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -83,6 +83,34 @@ class ChatViewModelTest {
         assertEquals(listOf(latest), merged)
     }
 
+    @Test
+    fun mergeTranscriptWithLive_matchingUserContentCollapsesLocalAndRestCopies() {
+        // /queue bubbles show the stripped queued text, so the optimistic
+        // local copy and the later REST echo share content — the sync merge
+        // must collapse them into one row instead of rendering a duplicate
+        // below its answer (PR #892 follow-up).
+        val local =
+            ChatMessage(
+                id = "ws-local-1",
+                role = MessageRole.USER,
+                content = "do the thing",
+                timestamp = 100L,
+            )
+        val rest =
+            ChatMessage(
+                id = "rest-sess-5",
+                role = MessageRole.USER,
+                content = "do the thing",
+                timestamp = 100L,
+            )
+
+        val merged = mergeTranscriptWithLive(listOf(rest), listOf(local))
+
+        assertEquals(1, merged.size)
+        // The richer local copy wins when both sides carry the same content.
+        assertEquals("ws-local-1", merged.single().id)
+    }
+
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -144,7 +144,7 @@ class ChatViewModelTest {
             arg<((String) -> Unit)?>(2)?.invoke(id)
             id
         }
-        every { HermesWsClient.sendMessage(any(), any(), any()) } answers {
+        every { HermesWsClient.sendMessage(any(), any(), any(), any()) } answers {
             reqCount++
             val id = "req-msg-$reqCount"
             arg<((String) -> Unit)?>(2)?.invoke(id)

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
@@ -108,7 +108,7 @@ class SlashCommandDispatchRpcTest {
             arg<((String) -> Unit)?>(2)?.invoke(id)
             id
         }
-        every { HermesWsClient.sendMessage(any(), any(), any()) } answers {
+        every { HermesWsClient.sendMessage(any(), any(), any(), any()) } answers {
             reqCount++
             val id = "req-msg-$reqCount"
             arg<((String) -> Unit)?>(2)?.invoke(id)
@@ -181,28 +181,94 @@ class SlashCommandDispatchRpcTest {
         }
 
     @Test
-    fun `slash command with args forwards arg separately`() =
+    fun `slash queue submits the arg with queued=true instead of command dispatch`() =
         runTest {
             val (vm, sessionId) = createViewModelWithSession()
 
             val methodCalls = mutableListOf<String>()
             val paramsCalls = mutableListOf<Map<String, Any>>()
+            val sentSession = slot<String>()
+            val sentText = slot<String>()
+            val sentQueued = slot<Boolean>()
             every {
                 HermesWsClient.request(capture(methodCalls), capture(paramsCalls), any())
             } answers {
                 CompletableDeferred<Any?>(Unit)
             }
+            every {
+                HermesWsClient.sendMessage(
+                    capture(sentSession),
+                    capture(sentText),
+                    any(),
+                    capture(sentQueued),
+                )
+            } answers {
+                "queued-msg-1"
+            }
 
             vm.sendMessage("/queue do the thing")
             advanceUntilIdle()
 
-            // Find the dispatch record (capture race — see the /help test).
-            val dispatchIndex = methodCalls.indexOf(WsMethods.COMMAND_DISPATCH)
-            assertTrue("expected COMMAND_DISPATCH, got $methodCalls", dispatchIndex >= 0)
-            val params = paramsCalls[dispatchIndex]
-            assertEquals("queue", params["name"])
-            assertEquals("do the thing", params["arg"])
-            assertEquals(sessionId, params["session_id"])
+            // /queue must NOT ride command.dispatch — the backend shim returns
+            // a "send" payload that re-submits WITHOUT the queued flag, and a
+            // busy session then redirects the live turn (verified on-device:
+            // {"status":"redirected"} while sleep 60 was running, message lost).
+            assertTrue(
+                "expected NO command.dispatch for /queue, got $methodCalls",
+                WsMethods.COMMAND_DISPATCH !in methodCalls,
+            )
+            assertEquals(sessionId, sentSession.captured)
+            assertEquals("do the thing", sentText.captured)
+            assertEquals(true, sentQueued.captured)
+        }
+
+    @Test
+    fun `slash queue with no arg shows usage and sends nothing`() =
+        runTest {
+            val (vm, _) = createViewModelWithSession()
+
+            val rpcMethods = mutableListOf<String>()
+            var sendCalls = 0
+            every {
+                HermesWsClient.request(capture(rpcMethods), any(), any())
+            } answers {
+                CompletableDeferred<Any?>(Unit)
+            }
+            every { HermesWsClient.sendMessage(any(), any(), any(), any()) } answers {
+                sendCalls++
+                "queued-msg-1"
+            }
+
+            vm.sendMessage("/queue")
+            advanceUntilIdle()
+
+            val last = vm.uiState.value.messages.lastOrNull()
+            assertEquals("usage: /queue <prompt>", last?.content)
+            assertEquals(0, sendCalls)
+            assertTrue(
+                "expected NO command.dispatch for bare /queue, got $rpcMethods",
+                WsMethods.COMMAND_DISPATCH !in rpcMethods,
+            )
+        }
+
+    @Test
+    fun `slash q alias queues the arg with queued=true`() =
+        runTest {
+            val (vm, _) = createViewModelWithSession()
+
+            val sentText = slot<String>()
+            val sentQueued = slot<Boolean>()
+            every {
+                HermesWsClient.sendMessage(any(), capture(sentText), any(), capture(sentQueued))
+            } answers {
+                "queued-msg-1"
+            }
+
+            vm.sendMessage("/q hey there")
+            advanceUntilIdle()
+
+            assertEquals("hey there", sentText.captured)
+            assertEquals(true, sentQueued.captured)
         }
 
     @Test
@@ -521,7 +587,7 @@ class SlashCommandDispatchRpcTest {
             }
             // submitPrompt() forwards the returned prompt via wsClient.sendMessage.
             every {
-                HermesWsClient.sendMessage(any(), capture(sentText), any())
+                HermesWsClient.sendMessage(any(), capture(sentText), any(), any())
             } answers {
                 val id = "send-msg-1"
                 arg<((String) -> Unit)?>(2)?.invoke(id)

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatchRpcTest.kt
@@ -220,6 +220,11 @@ class SlashCommandDispatchRpcTest {
             assertEquals(sessionId, sentSession.captured)
             assertEquals("do the thing", sentText.captured)
             assertEquals(true, sentQueued.captured)
+            // The optimistic bubble shows the queued TEXT (prefix stripped) so
+            // the transcript sync dedupes it against the server echo.
+            val userBubble =
+                vm.uiState.value.messages.lastOrNull { it.role == MessageRole.USER }
+            assertEquals("do the thing", userBubble?.content)
         }
 
     @Test

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatcherTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatcherTest.kt
@@ -82,6 +82,33 @@ class SlashCommandDispatcherTest {
     }
 
     @Test
+    fun `queue routes to QueuePrompt with stripped display content`() {
+        // /queue queues the prompt for after the current turn (PR #892). The
+        // optimistic bubble shows the queued TEXT, not the raw command, so the
+        // transcript sync dedupes it against the server echo ("/queue foo" vs
+        // "foo" would never match logically and both would render).
+        assertEquals(
+            SlashResult.QueuePrompt("do the thing"),
+            dispatcher.dispatch("/queue do the thing"),
+        )
+        assertEquals(
+            SlashResult.QueuePrompt("hi"),
+            dispatcher.dispatch("/q hi"),
+        )
+        assertEquals(
+            SlashResult.QueuePrompt("hi"),
+            dispatcher.dispatch("/QUEUE hi"),
+        )
+    }
+
+    @Test
+    fun `bare queue keeps the raw command as display content`() {
+        // No argument -> the usage message renders under the raw command.
+        assertEquals(SlashResult.QueuePrompt("/queue"), dispatcher.dispatch("/queue"))
+        assertEquals(SlashResult.QueuePrompt("/q"), dispatcher.dispatch("/q"))
+    }
+
+    @Test
     fun `command with args forwards to RpcDispatch`() {
         // Anything not /stop, /interrupt, /new goes to the backend.
         assertEquals(SlashResult.RpcDispatch, dispatcher.dispatch("/foo bar"))


### PR DESCRIPTION
## What

Two `/queue` fixes:

1. **Queued, not redirected** — `/queue <prompt>` (and `/q`) intercepts client-side and submits `prompt.submit` directly with `queued=true` instead of riding the `command.dispatch` `queue` shim.
2. **Bubble order** — the optimistic `/queue` bubble now shows the queued text (prefix stripped) so the transcript sync's logical dedupe collapses it with the server echo into one row at the correct position (was: duplicate echoed bubble rendering below its own answer).

## Why

1. The backend's `command.dispatch name=queue` shim only echoes the text back as a `send` payload (`methods_tools.py`), which the client re-submitted **without** the `queued` flag. On a busy session the gateway then applied the default `display.busy_input_mode: interrupt` — verified on-device: the backend replied `{"status":"redirected"}` and **redirected the live turn**; the queued message was dropped and never answered. The gateway explicitly supports `queued=true` on `prompt.submit` (`methods_prompt.py` `_handle_busy_submit`: *"the message was explicitly queued as 'run after', so it must NEVER become a live-turn correction or interrupt"*) — the mobile client just never sent it.
2. The optimistic bubble carried the raw command (`/queue foo`) while the server only ever sees the stripped text (`foo`) — `sameLogicalMessage` can't match them, so the sync kept both copies and the echo landed below its answer.

## Verified

- **On-device (emulator, fix 1):** was `{"status":"redirected"}` + message lost; now `{"status":"queued"}`, the running turn (`sleep 60`) completed untouched, and the queued `2+2` ran as the **next** turn and was answered. Server transcript: `user sleep → assistant done → user 2+2 → assistant 4`.
- **Unit (fix 1+2):** full `testDebugUnitTest` — 1016 tests, 0 failures. New coverage: no `command.dispatch` for `/queue`, `queued=true` on the submit, usage message on bare `/queue`, `/q` alias, stripped bubble content, `QueuePrompt.displayContent` classification, and a `mergeTranscriptWithLive` collapse test for matching user content.
- ktlint green.