### PR TITLE
feat: open gateway MEDIA files via WPS deep-link streaming

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,15 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
+    <queries>
+        <!-- See wps:// (and file-type) VIEW handlers to route deep links to
+             WPS explicitly instead of showing the system resolver chooser. -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="wps" />
+        </intent>
+    </queries>
+
     <application
         android:name=".HermesControlApp"
         android:allowBackup="false"

--- a/app/src/main/java/com/m57/hermescontrol/data/remote/GatewayFileClient.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/remote/GatewayFileClient.kt
@@ -1,6 +1,7 @@
 package com.m57.hermescontrol.data.remote
 
 import com.m57.hermescontrol.data.local.AuthManager
+import kotlinx.serialization.Serializable
 import okhttp3.Request
 import java.io.IOException
 import java.net.URLDecoder
@@ -87,6 +88,39 @@ object GatewayFileClient {
         return expanded
     }
 
+    /** Mint a short-lived signed download URL for an external viewer (WPS etc.).
+     *
+     * Calls ``GET /api/files/download-ticket?path=<enc>`` with the shared
+     * CookieJar (gated basic-auth session). The returned URL is HMAC-signed,
+     * valid ~5 minutes, bound to exactly this file, and needs no cookie — so
+     * an external viewer that can't attach cookies or headers (WPS deep link)
+     * can stream it directly over LAN/Tailscale. Returns null on any failure;
+     * the caller falls back to the cookie-authenticated [fetch] below.
+     */
+    suspend fun mintDownloadUrl(path: String): String? {
+        return try {
+            val baseUrl = AuthManager.getBaseUrl()
+            if (baseUrl.isBlank()) return null
+            val norm = normalizePath(path) ?: return null
+            val encPath = URLEncoder.encode(norm, StandardCharsets.UTF_8.name()).replace("+", "%20")
+            val url = "${baseUrl.trimEnd('/')}/api/files/download-ticket?path=$encPath"
+            val request = Request.Builder().url(url).build()
+            OkHttpProvider.probe.newCall(request).execute().use { resp ->
+                if (!resp.isSuccessful) return null
+                val body = resp.body?.string() ?: return null
+                runCatching { OkHttpProvider.json.decodeFromString<DownloadTicketResponse>(body) }
+                    .getOrNull()
+                    ?.url
+                    ?.takeIf { it.isNotBlank() }
+            }
+        } catch (e: Throwable) {
+            // Unconfigured server, bad path, network error, or unrecognised
+            // response — treat as "no ticket" so the caller falls back to the
+            // cookie-authenticated download.
+            null
+        }
+    }
+
     /** Map an HTTP status to a non-success result; `null` means "let the
      * caller treat the body as a successful file." */
     internal fun classifyStatus(code: Int): GatewayFileResult? =
@@ -147,6 +181,14 @@ object GatewayFileClient {
 
     private val FILENAME_RE = Regex("""filename\*?=(?:UTF-8'')?"?([^";]+)"?""", RegexOption.IGNORE_CASE)
 }
+
+/** JSON envelope for `GET /api/files/download-ticket`. */
+@Serializable
+private data class DownloadTicketResponse(
+    val ok: Boolean = false,
+    val url: String = "",
+    val path: String = "",
+)
 
 /** A file fetched from the gateway. */
 data class GatewayFile(

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -3039,9 +3039,13 @@ class ChatViewModel(
                 .onSuccess { return }
                 .onFailure { /* fall through to cache-copy below */ }
         }
-        // GATEWAY, or LOCAL direct-open failed → fetch/copy then open.
+        // GATEWAY, or LOCAL direct-open failed → try WPS deep-link streaming
+        // first (ticket URL → `wps://open?url=...`), fall back to
+        // fetch/copy-then-open when the device has no WPS handler or the
+        // hand-off failed.
         val path = gatewayPathFor(attachment)
         viewModelScope.launch(ioDispatcher) {
+            if (openGatewayStreaming(ctx, path)) return@launch
             when (val result = GatewayFileClient.fetch(path)) {
                 is GatewayFileResult.Success -> {
                     openBytes(ctx, result.file)
@@ -3121,6 +3125,60 @@ class ChatViewModel(
         attachment.gatewayUrl?.let(::gatewayPathFromUrl)
             ?: attachment.uri.removePrefix("gateway:").takeIf { it != attachment.uri }
             ?: attachment.name
+
+    /** Try to open a gateway file with WPS streaming via its deep link:
+     * `wps://open?url=<urlencoded signed ticket URL>`. The ticket URL is
+     * cookie-free and short-lived, so WPS can stream the file directly over
+     * LAN or Tailscale without the app downloading it first. Returns true
+     * only when the intent was handed to a handler; false on any failure so
+     * the caller falls back to download-then-open. Only document-ish
+     * attachments (MediaKind.FILE) are routed this way — images render
+     * inline and audio/video go through their own players.
+     */
+    private suspend fun openGatewayStreaming(
+        ctx: android.content.Context,
+        path: String,
+    ): Boolean {
+        if (mediaKindForPath(path) != MediaKind.FILE) return false
+        val ticketUrl = GatewayFileClient.mintDownloadUrl(path) ?: return false
+        val wpsUri = android.net.Uri.parse("wps://open?url=" + android.net.Uri.encode(ticketUrl))
+        // Route straight to WPS by trying the known WPS packages explicitly.
+        // This avoids the system resolver chooser on every tap and doesn't
+        // depend on package visibility (which MIUI can restrict), unlike
+        // queryIntentActivities. Falls back to the implicit chooser when no
+        // candidate package is installed.
+        val wpsCandidates =
+            listOf(
+                "cn.wps.moffice",
+                "cn.wps.moffice_eng",
+                "cn.wps.moffice_global",
+                "cn.wps.moffice_main",
+            )
+        for (pkg in wpsCandidates) {
+            val intent =
+                android.content.Intent(android.content.Intent.ACTION_VIEW, wpsUri).apply {
+                    setPackage(pkg)
+                    addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+            try {
+                ctx.startActivity(intent)
+                return true
+            } catch (e: Throwable) {
+                // Candidate not installed / not a handler → try the next one.
+            }
+        }
+        // No known WPS package resolved → let the system resolver choose.
+        val fallback =
+            android.content.Intent(android.content.Intent.ACTION_VIEW, wpsUri).apply {
+                addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        return try {
+            ctx.startActivity(fallback)
+            true
+        } catch (e: Throwable) {
+            false
+        }
+    }
 
     /** Open bytes written to a cache file via FileProvider + ACTION_VIEW. */
     private fun openBytes(

--- a/app/src/test/java/com/m57/hermescontrol/data/remote/GatewayFileClientTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/remote/GatewayFileClientTest.kt
@@ -5,6 +5,7 @@ import com.m57.hermescontrol.data.config.ServerStoreState
 import com.m57.hermescontrol.data.local.AuthManager
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -100,5 +101,16 @@ class GatewayFileClientTest {
     fun `parseFilename extracts from content-disposition`() {
         assertEquals("report.pdf", GatewayFileClient.parseFilename("attachment; filename=\"report.pdf\""))
         assertEquals("a b.png", GatewayFileClient.parseFilename("inline; filename*=UTF-8''a%20b.png"))
+    }
+
+    @Test
+    fun `mintDownloadUrl returns null on blank base url`() {
+        val blankStore = mockk<ServerStore>(relaxed = true)
+        every { blankStore.getLatestState() } returns
+            ServerStoreState(wsAuthParam = "ticket", baseUrl = "")
+        val field = AuthManager::class.java.getDeclaredField("_serverStore")
+        field.isAccessible = true
+        field.set(AuthManager, blankStore)
+        assertNull(runBlocking { GatewayFileClient.mintDownloadUrl("/tmp/report.docx") })
     }
 }


### PR DESCRIPTION
## What

Open agent-delivered (MEDIA:) document attachments directly in **WPS streaming** instead of downloading the whole file first.

**Problem**: gated (basic-auth) dashboards authenticate file downloads with a session cookie. An external viewer like WPS Office opens a plain GET URL and can attach neither cookies nor headers — so a direct link 401s.

**Fix**:
1. `GatewayFileClient.mintDownloadUrl(path)` — calls `GET /api/files/download-ticket?path=<enc>` with the shared CookieJar and gets back a short-lived (5 min), HMAC-signed, single-file download URL that needs no cookie.
2. `ChatViewModel.openGatewayStreaming()` — for `MediaKind.FILE` attachments, hand that URL to WPS via its `wps://open?url=` deep link so the file **streams** over LAN/Tailscale. Tries known `cn.wps.moffice*` packages explicitly (avoids the system resolver chooser and package-visibility quirks on MIUI), then falls back to the existing download-then-open path on any failure.
3. `<queries>` declaration for `wps://` VIEW handlers.
4. Unit test for the blank-base-url fast path.

**Fallback safety**: if the dashboard doesn't expose the ticket endpoint (older server), minting fails and the existing cookie download path is used unchanged — no user-visible regression.

## Design notes

- Mobile-only; the `GET /api/files/download-ticket` endpoint is a small dashboard addition (follow-up PR to hermes-agent, 3 files). Without it this feature degrades gracefully to the current behavior.
- Ticket security: HMAC over `path|expiry` with an in-process random secret, 5-minute TTL, one file per ticket; file-level guards (managed-root resolution, sensitive-path denylist, size cap) still run server-side.
- Verified on device: WiFi (192.168.1.x) and Tailscale (100.x) both stream, md5 of downloaded bytes matches the local file; tampered/expired tickets are rejected (401).

## Tests

- `./gradlew ktlintCheck` ✅
- `./gradlew testDebugUnitTest --tests GatewayFileClientTest` ✅ (11 passed)
- `assembleRelease` builds ✅
