### PR TITLE
fix(#928): use active usedTokens in ContextDetailSheet progress bar

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -801,6 +801,7 @@ fun ChatScreen(
         if (showContextSheet && state.contextBreakdown != null) {
             ContextDetailSheet(
                 breakdown = state.contextBreakdown!!,
+                usedTokens = state.usedContextTokens,
                 fullTokens = state.fullContextTokens,
                 onDismiss = { showContextSheet = false },
             )

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ContextDetailSheet.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ContextDetailSheet.kt
@@ -33,13 +33,15 @@ import kotlin.math.min
  * token breakdown (input / output / cache read / cache write / reasoning) and
  * the message count, plus a prominent used / full bar.
  *
- * `fullTokens` is the model context window (denominator); `breakdown` carries
- * the per-category counts from `GET /api/sessions/{id}`.
+ * @param breakdown Sourced per-category token counts from `GET /api/sessions/{id}`.
+ * @param usedTokens Tokens currently in the active session prompt window (matches ContextUsageChip), or null.
+ * @param fullTokens The active model's full context window (denominator).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ContextDetailSheet(
     breakdown: ContextBreakdown,
+    usedTokens: Long?,
     fullTokens: Long?,
     onDismiss: () -> Unit,
     sheetState: SheetState = rememberModalBottomSheetState(),
@@ -49,7 +51,7 @@ fun ContextDetailSheet(
         sheetState = sheetState,
     ) {
         val full = fullTokens ?: 0L
-        val used = breakdown.inputTokens
+        val used = usedTokens ?: breakdown.inputTokens
         val fraction = if (full > 0L) min(1f, used.toFloat() / full.toFloat()) else 0f
         val pct = (fraction * 100).toInt()
         val statusColors = LocalHermesStatusColors.current


### PR DESCRIPTION
## Summary

Fixes #928:

- Updated `ContextDetailSheet` to accept `usedTokens: Long?` (defaulting to `breakdown.inputTokens` if null).
- In `ChatScreen.kt`, passed `usedTokens = state.usedContextTokens` to `ContextDetailSheet`.
- The progress bar and header in the detail sheet now accurately reflect the active turn's context window fill (matching `ContextUsageChip` 1:1), while the rows below continue displaying the cumulative session breakdown stats.

## Verification
- `./gradlew ktlintCheck`: PASSED
- `./gradlew testDebugUnitTest --tests "com.m57.hermescontrol.ui.chat.*"`: PASSED