### PR TITLE
feat(billing): wire tier switcher, plan change preview, resume and cancel UI (#902)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/model/BillingModels.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/model/BillingModels.kt
@@ -51,6 +51,7 @@ data class SubscriptionStateResponse(
     val tiers: List<SubscriptionTier> = emptyList(),
     val portal_url: String? = null,
     val error: String? = null,
+    val usage: UsageBarsResponse? = null,
 )
 
 @Serializable
@@ -131,6 +132,15 @@ data class SubscriptionPreviewResponse(
     val error: String? = null,
     val message: String? = null,
     val payload: SubscriptionPreviewPayload? = null,
+    val effect: String? = null,
+    val reason: String? = null,
+    val current_tier_id: String? = null,
+    val current_tier_name: String? = null,
+    val target_tier_id: String? = null,
+    val target_tier_name: String? = null,
+    val monthly_credits_delta: String? = null,
+    val amount_due_now_cents: Int? = null,
+    val effective_at: String? = null,
     val subscription_type_id: String? = null,
     val subscription_type_name: String? = null,
     val price: String? = null,

--- a/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingScreen.kt
@@ -9,21 +9,36 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.AccountBalanceWallet
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -32,12 +47,17 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.SubscriptionCurrent
 import com.m57.hermescontrol.data.model.SubscriptionStateResponse
+import com.m57.hermescontrol.data.model.SubscriptionTier
+import com.m57.hermescontrol.data.model.UsageBar
 import com.m57.hermescontrol.ui.common.ErrorState
 import com.m57.hermescontrol.ui.common.HermesScaffold
 import com.m57.hermescontrol.ui.common.LoadingState
 import com.m57.hermescontrol.ui.common.NavIcon
+import com.m57.hermescontrol.ui.common.StatusBadge
+import com.m57.hermescontrol.ui.common.StatusBadgeType
 import com.m57.hermescontrol.ui.common.listContentPadding
 import com.m57.hermescontrol.ui.common.listItemSpacing
+import java.util.Locale
 
 @Composable
 fun BillingScreen(
@@ -46,6 +66,10 @@ fun BillingScreen(
     viewModel: BillingViewModel = viewModel { BillingViewModel() },
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    DisposableEffect(Unit) {
+        onDispose { viewModel.clearTransientState() }
+    }
 
     LaunchedEffect(Unit) {
         if (state.subscription == null && state.usage == null && !state.featureUnavailable) {
@@ -83,6 +107,7 @@ fun BillingScreen(
                     onChange = viewModel::change,
                     onResume = viewModel::resume,
                     onPreview = viewModel::preview,
+                    onDismissPreview = viewModel::clearPreview,
                 )
             }
         }
@@ -96,35 +121,212 @@ private fun BillingContent(
     onChange: (String?, Boolean?) -> Unit,
     onResume: () -> Unit,
     onPreview: (String) -> Unit,
+    onDismissPreview: () -> Unit,
 ) {
     val subscription = state.subscription
     val usage = state.usage
+    val uriHandler = LocalUriHandler.current
+
+    var showCancelDialog by remember { mutableStateOf(false) }
+
+    if (showCancelDialog) {
+        val currentPlanName = subscription?.current?.tier_name ?: stringResource(R.string.billing_plan)
+        val effectiveDate =
+            subscription?.current?.cancellation_effective_display
+                ?: subscription?.current?.cycle_ends_at
+                ?: stringResource(R.string.billing_renews, "")
+        AlertDialog(
+            onDismissRequest = { showCancelDialog = false },
+            title = { Text(stringResource(R.string.billing_cancel_dialog_title)) },
+            text = {
+                Text(
+                    stringResource(
+                        R.string.billing_cancel_dialog_message,
+                        currentPlanName,
+                        effectiveDate,
+                    ),
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showCancelDialog = false
+                        onChange(null, true)
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
+                ) {
+                    Text(stringResource(R.string.billing_cancel_dialog_confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCancelDialog = false }) {
+                    Text(stringResource(R.string.common_cancel))
+                }
+            },
+        )
+    }
+
+    val preview = state.preview
+    if (preview != null) {
+        val targetTier =
+            subscription?.tiers?.find {
+                it.tier_id == preview.target_tier_id || it.tier_id == state.previewingTierId
+            }
+        val targetName =
+            preview.target_tier_name
+                ?: targetTier?.name
+                ?: preview.subscription_type_name
+                ?: stringResource(R.string.billing_plan)
+        val effect = preview.effect ?: "scheduled"
+        val isUpgrade = effect == "charge_now"
+        val isBlocked = effect == "blocked"
+        val isNoOp = effect == "no_op"
+
+        AlertDialog(
+            onDismissRequest = onDismissPreview,
+            title = { Text(stringResource(R.string.billing_preview_dialog_title)) },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = targetName,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    when {
+                        isUpgrade -> {
+                            val amountStr =
+                                preview.amount_due_now_cents?.let {
+                                    String.format(Locale.US, "$%.2f", it / 100.0)
+                                } ?: preview.price ?: ""
+                            Text(
+                                stringResource(
+                                    R.string.billing_preview_upgrade_message,
+                                    targetName,
+                                    amountStr,
+                                ),
+                            )
+                        }
+
+                        isBlocked -> {
+                            Text(
+                                text = preview.reason ?: preview.message ?: "This change cannot be made here.",
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        }
+
+                        isNoOp -> {
+                            Text(text = "You are already on $targetName — nothing to change.")
+                        }
+
+                        else -> {
+                            val whenDate = preview.effective_at ?: "the end of the billing period"
+                            Text(
+                                stringResource(
+                                    R.string.billing_preview_downgrade_message,
+                                    targetName,
+                                    whenDate,
+                                ),
+                            )
+                        }
+                    }
+                    if (preview.monthly_credits_delta != null) {
+                        Text(
+                            text =
+                                stringResource(
+                                    R.string.billing_preview_credits_delta,
+                                    preview.monthly_credits_delta,
+                                ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                if (!isBlocked && !isNoOp) {
+                    Button(
+                        enabled = !state.isActionInFlight,
+                        onClick = {
+                            val tid = preview.target_tier_id ?: state.previewingTierId ?: ""
+                            if (isUpgrade) {
+                                onUpgrade(tid)
+                            } else {
+                                onChange(tid, null)
+                            }
+                        },
+                    ) {
+                        Text(
+                            if (isUpgrade) {
+                                stringResource(R.string.billing_preview_confirm_upgrade)
+                            } else {
+                                stringResource(R.string.billing_preview_confirm_change)
+                            },
+                        )
+                    }
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = onDismissPreview) {
+                    Text(stringResource(R.string.common_cancel))
+                }
+            },
+        )
+    }
+
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = listContentPadding,
         verticalArrangement = listItemSpacing,
     ) {
         val sub = subscription
-        if (sub != null && sub.logged_in == true && sub.current != null) {
-            item { PlanCard(sub.current) }
-            if (sub.can_change_plan == true) {
-                item {
+        if (sub != null && sub.context == "team") {
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+                    shape = RoundedCornerShape(16.dp),
+                ) {
                     Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
-                        OutlinedButton(
-                            onClick = { onChange(null, true) },
-                            enabled = !state.isActionInFlight,
-                            modifier = Modifier.weight(1f),
-                        ) {
-                            Text(stringResource(R.string.billing_cancel))
-                        }
+                        Icon(
+                            imageVector = Icons.Filled.Info,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                        Text(
+                            text = stringResource(R.string.billing_team_notice, sub.org_name ?: "Team"),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
                     }
                 }
             }
+        }
+
+        if (sub != null && sub.logged_in == true && sub.current != null) {
+            item {
+                PlanCard(
+                    subscription = sub.current,
+                    allTiers = sub.tiers,
+                    orgName = if (sub.context != "team") sub.org_name else null,
+                    role = if (sub.context != "team") sub.role else null,
+                    canChangePlan = sub.can_change_plan == true,
+                    portalUrl = sub.portal_url,
+                    isActionInFlight = state.isActionInFlight,
+                    onResume = onResume,
+                    onCancelRequest = { showCancelDialog = true },
+                    onOpenPortal = { url -> uriHandler.openUri(url) },
+                )
+            }
         } else if (sub != null) {
-            item { NoActivePlanCard(sub) }
+            item {
+                NoActivePlanCard(
+                    subscription = sub,
+                    onOpenPortal = sub.portal_url?.let { url -> { uriHandler.openUri(url) } },
+                )
+            }
         }
 
         if (state.errorMessage != null) {
@@ -151,12 +353,50 @@ private fun BillingContent(
                     colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
                     shape = RoundedCornerShape(12.dp),
                 ) {
-                    Text(
-                        text = state.actionMessage,
-                        modifier = Modifier.padding(12.dp),
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
+                    Column(modifier = Modifier.padding(12.dp)) {
+                        Text(
+                            text = state.actionMessage,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        )
+                        val actionUrl = extractUrl(state.actionMessage)
+                        if (actionUrl != null) {
+                            Button(
+                                onClick = { uriHandler.openUri(actionUrl) },
+                                modifier = Modifier.padding(top = 8.dp),
+                            ) {
+                                Text(stringResource(R.string.billing_open_portal))
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                                    contentDescription = null,
+                                    modifier = Modifier.padding(start = 4.dp).size(16.dp),
+                                )
+                            }
+                        }
+                    }
                 }
+            }
+        }
+
+        if (sub != null && sub.tiers.isNotEmpty()) {
+            item { SectionTitle(stringResource(R.string.billing_available_plans)) }
+            val currentTier = sub.tiers.find { it.is_current == true || it.tier_id == sub.current?.tier_id }
+            val currentTierOrder = currentTier?.tier_order ?: 0.0
+            val pendingDowngradeName = sub.current?.pending_downgrade_tier_name
+
+            items(sub.tiers, key = { it.tier_id ?: it.name ?: "" }) { tier ->
+                TierCard(
+                    tier = tier,
+                    isCurrent = tier.is_current == true || tier.tier_id == sub.current?.tier_id,
+                    isPendingTarget = tier.name != null && tier.name == pendingDowngradeName,
+                    currentTierOrder = currentTierOrder,
+                    canChangePlan = sub.can_change_plan == true,
+                    isActionInFlight = state.isActionInFlight,
+                    onSelect = {
+                        tier.tier_id?.let { onPreview(it) }
+                    },
+                    onOpenPortal = sub.portal_url?.let { url -> { uriHandler.openUri(url) } },
+                )
             }
         }
 
@@ -173,18 +413,63 @@ private fun BillingContent(
 }
 
 @Composable
-private fun PlanCard(subscription: SubscriptionCurrent) {
+private fun PlanCard(
+    subscription: SubscriptionCurrent,
+    allTiers: List<SubscriptionTier>,
+    orgName: String?,
+    role: String?,
+    canChangePlan: Boolean,
+    portalUrl: String?,
+    isActionInFlight: Boolean,
+    onResume: () -> Unit,
+    onCancelRequest: () -> Unit,
+    onOpenPortal: (String) -> Unit,
+) {
+    val tierPrice = allTiers.find { it.tier_id == subscription.tier_id }?.dollars_per_month_display
+    val hasPendingChange = subscription.cancel_at_period_end == true || subscription.pending_downgrade_tier_name != null
+
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
         shape = RoundedCornerShape(16.dp),
     ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(
-                text = subscription.tier_name ?: stringResource(R.string.billing_free_plan),
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold,
-            )
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = subscription.tier_name ?: stringResource(R.string.billing_free_plan),
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    if (tierPrice != null) {
+                        Text(
+                            text = stringResource(R.string.billing_price_per_month, tierPrice),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                StatusBadge(
+                    text = stringResource(R.string.billing_current_plan_badge),
+                    status = StatusBadgeType.SUCCESS,
+                )
+            }
+
+            if (orgName != null) {
+                Text(
+                    text = if (role != null) "Org: $orgName ($role)" else "Org: $orgName",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
             if (subscription.credits_remaining != null) {
                 Text(
                     text =
@@ -192,25 +477,253 @@ private fun PlanCard(subscription: SubscriptionCurrent) {
                             R.string.billing_credits_remaining,
                             subscription.credits_remaining,
                         ),
-                    style = MaterialTheme.typography.bodySmall,
+                    style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 4.dp),
                 )
             }
-            if (subscription.cycle_ends_at != null) {
+
+            if (subscription.cycle_ends_at != null && !hasPendingChange) {
                 Text(
                     text = stringResource(R.string.billing_renews, subscription.cycle_ends_at),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 4.dp),
                 )
             }
-            if (subscription.pending_downgrade_display != null) {
+
+            if (subscription.pending_downgrade_tier_name != null) {
+                val effectiveDate = subscription.pending_downgrade_display ?: subscription.pending_downgrade_at ?: ""
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.5f),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Schedule,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.tertiary,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Text(
+                                text =
+                                    stringResource(
+                                        R.string.billing_scheduled_downgrade_banner,
+                                        subscription.pending_downgrade_tier_name,
+                                        effectiveDate,
+                                    ),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                            )
+                        }
+                        if (canChangePlan) {
+                            Button(
+                                onClick = onResume,
+                                enabled = !isActionInFlight,
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                Text(stringResource(R.string.billing_undo_change))
+                            }
+                        }
+                    }
+                }
+            } else if (subscription.cancel_at_period_end == true) {
+                val effectiveDate =
+                    subscription.cancellation_effective_display
+                        ?: subscription.cancellation_effective_at
+                        ?: ""
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.5f),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Schedule,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Text(
+                                text =
+                                    stringResource(
+                                        R.string.billing_scheduled_cancellation_banner,
+                                        effectiveDate,
+                                    ),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                            )
+                        }
+                        if (canChangePlan) {
+                            Button(
+                                onClick = onResume,
+                                enabled = !isActionInFlight,
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                Text(stringResource(R.string.billing_resume))
+                            }
+                        }
+                    }
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                if (canChangePlan && !hasPendingChange) {
+                    OutlinedButton(
+                        onClick = onCancelRequest,
+                        enabled = !isActionInFlight,
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Text(stringResource(R.string.billing_cancel_subscription))
+                    }
+                }
+                if (portalUrl != null) {
+                    OutlinedButton(
+                        onClick = { onOpenPortal(portalUrl) },
+                        modifier =
+                            if (canChangePlan && !hasPendingChange) {
+                                Modifier.weight(1f)
+                            } else {
+                                Modifier.fillMaxWidth()
+                            },
+                    ) {
+                        Text(stringResource(R.string.billing_manage_portal))
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                            contentDescription = null,
+                            modifier = Modifier.padding(start = 4.dp).size(16.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TierCard(
+    tier: SubscriptionTier,
+    isCurrent: Boolean,
+    isPendingTarget: Boolean,
+    currentTierOrder: Double,
+    canChangePlan: Boolean,
+    isActionInFlight: Boolean,
+    onSelect: () -> Unit,
+    onOpenPortal: ((String) -> Unit)?,
+) {
+    val tierOrder = tier.tier_order ?: 0.0
+    val isUpgrade = tierOrder > currentTierOrder
+    val isDowngrade = tierOrder < currentTierOrder && currentTierOrder > 0.0
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors =
+            CardDefaults.cardColors(
+                containerColor =
+                    if (isCurrent) {
+                        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.25f)
+                    } else {
+                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                    },
+            ),
+        shape = RoundedCornerShape(14.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = tier.name ?: "",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Text(
+                        text =
+                            stringResource(
+                                R.string.billing_price_per_month,
+                                tier.dollars_per_month_display ?: "$0",
+                            ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                when {
+                    isCurrent -> {
+                        StatusBadge(
+                            text = stringResource(R.string.billing_current_plan_badge),
+                            status = StatusBadgeType.SUCCESS,
+                        )
+                    }
+
+                    isPendingTarget -> {
+                        StatusBadge(
+                            text = stringResource(R.string.billing_scheduled_badge),
+                            status = StatusBadgeType.WARNING,
+                        )
+                    }
+
+                    canChangePlan -> {
+                        Button(
+                            onClick = onSelect,
+                            enabled = !isActionInFlight && tier.is_enabled != false,
+                        ) {
+                            Text(
+                                when {
+                                    isUpgrade -> stringResource(R.string.billing_upgrade)
+                                    isDowngrade -> stringResource(R.string.billing_downgrade)
+                                    else -> stringResource(R.string.billing_choose)
+                                },
+                            )
+                        }
+                    }
+
+                    onOpenPortal != null -> {
+                        OutlinedButton(
+                            onClick = { onOpenPortal("https://portal.nousresearch.com") },
+                        ) {
+                            Text(stringResource(R.string.billing_choose))
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                                contentDescription = null,
+                                modifier = Modifier.padding(start = 4.dp).size(14.dp),
+                            )
+                        }
+                    }
+                }
+            }
+
+            if (tier.monthly_credits != null && tier.monthly_credits != "0") {
                 Text(
-                    text = subscription.pending_downgrade_display,
+                    text =
+                        stringResource(
+                            R.string.billing_monthly_credits_suffix,
+                            tier.monthly_credits,
+                        ),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 4.dp),
                 )
             }
         }
@@ -218,13 +731,19 @@ private fun PlanCard(subscription: SubscriptionCurrent) {
 }
 
 @Composable
-private fun NoActivePlanCard(subscription: SubscriptionStateResponse) {
+private fun NoActivePlanCard(
+    subscription: SubscriptionStateResponse,
+    onOpenPortal: (() -> Unit)?,
+) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
         shape = RoundedCornerShape(16.dp),
     ) {
-        Column(modifier = Modifier.padding(16.dp)) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
             Text(
                 text = stringResource(R.string.billing_free_plan),
                 style = MaterialTheme.typography.headlineSmall,
@@ -239,8 +758,20 @@ private fun NoActivePlanCard(subscription: SubscriptionStateResponse) {
                     },
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 4.dp),
             )
+            if (onOpenPortal != null) {
+                OutlinedButton(
+                    onClick = onOpenPortal,
+                    modifier = Modifier.padding(top = 4.dp),
+                ) {
+                    Text(stringResource(R.string.billing_open_portal))
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                        contentDescription = null,
+                        modifier = Modifier.padding(start = 4.dp).size(16.dp),
+                    )
+                }
+            }
         }
     }
 }
@@ -248,7 +779,7 @@ private fun NoActivePlanCard(subscription: SubscriptionStateResponse) {
 @Composable
 private fun UsageBarRow(
     label: String,
-    bar: com.m57.hermescontrol.data.model.UsageBar,
+    bar: UsageBar,
 ) {
     val fraction = (bar.fill_fraction ?: 0.0).toFloat().coerceIn(0f, 1f)
     val summary = bar.remaining_display ?: bar.total_display ?: ""
@@ -300,8 +831,8 @@ private fun FeatureUnavailableState(onRetry: () -> Unit) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        androidx.compose.material3.Icon(
-            imageVector = androidx.compose.material.icons.Icons.Filled.AccountBalanceWallet,
+        Icon(
+            imageVector = Icons.Filled.AccountBalanceWallet,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
             modifier = Modifier.padding(bottom = 16.dp).size(48.dp),
@@ -310,5 +841,17 @@ private fun FeatureUnavailableState(onRetry: () -> Unit) {
             message = stringResource(R.string.billing_feature_unavailable),
             onRetry = onRetry,
         )
+    }
+}
+
+private fun extractUrl(message: String): String? {
+    val prefix = "open: "
+    val idx = message.indexOf(prefix)
+    return if (idx != -1) {
+        message.substring(idx + prefix.length).trim()
+    } else if (message.startsWith("http://") || message.startsWith("https://")) {
+        message.trim()
+    } else {
+        null
     }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/billing/BillingViewModel.kt
@@ -31,6 +31,7 @@ data class BillingUiState(
     val subscription: SubscriptionStateResponse? = null,
     val usage: UsageBarsResponse? = null,
     val preview: com.m57.hermescontrol.data.model.SubscriptionPreviewResponse? = null,
+    val previewingTierId: String? = null,
     /** Set when an RPC method is unavailable on the connected backend (e.g. -32601). */
     val featureUnavailable: Boolean = false,
     val errorMessage: String? = null,
@@ -110,12 +111,23 @@ class BillingViewModel : ViewModel() {
 
     fun preview(subscriptionTypeId: String) {
         viewModelScope.launch {
-            _uiState.update { it.copy(isActionInFlight = true, errorMessage = null, actionMessage = null) }
+            _uiState.update {
+                it.copy(
+                    isActionInFlight = true,
+                    errorMessage = null,
+                    actionMessage = null,
+                    previewingTierId = subscriptionTypeId,
+                )
+            }
             runCatching { BillingRepository.previewSubscription(subscriptionTypeId) }
                 .onSuccess { preview ->
                     if (preview == null) {
                         _uiState.update {
-                            it.copy(isActionInFlight = false, errorMessage = "No billing data returned")
+                            it.copy(
+                                isActionInFlight = false,
+                                errorMessage = "No billing data returned",
+                                previewingTierId = null,
+                            )
                         }
                         return@onSuccess
                     }
@@ -124,6 +136,7 @@ class BillingViewModel : ViewModel() {
                             it.copy(
                                 isActionInFlight = false,
                                 errorMessage = preview.error ?: preview.message ?: "Preview unavailable",
+                                previewingTierId = null,
                             )
                         }
                     } else {
@@ -134,15 +147,47 @@ class BillingViewModel : ViewModel() {
                         it.copy(
                             isActionInFlight = false,
                             errorMessage = (e as? HermesWsClient.HermesRpcException)?.message ?: e.message,
+                            previewingTierId = null,
                         )
                     }
                 }
         }
     }
 
+    fun clearPreview() {
+        _uiState.update { it.copy(preview = null, previewingTierId = null) }
+    }
+
+    fun clearTransientState() {
+        _uiState.update {
+            it.copy(
+                errorMessage = null,
+                actionMessage = null,
+                preview = null,
+                previewingTierId = null,
+            )
+        }
+    }
+
+    fun clearActionMessage() {
+        _uiState.update { it.copy(actionMessage = null) }
+    }
+
+    fun clearErrorMessage() {
+        _uiState.update { it.copy(errorMessage = null) }
+    }
+
     fun upgrade(subscriptionTypeId: String) {
         viewModelScope.launch {
-            _uiState.update { it.copy(isActionInFlight = true, errorMessage = null, actionMessage = null) }
+            _uiState.update {
+                it.copy(
+                    isActionInFlight = true,
+                    errorMessage = null,
+                    actionMessage = null,
+                    preview = null,
+                    previewingTierId = null,
+                )
+            }
             runCatching { BillingRepository.upgradeSubscription(subscriptionTypeId) }
                 .onSuccess { resp ->
                     if (resp == null) {
@@ -196,7 +241,15 @@ class BillingViewModel : ViewModel() {
         cancel: Boolean? = null,
     ) {
         viewModelScope.launch {
-            _uiState.update { it.copy(isActionInFlight = true, errorMessage = null, actionMessage = null) }
+            _uiState.update {
+                it.copy(
+                    isActionInFlight = true,
+                    errorMessage = null,
+                    actionMessage = null,
+                    preview = null,
+                    previewingTierId = null,
+                )
+            }
             runCatching { BillingRepository.changeSubscription(SubscriptionChangeRequest(subscriptionTypeId, cancel)) }
                 .onSuccess { resp ->
                     if (resp == null) {

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -47,6 +47,31 @@
     <string name="billing_credits_remaining">남은 크레딧: %1$s</string>
     <string name="billing_plan">요금제</string>
     <string name="billing_topup">충전</string>
+    <string name="billing_available_plans">사용 가능한 요금제</string>
+    <string name="billing_current_plan_badge">현재 요금제</string>
+    <string name="billing_scheduled_badge">예정됨</string>
+    <string name="billing_upgrade">업그레이드</string>
+    <string name="billing_downgrade">다운그레이드</string>
+    <string name="billing_choose">선택</string>
+    <string name="billing_resume">요금제 유지</string>
+    <string name="billing_undo_change">변경 취소</string>
+    <string name="billing_scheduled_downgrade_banner">예정된 변경: %2$s에 %1$s(으)로 변경됩니다. 그때까지 현재 요금제가 유지됩니다.</string>
+    <string name="billing_scheduled_cancellation_banner">예정된 취소: %1$s에 취소됩니다. 기간 종료 시까지 요금제가 유지됩니다.</string>
+    <string name="billing_cancel_subscription">구독 취소</string>
+    <string name="billing_cancel_dialog_title">구독 취소</string>
+    <string name="billing_cancel_dialog_message">%1$s 요금제를 취소하시겠습니까? %2$s까지 활성 상태로 유지된 후 갱신되지 않습니다. 남은 크레딧은 기간 종료 시까지 유지됩니다.</string>
+    <string name="billing_cancel_dialog_confirm">구독 취소 확인</string>
+    <string name="billing_preview_dialog_title">요금제 변경 확인</string>
+    <string name="billing_preview_upgrade_message">%1$s(으)로 업그레이드합니다. 지금 %2$s이(가) 비례 청구됩니다.</string>
+    <string name="billing_preview_downgrade_message">%1$s(으)로 변경 — %2$s부터 적용됩니다. 오늘은 청구되지 않으며 그때까지 현재 요금제가 유지됩니다.</string>
+    <string name="billing_preview_credits_delta">월간 크레딧 변경: %1$s</string>
+    <string name="billing_preview_confirm_upgrade">결제 및 업그레이드</string>
+    <string name="billing_preview_confirm_change">변경 확인</string>
+    <string name="billing_open_portal">포털 열기</string>
+    <string name="billing_manage_portal">포털에서 관리</string>
+    <string name="billing_monthly_credits_suffix">월 %1$s 크레딧</string>
+    <string name="billing_price_per_month">월 %1$s</string>
+    <string name="billing_team_notice">이 계정은 %1$s(팀)에 연결되어 있습니다. 팀 계정은 공유 크레딧으로 실행됩니다.</string>
 
     <!-- Navigation & Drawer -->
     <string name="nav_drawer_title">헤르메스</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,31 @@
     <string name="billing_credits_remaining">Credits remaining: %1$s</string>
     <string name="billing_plan">Plan</string>
     <string name="billing_topup">Top-up</string>
+    <string name="billing_available_plans">Available Plans</string>
+    <string name="billing_current_plan_badge">Current Plan</string>
+    <string name="billing_scheduled_badge">Scheduled</string>
+    <string name="billing_upgrade">Upgrade</string>
+    <string name="billing_downgrade">Downgrade</string>
+    <string name="billing_choose">Choose</string>
+    <string name="billing_resume">Resume Plan</string>
+    <string name="billing_undo_change">Undo Change</string>
+    <string name="billing_scheduled_downgrade_banner">Scheduled change: switches to %1$s on %2$s. You keep your current plan until then.</string>
+    <string name="billing_scheduled_cancellation_banner">Scheduled cancellation: cancels on %1$s. Plan remains active until period ends.</string>
+    <string name="billing_cancel_subscription">Cancel Subscription</string>
+    <string name="billing_cancel_dialog_title">Cancel Subscription</string>
+    <string name="billing_cancel_dialog_message">Cancel your %1$s plan? It will stay active until %2$s, then will not renew. You keep your remaining credits until the period ends.</string>
+    <string name="billing_cancel_dialog_confirm">Confirm Cancellation</string>
+    <string name="billing_preview_dialog_title">Confirm Plan Change</string>
+    <string name="billing_preview_upgrade_message">Upgrade to %1$s. You will be charged %2$s now (prorated).</string>
+    <string name="billing_preview_downgrade_message">Change to %1$s — takes effect on %2$s. No charge today; you keep your current plan until then.</string>
+    <string name="billing_preview_credits_delta">Monthly credits change: %1$s</string>
+    <string name="billing_preview_confirm_upgrade">Pay &amp; Upgrade</string>
+    <string name="billing_preview_confirm_change">Confirm Change</string>
+    <string name="billing_open_portal">Open Portal</string>
+    <string name="billing_manage_portal">Manage on Portal</string>
+    <string name="billing_monthly_credits_suffix">%1$s credits/mo</string>
+    <string name="billing_price_per_month">%1$s/mo</string>
+    <string name="billing_team_notice">This account is connected to %1$s (Team). Team accounts run on shared credits.</string>
 
     <!-- Navigation & Drawer -->
     <string name="nav_drawer_title">Hermes</string>

--- a/app/src/test/java/com/m57/hermescontrol/ui/billing/BillingViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/billing/BillingViewModelTest.kt
@@ -1,0 +1,209 @@
+package com.m57.hermescontrol.ui.billing
+
+import com.m57.hermescontrol.data.model.SubscriptionCurrent
+import com.m57.hermescontrol.data.model.SubscriptionPreviewResponse
+import com.m57.hermescontrol.data.model.SubscriptionResumeResponse
+import com.m57.hermescontrol.data.model.SubscriptionStateResponse
+import com.m57.hermescontrol.data.model.SubscriptionTier
+import com.m57.hermescontrol.data.model.SubscriptionUpgradeResponse
+import com.m57.hermescontrol.data.model.UsageBarsResponse
+import com.m57.hermescontrol.data.ws.BillingRepository
+import io.mockk.coEvery
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BillingViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var viewModel: BillingViewModel
+
+    private val sampleSubscription =
+        SubscriptionStateResponse(
+            ok = true,
+            logged_in = true,
+            is_admin = true,
+            can_change_plan = true,
+            org_name = "Acme",
+            org_id = "org_123",
+            current =
+                SubscriptionCurrent(
+                    tier_id = "plus",
+                    tier_name = "Plus",
+                    credits_remaining = "150.00",
+                    cycle_ends_at = "2026-09-01",
+                ),
+            tiers =
+                listOf(
+                    SubscriptionTier(
+                        tier_id = "plus",
+                        name = "Plus",
+                        tier_order = 1.0,
+                        dollars_per_month_display = "$20",
+                        is_current = true,
+                        is_enabled = true,
+                    ),
+                    SubscriptionTier(
+                        tier_id = "ultra",
+                        name = "Ultra",
+                        tier_order = 2.0,
+                        dollars_per_month_display = "$80",
+                        is_current = false,
+                        is_enabled = true,
+                    ),
+                ),
+            portal_url = "https://portal.nousresearch.com",
+        )
+
+    private val sampleUsage =
+        UsageBarsResponse(
+            ok = true,
+            available = true,
+            status = "active",
+            plan_name = "Plus",
+            subscription_remaining_display = "$150.00",
+        )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockkObject(BillingRepository)
+        coEvery { BillingRepository.getSubscriptionState() } returns sampleSubscription
+        coEvery { BillingRepository.getUsageBars() } returns sampleUsage
+        viewModel = BillingViewModel()
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun load_populatesSubscriptionAndUsage() =
+        runTest(testDispatcher) {
+            viewModel.load()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertEquals(false, state.isLoading)
+            assertNotNull(state.subscription)
+            assertEquals("Plus", state.subscription?.current?.tier_name)
+            assertNotNull(state.usage)
+            assertEquals("$150.00", state.usage?.subscription_remaining_display)
+            assertNull(state.errorMessage)
+        }
+
+    @Test
+    fun preview_success_setsPreviewState() =
+        runTest(testDispatcher) {
+            val previewResp =
+                SubscriptionPreviewResponse(
+                    ok = true,
+                    effect = "charge_now",
+                    target_tier_id = "ultra",
+                    target_tier_name = "Ultra",
+                    amount_due_now_cents = 6000,
+                )
+            coEvery { BillingRepository.previewSubscription("ultra") } returns previewResp
+
+            viewModel.preview("ultra")
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertEquals(false, state.isActionInFlight)
+            assertEquals(previewResp, state.preview)
+            assertEquals("ultra", state.previewingTierId)
+        }
+
+    @Test
+    fun clearPreview_resetsPreviewAndTierId() =
+        runTest(testDispatcher) {
+            val previewResp =
+                SubscriptionPreviewResponse(
+                    ok = true,
+                    effect = "charge_now",
+                    target_tier_id = "ultra",
+                )
+            coEvery { BillingRepository.previewSubscription("ultra") } returns previewResp
+            viewModel.preview("ultra")
+            advanceUntilIdle()
+
+            viewModel.clearPreview()
+
+            val state = viewModel.uiState.value
+            assertNull(state.preview)
+            assertNull(state.previewingTierId)
+        }
+
+    @Test
+    fun upgrade_success_setsActionMessageAndReloads() =
+        runTest(testDispatcher) {
+            val upgradeResp =
+                SubscriptionUpgradeResponse(
+                    ok = true,
+                    status = "upgraded",
+                    message = "Upgraded to Ultra",
+                )
+            coEvery { BillingRepository.upgradeSubscription("ultra") } returns upgradeResp
+
+            viewModel.upgrade("ultra")
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertEquals(false, state.isActionInFlight)
+            assertEquals("Upgrade successful", state.actionMessage)
+            assertNull(state.preview)
+        }
+
+    @Test
+    fun resume_success_setsActionMessageAndReloads() =
+        runTest(testDispatcher) {
+            val resumeResp =
+                SubscriptionResumeResponse(
+                    ok = true,
+                    message = "Subscription resumed",
+                )
+            coEvery { BillingRepository.resumeSubscription() } returns resumeResp
+
+            viewModel.resume()
+            advanceUntilIdle()
+
+            val state = viewModel.uiState.value
+            assertEquals(false, state.isActionInFlight)
+            assertEquals("Subscription resumed", state.actionMessage)
+        }
+
+    @Test
+    fun clearTransientState_clearsAllTransientFields() =
+        runTest(testDispatcher) {
+            val previewResp =
+                SubscriptionPreviewResponse(
+                    ok = true,
+                    effect = "charge_now",
+                )
+            coEvery { BillingRepository.previewSubscription("ultra") } returns previewResp
+            viewModel.preview("ultra")
+            advanceUntilIdle()
+
+            viewModel.clearTransientState()
+
+            val state = viewModel.uiState.value
+            assertNull(state.errorMessage)
+            assertNull(state.actionMessage)
+            assertNull(state.preview)
+            assertNull(state.previewingTierId)
+        }
+}


### PR DESCRIPTION
Closes #902

### Summary
Wires complete parity for the Billing tab with the web dashboard / desktop application:
- **Selectable Tier Catalog:** Displays all available subscription tiers with live pricing and monthly credit allocations.
- **Plan Change Preview & Directional Routing:** Interactive confirmation dialog that checks  quotes, distinguishing prorated instant upgrades (`charge_now`) from period-end scheduled downgrades (`scheduled`), blocked changes, and no-ops.
- **Undo / Resume Action:** Banners displaying pending downgrades or cancellations with an inline **Undo Change** / **Resume Plan** action calling `subscription.resume`.
- **Cancellation Flow:** Confirmation dialog to safely schedule a subscription cancellation.
- **Portal Link Outs:** Outlined actions to open Nous Portal for payment methods, 3DS challenges, or team-context org notifications.
- **Unit Tests:** Full test suite in `BillingViewModelTest` validating state flows and lifecycle.