### PR TITLE
fix(chat): skip empty assistant tool-call placeholder rows in REST transcript

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -2929,11 +2929,18 @@ class ChatViewModel(
                     existingReasoningMap[rawContent]?.reasoningText.orEmpty()
                 }
 
-            // Reasoning-only assistant row (the gateway's split storage of a
-            // reasoning turn): stash the trace, skip the empty bubble, and
-            // attach it to the next assistant message that has content.
-            if (role == MessageRole.ASSISTANT && rawContent.isBlank() && rowReasoning.isNotBlank()) {
-                pendingReasoning = rowReasoning
+            // Empty assistant row — two cases stored by the gateway:
+            //  1. Reasoning-only: thinking-model split storage (content = "",
+            //     reasoning = trace). Stash the trace and fold it into the
+            //     next assistant message that has content (issue #771).
+            //  2. Tool-call placeholder: non-reasoning models emit content = ""
+            //     with tool_calls metadata and no reasoning. These carry no
+            //     user-visible text and must not render as empty bubbles
+            //     (issue #956).
+            if (role == MessageRole.ASSISTANT && rawContent.isBlank()) {
+                if (rowReasoning.isNotBlank()) {
+                    pendingReasoning = rowReasoning
+                }
                 return@forEachIndexed
             }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/fullbleed/FullBleedAgentMessage.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/fullbleed/FullBleedAgentMessage.kt
@@ -103,15 +103,21 @@ internal fun FullBleedAgentMessage(
             Spacer(modifier = Modifier.height(6.dp))
         }
 
-        SelectionContainer {
-            MarkdownText(
-                text = message.content,
-                textColor = textColor,
-                isStreaming = message.isStreaming,
-                searchQuery = searchQuery,
-                isCurrentMatch = isCurrentMatch,
-                onImageClick = onImageClick,
-            )
+        // Defense-in-depth: never render an empty prose block (blank bubble +
+        // lone Copy button). Blank settled rows are tool-call placeholders that
+        // slipped through upstream mapping; streaming keeps rendering so the
+        // live cursor survives until the first delta lands.
+        if (message.content.isNotBlank() || message.isStreaming) {
+            SelectionContainer {
+                MarkdownText(
+                    text = message.content,
+                    textColor = textColor,
+                    isStreaming = message.isStreaming,
+                    searchQuery = searchQuery,
+                    isCurrentMatch = isCurrentMatch,
+                    onImageClick = onImageClick,
+                )
+            }
         }
 
         // Render inline attachments (mirrors ChatBubble so agent-delivered


### PR DESCRIPTION
## Problem

Chat sessions using **non-reasoning models** (e.g. `gemini-3.5-flash`) show stacks of empty ghost bubbles in the transcript — blank bubbles with only a Copy button, one per tool call the model made during the turn.

Repro: any session where the model made tool calls without emitting narration text between them. Session "Friendly greeting #9" showed **10 empty bubbles** stacked above the real reply.

## Root cause

The gateway stores each tool-calling turn as an **empty assistant row** (`content = ""`, no reasoning) carrying the `tool_calls` metadata, directly before the tool result row:

```
230695 user      "hello"
230696 assistant ""            ← tool-call placeholder
230697 tool      {mem0_search…}
230698 assistant ""            ← placeholder
230699 tool      {skill_view…}
… × 10
230716 assistant "hey~ 🌸✨…"   ← the only visible row
```

The REST transcript returns these rows verbatim. `mapServerMessages` had a filter for empty assistant rows, but it required **reasoning text** to be present (the issue #771 thinking-model split-storage case). Non-reasoning models emit these placeholders with **blank reasoning**, so the check failed and every placeholder fell through to bubble rendering.

DB stats across all sessions: ~20k empty assistant rows with `tool_calls`, 13 without — confirming placeholders are the dominant source of blank assistant rows.

## Fix

`ChatViewModel.kt` — skip ANY blank assistant row; stash reasoning when present so the #771 fold-into-next-answer path is unchanged:

```kotlin
if (role == MessageRole.ASSISTANT && rawContent.isBlank()) {
    if (rowReasoning.isNotBlank()) {
        pendingReasoning = rowReasoning
    }
    return@forEachIndexed
}
```

No user-visible content is lost: these rows never carried displayable text, and the tool results themselves still render as tool chips.

## Verification

- `ktlintCheck` ✅
- `testDebugUnitTest --tests ChatToolDedupeTest` — all green ✅
- On-device (hermes37 emulator): installed fix build over existing install → opened "Friendly greeting #9" → **10 ghost bubbles gone**; transcript shows only the real messages (greeting, /model command, system chip, 4 tool chips with names)
