### PR TITLE
fix(chat): show send button for attachment-only sends (#956)

### DIFF
--- a/app/src/androidTest/java/com/m57/hermescontrol/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/m57/hermescontrol/ui/chat/ChatScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.core.content.ContextCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
+import com.m57.hermescontrol.data.model.Attachment
 import com.m57.hermescontrol.data.ws.ConnectionStatus
 import com.m57.hermescontrol.ui.common.ActionProgressController
 import io.mockk.every
@@ -81,5 +82,41 @@ class ChatScreenTest {
         composeTestRule.onNodeWithTag("chat_input").performTextInput("Hello Hermes")
         composeTestRule.onNodeWithTag("send_button").assertIsDisplayed()
         composeTestRule.onNodeWithTag("mic_button").assertIsDisplayed()
+    }
+
+    @Test
+    fun chatScreen_sendButtonShownForAttachmentWithEmptyInput() {
+        // Issue #956: an attachment queued with an EMPTY input must still show
+        // the send button — the old AnimatedContent gate required non-blank
+        // text even though ChatInputPolicy.canSend already allowed
+        // attachment-only sends.
+        val uiState =
+            ChatUiState(
+                connectionStatus = ConnectionStatus.CONNECTED,
+                pendingAttachments =
+                    listOf(
+                        Attachment(
+                            uri = "content://test/photo.jpg",
+                            name = "photo.jpg",
+                            mimeType = "image/jpeg",
+                        ),
+                    ),
+            )
+        val mockViewModel = mockk<ChatViewModel>(relaxed = true)
+        every { mockViewModel.uiState } returns MutableStateFlow(uiState).asStateFlow()
+        every { mockViewModel.streamingState } returns MutableStateFlow(StreamingState()).asStateFlow()
+        every { mockViewModel.actionProgress } returns
+            ActionProgressController(scope = CoroutineScope(Dispatchers.Main))
+
+        composeTestRule.setContent {
+            ChatScreen(
+                onOpenDrawer = {},
+                sessionId = null,
+                viewModel = mockViewModel,
+            )
+        }
+
+        composeTestRule.onNodeWithTag("chat_input").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("send_button").assertIsDisplayed()
     }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatComposer.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatComposer.kt
@@ -278,9 +278,12 @@ fun ChatInputBar(
                                         innerTextField()
                                     }
 
-                                    // Send button INSIDE the field
+                                    // Send button INSIDE the field. Shown whenever a send is
+                                    // possible — text typed OR an attachment pending (issue
+                                    // #956): the old text-only gate hid the button entirely
+                                    // for attachment-only sends.
                                     AnimatedContent(
-                                        targetState = canSend && inputFieldValue.text.isNotBlank(),
+                                        targetState = canSend,
                                         transitionSpec = {
                                             (scaleIn(initialScale = 0.8f) + fadeIn())
                                                 .togetherWith(scaleOut(targetScale = 0.8f) + fadeOut())


### PR DESCRIPTION
## Problem

Attaching an image or file and tapping send with an **empty input bar** was impossible — the send button never appeared. Users had to type filler text just to send an attachment.

## Root cause

`ChatComposer.kt` gated the send button's `AnimatedContent` on:

```kotlin
targetState = canSend && inputFieldValue.text.isNotBlank()
```

The stale text gate hid the button entirely for attachment-only sends, even though everything underneath already supported them:

- `ChatInputPolicy.canSend()` already allowed `(text.isNotBlank() || pendingAttachments.isNotEmpty()) && isConnected`
- `ChatViewModel.sendMessage()` already accepted blank text when attachments are pending
- The backend handles image-only turns natively (`prompt.submit` with empty text + queued images → `build_native_content_parts` wraps pixels with an `[Image attached at: ...]` hint)

The UI render gate was the only layer that missed the memo.

## Fix

Track `canSend` alone in the `AnimatedContent` target state, so the send affordance appears whenever a send is possible — typed text OR pending attachment.

## Test

New instrumented Compose test `chatScreen_sendButtonShownForAttachmentWithEmptyInput`: connected state + one pending image attachment + empty input → asserts `send_button` is displayed.

- [x] `./gradlew ktlintFormat` + `ktlintCheck` green
- [x] `compileDebugKotlin` green
- [x] `ChatInputPolicyTest` green

Fixes #956
