### PR TITLE
fix: model pickers wrap long names, keep pin button visible (#910)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/model/ModelScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/ModelScreen.kt
@@ -820,6 +820,10 @@ private fun ProviderCard(
                                             } else {
                                                 MaterialTheme.colorScheme.onSurface
                                             },
+                                        // Weight + wrap: a long model name grows
+                                        // the row vertically instead of pushing
+                                        // the check/pin buttons off-screen.
+                                        modifier = Modifier.weight(1f),
                                     )
                                     Row(
                                         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/m57/hermescontrol/ui/model/components/ModelPickerDialog.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/model/components/ModelPickerDialog.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.m57.hermescontrol.R
 import com.m57.hermescontrol.data.model.ModelProvider
@@ -273,8 +272,8 @@ private fun ModelItemCard(
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.onSurface,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
+                // No maxLines/ellipsis: a long model name wraps so the full
+                // name stays readable while the pin button keeps its spot.
                 modifier = Modifier.weight(1f),
             )
             if (onPinToggle != null) {


### PR DESCRIPTION
## Summary

Long model names broke the model pickers: on the Model tab a long name pushed the check/pin buttons off-screen (they had no `weight(1f)` on the name), and in the picker dialogs names were truncated with ellipsis so users couldn't read the full name (e.g. `anthropic/claude-sonnet-4-5-20250929`).

## Changes

- **`ModelScreen` → `ProviderCard`** — model name `Text` now gets `Modifier.weight(1f)` and wraps (no `maxLines`): the row grows vertically with the name, and the check/pin buttons stay anchored right — never hidden.
- **`ModelPickerDialog` → `ModelItemCard`** (shared by main / aux / in-session `/model` pickers) — dropped `maxLines = 1` + `TextOverflow.Ellipsis`: names wrap and render in full; the pin button keeps its fixed spot.

Short names look identical (single line); only long names change behavior.

## Tests

- Local: `ktlintCheck` ✅ · full `testDebugUnitTest` ✅ (BUILD SUCCESSFUL, 0 failures)
- No unit tests exist for these private composables; behavior is layout-only.

Fixes #910
