### PR TITLE
fix: tab reloads actually reload — kanban switch spam, plugins/skills refresh, ws mint

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/remote/DashboardSessionTokenRefresher.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/DashboardSessionTokenRefresher.kt
@@ -1,6 +1,7 @@
 package com.m57.hermescontrol.data.remote
 
 import com.m57.hermescontrol.data.local.AuthManager
+import kotlinx.coroutines.Dispatchers
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okio.Buffer
@@ -31,22 +32,28 @@ internal object DashboardSessionTokenRefresher {
                     .url(baseUrl)
                     .get()
                     .build()
-            client.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) return null
-                // Cap the read — the SPA HTML can be large, and we only need the
-                // injected token near the top of the document. Reading the whole
-                // body into a String risks OOM on low-end devices.
-                val html =
-                    response.body.source().use { source ->
-                        val buffer = Buffer()
-                        source.read(buffer, MAX_BODY_BYTES)
-                        buffer.readUtf8()
-                    }
-                tokenPattern
-                    .find(html)
-                    ?.groupValues
-                    ?.getOrNull(1)
-                    ?.takeIf { it.isNotBlank() }
+            // execute() + body read on Dispatchers.IO: the body read touches
+            // the socket on the CALLING thread otherwise — when that is main
+            // (loopback ticket mint from the kanban events connect), it throws
+            // NetworkOnMainThreadException (same bug class as requestWsTicket).
+            kotlinx.coroutines.runBlocking(Dispatchers.IO) {
+                client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return@runBlocking null
+                    // Cap the read — the SPA HTML can be large, and we only need the
+                    // injected token near the top of the document. Reading the whole
+                    // body into a String risks OOM on low-end devices.
+                    val html =
+                        response.body.source().use { source ->
+                            val buffer = Buffer()
+                            source.read(buffer, MAX_BODY_BYTES)
+                            buffer.readUtf8()
+                        }
+                    tokenPattern
+                        .find(html)
+                        ?.groupValues
+                        ?.getOrNull(1)
+                        ?.takeIf { it.isNotBlank() }
+                }
             }
         } catch (_: Exception) {
             null

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/HermesWsClient.kt
@@ -450,28 +450,34 @@ object HermesWsClient {
                     .post("{}".toRequestBody())
                     .build()
 
-            // Run network call on Dispatchers.IO to avoid NetworkOnMainThreadException
-            val response =
+            // Run the ENTIRE call on Dispatchers.IO — execute() already hops,
+            // but ResponseBody.string() reads the socket on the CALLING
+            // thread. When the caller is main (kanban events connect), that
+            // read throws NetworkOnMainThreadException and the mint fails.
+            val (code, body) =
                 kotlinx.coroutines.runBlocking(Dispatchers.IO) {
-                    client.newCall(request).execute()
+                    client.newCall(request).execute().use { resp ->
+                        resp.code to resp.body?.string()
+                    }
                 }
 
-            response.use {
-                if (response.isSuccessful) {
-                    val body = response.body.string()
-                    val ticketMatch = Regex("""\"ticket\":\"([^\"]+)\"""").find(body)
-                    val ticket = ticketMatch?.groupValues?.getOrNull(1)
-                    if (!ticket.isNullOrBlank()) {
-                        return TicketRequestResult(ticket, null)
-                    }
-                    Log.w(TAG, "WS ticket mint failed: response body did not contain ticket")
-                } else {
-                    Log.w(TAG, "WS ticket mint failed: HTTP ${response.code}")
-                    return TicketRequestResult(null, response.code)
+            if (body != null && code in 200..299) {
+                val ticketMatch = Regex("""\"ticket\":\"([^\"]+)\"""").find(body)
+                val ticket = ticketMatch?.groupValues?.getOrNull(1)
+                if (!ticket.isNullOrBlank()) {
+                    return TicketRequestResult(ticket, null)
                 }
+                Log.w(TAG, "WS ticket mint failed: response body did not contain ticket")
+            } else {
+                Log.w(TAG, "WS ticket mint failed: HTTP $code")
+                return TicketRequestResult(null, code)
             }
         } catch (e: Exception) {
-            Log.w(TAG, "WS ticket mint failed: ${e.javaClass.simpleName}")
+            // Include the stack: the exception class alone (e.g.
+            // NetworkOnMainThreadException) can't show WHICH caller on what
+            // thread tripped the mint (main-scope kanban events connect vs
+            // the WS reconnect path).
+            Log.w(TAG, "WS ticket mint failed: ${e.javaClass.simpleName}", e)
             return TicketRequestResult(null, null, exception = true)
         }
         return TicketRequestResult(null, null)

--- a/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/kanban/KanbanViewModel.kt
@@ -121,6 +121,15 @@ class KanbanViewModel(
     }
 
     fun selectBoard(board: KanbanBoard) {
+        val current = _uiState.value.selectedBoard
+        if (current?.id == board.id) {
+            // Already-active board: reload its data and (re)connect the events
+            // stream WITHOUT the /switch round-trip — refresh and createTask
+            // re-select the same board and must not POST a redundant switch.
+            viewModelScope.launch { loadBoardIntoState(board) }
+            connectEvents(board)
+            return
+        }
         _uiState.update { it.copy(selectedBoard = board, isLoading = true, errorMessage = null) }
         viewModelScope.launch {
             val switchResult =

--- a/app/src/main/java/com/m57/hermescontrol/ui/plugins/PluginsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/plugins/PluginsScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -121,86 +120,82 @@ fun PluginsScreen(
     HermesScaffold(
         title = { Text(stringResource(R.string.screen_plugins)) },
         navigationIcon = onOpenDrawer?.let { NavIcon.Menu(it) },
+        isRefreshing = state.isLoading,
+        onRefresh = { viewModel.loadPlugins() },
     ) { paddingValues ->
-        PullToRefreshBox(
-            isRefreshing = state.isLoading,
-            onRefresh = { viewModel.loadPlugins() },
-            modifier = Modifier.fillMaxSize(),
-        ) {
-            when {
-                state.isLoading && state.plugins.isEmpty() -> {
-                    SkeletonListState(modifier = Modifier.padding(paddingValues))
-                }
+        when {
+            state.isLoading && state.plugins.isEmpty() -> {
+                SkeletonListState(modifier = Modifier.padding(paddingValues))
+            }
 
-                state.errorMessage != null -> {
-                    ErrorState(
-                        message = state.errorMessage ?: "",
-                        onRetry = { viewModel.loadPlugins() },
-                        modifier = Modifier.padding(paddingValues),
-                    )
-                }
+            state.errorMessage != null -> {
+                ErrorState(
+                    message = state.errorMessage ?: "",
+                    onRetry = { viewModel.loadPlugins() },
+                    modifier = Modifier.padding(paddingValues),
+                )
+            }
 
-                state.plugins.isEmpty() && state.orphanPlugins.isEmpty() -> {
-                    EmptyState(
-                        title = stringResource(R.string.plugins_empty_title),
-                        subtitle = stringResource(R.string.plugins_empty_desc),
-                        onAction = { viewModel.loadPlugins() },
-                        actionLabel = stringResource(R.string.content_desc_refresh),
-                        modifier = Modifier.padding(paddingValues),
-                    )
-                }
+            state.plugins.isEmpty() && state.orphanPlugins.isEmpty() -> {
+                EmptyState(
+                    title = stringResource(R.string.plugins_empty_title),
+                    subtitle = stringResource(R.string.plugins_empty_desc),
+                    onAction = { viewModel.loadPlugins() },
+                    actionLabel = stringResource(R.string.content_desc_refresh),
+                    modifier = Modifier.padding(paddingValues),
+                )
+            }
 
-                else -> {
-                    LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
-                        contentPadding = listContentPadding,
-                        verticalArrangement = listItemSpacing,
-                    ) {
-                        // Provider selection section
-                        if (state.memoryOptions.isNotEmpty() || state.contextOptions.isNotEmpty()) {
-                            item(key = "providers") {
-                                ProviderSelectionSection(state, viewModel)
-                            }
+            else -> {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = listContentPadding,
+                    verticalArrangement = listItemSpacing,
+                ) {
+                    // Provider selection section
+                    if (state.memoryOptions.isNotEmpty() || state.contextOptions.isNotEmpty()) {
+                        item(key = "providers") {
+                            ProviderSelectionSection(state, viewModel)
                         }
+                    }
 
-                        // Install section
-                        item(key = "install") {
-                            InstallSection(state, viewModel)
-                        }
+                    // Install section
+                    item(key = "install") {
+                        InstallSection(state, viewModel)
+                    }
 
-                        // Search bar
-                        item(key = "search") {
-                            SearchBar(
-                                query = query,
-                                onQueryChange = { query = it },
-                                placeholder = "Search plugins...",
+                    // Search bar
+                    item(key = "search") {
+                        SearchBar(
+                            query = query,
+                            onQueryChange = { query = it },
+                            placeholder = "Search plugins...",
+                        )
+                    }
+
+                    // Plugin list
+                    items(filteredPlugins, key = { it.name }) { plugin ->
+                        PluginCard(
+                            plugin = plugin,
+                            state = state,
+                            viewModel = viewModel,
+                            onClick = { showDetail = plugin },
+                        )
+                    }
+
+                    // Orphan dashboard plugins section
+                    if (state.orphanPlugins.isNotEmpty()) {
+                        item(key = "orphan-header") {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = stringResource(R.string.plugins_orphan_heading),
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(vertical = 8.dp),
                             )
                         }
-
-                        // Plugin list
-                        items(filteredPlugins, key = { it.name }) { plugin ->
-                            PluginCard(
-                                plugin = plugin,
-                                state = state,
-                                viewModel = viewModel,
-                                onClick = { showDetail = plugin },
-                            )
-                        }
-
-                        // Orphan dashboard plugins section
-                        if (state.orphanPlugins.isNotEmpty()) {
-                            item(key = "orphan-header") {
-                                Spacer(modifier = Modifier.height(8.dp))
-                                Text(
-                                    text = stringResource(R.string.plugins_orphan_heading),
-                                    style = MaterialTheme.typography.titleSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.padding(vertical = 8.dp),
-                                )
-                            }
-                            items(state.orphanPlugins, key = { "orphan-${it.name}" }) { plugin ->
-                                OrphanPluginCard(plugin = plugin, onClick = { showDetail = plugin })
-                            }
+                        items(state.orphanPlugins, key = { "orphan-${it.name}" }) { plugin ->
+                            OrphanPluginCard(plugin = plugin, onClick = { showDetail = plugin })
                         }
                     }
                 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/skills/SkillsScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Extension
-import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Shield
@@ -113,11 +112,19 @@ fun SkillsScreen(
         modifier = modifier,
         title = { Text(stringResource(R.string.skills_screen_title)) },
         navigationIcon = NavIcon.Menu(onOpen = onOpenDrawer),
+        isRefreshing = state.isLoading,
+        onRefresh = {
+            if (state.viewMode == SkillsViewMode.INSTALLED) {
+                viewModel.loadSkills()
+            } else {
+                viewModel.loadHubSources()
+            }
+        },
         actions = {
             if (state.viewMode == SkillsViewMode.INSTALLED) {
                 IconButton(onClick = { viewModel.updateSkillsFromHub() }) {
                     Icon(
-                        imageVector = Icons.Filled.Refresh,
+                        imageVector = Icons.Filled.CloudDownload,
                         contentDescription = stringResource(R.string.content_desc_update_skills_hub),
                     )
                 }

--- a/app/src/test/java/com/m57/hermescontrol/data/ws/HermesWsClientTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/ws/HermesWsClientTest.kt
@@ -49,6 +49,7 @@ class HermesWsClientTest {
         every { Log.d(any<String>(), any<String>()) } returns 0
         every { Log.i(any<String>(), any<String>()) } returns 0
         every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>(), any<Throwable>()) } returns 0
         every { Log.e(any<String>(), any<String>(), any()) } returns 0
 
         mockWebServer = MockWebServer()


### PR DESCRIPTION
## Summary

Device-verified audit of every tab's reload button on the emulator found several reloads that did NOT actually refresh — plus a root-caused WS ticket-mint crash breaking the Kanban events stream. All fixed and verified.

## Changes

**WS ticket mint (root cause of the History 'double-fetch' + Kanban Offline)**
- `HermesWsClient.requestWsTicket()` ran `execute()` on `Dispatchers.IO` but read `response.body.string()` on the **calling thread** — when that was main (kanban events connect), the socket read threw `NetworkOnMainThreadException`, the mint failed, and the events stream never connected (board stuck **Offline**; reconnect churn also produced duplicate session GETs that looked like a History double-fetch).
- Now the entire call (execute + body read) runs on `Dispatchers.IO`. Same bug class fixed in `DashboardSessionTokenRefresher.fetch()` (loopback mint path).

**Kanban — refresh fired a redundant board switch**
- Refresh → `loadBoards()` → auto-`selectBoard()` re-selected the already-active board → `POST /boards/hermes-mobile/switch` on every tap.
- Same-board re-select now reloads board data + reconnects the events stream **without** the switch round-trip.

**Plugins — no reload at all**
- Wired `HermesScaffold`'s top-bar Refresh + pull-to-refresh to `loadPlugins()` (removed the redundant nested `PullToRefreshBox`).

**Skills — Refresh icon was a hub update**
- Refresh icon now does a plain `GET /api/skills` reload; the heavy `POST /api/skills/hub/update` moved to a distinct cloud icon.

## Device-verified (emulator, signed build)

| Tab | Before | After |
|---|---|---|
| Plugins | no refresh control | tap → single `GET /api/dashboard/plugins/hub` |
| Skills | refresh = hub update POST | tap → single `GET /api/skills`; cloud icon → hub update |
| Kanban | boards + board + **switch POST** | boards + board only; board **Live** (events WS connected) |
| History | 2–3 duplicate `GET /api/sessions` (reconnect churn) | exactly **one** `GET /api/sessions` |

## Gates
- ktlintCheck ✅ · testDebugUnitTest (full suite) ✅ · assembleDebug ✅
- Test updated: mock 3-arg `Log.w` overload (catch now logs the full stack for diagnostics)