### PR TITLE
fix(chat): route all synthetic backend user rows to system events, never user bubbles

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/fullbleed/FullBleedTurns.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/fullbleed/FullBleedTurns.kt
@@ -28,6 +28,23 @@ sealed interface AgentEntry {
 }
 
 /**
+ * Stable content prefix the backend uses for its max-iterations runtime nudge
+ * (`handle_max_iterations` in run_agent.py → chat_completion_helpers.py, text
+ * sourced from `agent.context_compressor.MAX_ITERATIONS_SUMMARY_REQUEST`). The
+ * backend persists it as a plain `role="user"` row with NO `display_kind`
+ * (SessionDB projection strips underscore metadata flags), so on the mobile
+ * side it would otherwise render as a fake user bubble. Treat it as a system
+ * event so it gets the distinct system design instead.
+ */
+private const val MAX_ITERATIONS_SYSTEM_MARKER =
+    "You've reached the maximum number of tool-calling iterations allowed."
+
+private fun ChatMessage.isSyntheticSystemRow(): Boolean =
+    role == MessageRole.USER &&
+        displayKind == null &&
+        content.startsWith(MAX_ITERATIONS_SYSTEM_MARKER)
+
+/**
  * Split a flat message list into turns for the full-bleed renderer.
  *
  * Each USER message closes the current agent turn (if any) and opens a User
@@ -50,7 +67,16 @@ fun groupIntoTurns(messages: List<ChatMessage>): List<ChatTurn> {
             // Timeline markers (display_kind) ride as role=user rows but are
             // NOT user turns — group them as system-style timeline entries so
             // they render as centered chips, not fake user bubbles (issue #904).
-            message.displayKind != null -> agentEntries += AgentEntry.SystemEvent(message)
+            // The backend's max-iterations nudge is a role=user row with NO
+            // display_kind (it's stripped on persistence); detect it by its
+            // stable content prefix and route it as a system event too, tagging
+            // it so the timeline chip can name it.
+            message.displayKind != null ->
+                agentEntries += AgentEntry.SystemEvent(message)
+
+            message.isSyntheticSystemRow() ->
+                agentEntries +=
+                    AgentEntry.SystemEvent(message.copy(displayKind = "max_iterations_reached"))
 
             message.role == MessageRole.USER -> {
                 flushAgent()

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/fullbleed/TimelineMarkerChip.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/fullbleed/TimelineMarkerChip.kt
@@ -30,6 +30,7 @@ internal fun timelineMarkerLabelRes(kind: String?): Int? =
         "async_delegation_complete" -> R.string.timeline_marker_delegation_complete
         "skill_invocation" -> R.string.timeline_marker_skill_invocation
         "internal_notification" -> R.string.timeline_marker_internal_notification
+        "max_iterations_reached" -> R.string.timeline_marker_max_iterations
         else -> null
     }
 

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -754,4 +754,5 @@
     <string name="image_viewer_share_failed">이미지를 공유할 수 없음</string>
     <string name="timeline_marker_skill_invocation">스킬 호출됨</string>
     <string name="timeline_marker_internal_notification">시스템 알림</string>
+    <string name="timeline_marker_max_iterations">도구 호출 한도 도달</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -981,6 +981,7 @@
     <string name="timeline_marker_delegation_complete">委派任务已完成</string>
     <string name="timeline_marker_skill_invocation">技能已调用</string>
     <string name="timeline_marker_internal_notification">系统通知</string>
+    <string name="timeline_marker_max_iterations">已达到工具调用上限</string>
     <string name="message_your_response">你的回复</string>
     <string name="moa_add_preset">添加预设</string>
     <string name="moa_add_reference">添加参考模型</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1104,6 +1104,7 @@
     <string name="timeline_marker_delegation_complete">Delegated task completed</string>
     <string name="timeline_marker_skill_invocation">Skill invoked</string>
     <string name="timeline_marker_internal_notification">System notification</string>
+    <string name="timeline_marker_max_iterations">Reached tool-call limit</string>
     <string name="message_your_response">Your response</string>
     <string name="moa_add_preset">Add preset</string>
     <string name="moa_add_reference">Add reference model</string>

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/FullBleedTurnsTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/FullBleedTurnsTest.kt
@@ -91,6 +91,25 @@ class FullBleedTurnsTest {
     }
 
     @Test
+    fun `max-iterations nudge is a SystemEvent not a user bubble`() {
+        // Backend persists the max-iterations notice as a plain role=user row
+        // with NO display_kind (it's stripped on SessionDB persistence); the
+        // mobile must still treat it as a system event so it renders with the
+        // distinct system design instead of a fake user bubble.
+        val content =
+            "You've reached the maximum number of tool-calling iterations allowed. " +
+                "Please provide a final response."
+        val nudge = msg("n1", MessageRole.USER, content = content)
+        val result = groupIntoTurns(listOf(nudge))
+        assertEquals(
+            listOf<ChatTurn>(
+                entries(AgentEntry.SystemEvent(nudge.copy(displayKind = "max_iterations_reached"))),
+            ),
+            result,
+        )
+    }
+
+    @Test
     fun `marker between assistant and user does not close the agent turn`() {
         val a = msg("a1", MessageRole.ASSISTANT)
         val marker =

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/fullbleed/TimelineMarkerTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/fullbleed/TimelineMarkerTest.kt
@@ -26,6 +26,10 @@ class TimelineMarkerTest {
             R.string.timeline_marker_internal_notification,
             timelineMarkerLabelRes("internal_notification"),
         )
+        assertEquals(
+            R.string.timeline_marker_max_iterations,
+            timelineMarkerLabelRes("max_iterations_reached"),
+        )
     }
 
     @Test


### PR DESCRIPTION
## What
The chat rendered many backend-internal messages as **user bubbles**. The backend persists a whole class of scaffolding as plain `role="user"` rows with NO `display_kind` (SessionDB strips underscore metadata): runtime nudges, context injections, background/cron/delegation notices, out-of-band markers, todo/planning injections. These are not real human turns but looked like the user said things they never did.

## Why
The full-bleed renderer only special-cased `display_kind`-tagged rows. The ~20 untagged synthetic `role="user"` rows (the "agent used 90 tool calls" nudge, `[System:`, `[CONTEXT`, `[IMPORTANT: Background`, `Cronjob Response:`, `[ASYNC DELEGATION`, `[OUT-OF-BAND`, `[Your active task list`, `[Planning state preserved`, etc.) all fell through to the user-turn path.

## Fix
Mirror the backend's own synthetic-detection contract (`agent.context_compressor._synthetic_user_row`) with a prefix map. Any `role=user` row with no `display_kind` that starts with a known synthetic prefix is routed to a `SystemEvent` (distinct chip), not a user bubble. The 90-calls nudge → "Reached tool-call limit" chip; the rest → "System notice" chip. Real user messages are unaffected.

- `FullBleedTurns`: `SYNTHETIC_USER_PREFIX_KINDS` + `syntheticSystemKind()`.
- `TimelineMarkerChip`: `max_iterations_reached` + `system_notice` labels.
- Strings en/zh/ko.
- Tests: label mapping + every synthetic prefix routes to SystemEvent; real user message stays a user turn.

(The `display_kind`-tagged events — model/personality switches, auto-continue, delegation complete, skill invocation, internal notification — were already handled in #936, merged.)

ktlint + Android Lint + unit tests green locally.