### PR TITLE
[bug] fix(release): keep security-crypto/Tink — release builds can't read stored token

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -35,6 +35,11 @@
 }
 
 # ── AndroidX Security Crypto ─────────────────────────────────────────────
+# EncryptedSharedPreferences / MasterKey resolve primitives via Tink's
+# reflection-based Registry. Without -keep, R8 obfuscates those classes and
+# token reads silently fail (401 on every API call, "Session expired").
+-keep class androidx.security.crypto.** { *; }
+-keep class com.google.crypto.tink.** { *; }
 -dontwarn androidx.security.crypto.**
 
 # ── Tink / Error Prone ───────────────────────────────────────────────────


### PR DESCRIPTION
## Release blocker: release APK could not read the stored auth token

**Symptom:** debug builds connect fine; the R8-minified release APK shows "Session expired / Re-login" — `HermesWsClient: WS ticket mint failed: HTTP 401` — and the backend auth log shows no request ever authenticated. Root cause: `EncryptedSharedPreferences`/Tink resolve primitives via a **reflection-based Registry**, and `proguard-rules.pro` only had `-dontwarn androidx.security.crypto.**` — no `-keep`. R8 obfuscated those classes, decrypt returned nothing, every request went out tokenless.

**Fix:** keep `androidx.security.crypto.**` and `com.google.crypto.tink.**`.

**Verified on device (hyari emulator, existing token preserved):**
1. Debug APK → connects ✓
2. Release APK (before) → 401, "Session expired" ✗
3. Release APK (with these keeps) → **connects with no re-login** ✓
4. Config tab smoke on the fixed release: search → 4 results ✓

Release-blocking: tag v1.22.0 only after this merges.