### PR TITLE
feat(chat): intercept /new in canonical Bot Chat sessions to /compact

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -1573,7 +1573,22 @@ class ChatViewModel(
             }
 
             is SlashResult.NewSession -> {
-                createNewSession()
+                val currentTitle = _uiState.value.chatTitle
+                if (currentTitle.equals("Bot Chat", ignoreCase = true)) {
+                    // Bot Chat is a canonical forever-conversation — compact instead of creating an orphan
+                    val sessionId = _uiState.value.currentSessionId
+                    if (!sessionId.isNullOrBlank()) {
+                        addAssistantMessage(
+                            "Bot chats are one continuous conversation — compacting instead. " +
+                                "For a throwaway session, create a standard chat.",
+                        )
+                        dispatchViaRpc("/compact")
+                    } else {
+                        createNewSession()
+                    }
+                } else {
+                    createNewSession()
+                }
             }
 
             is SlashResult.SessionBranch -> {

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -104,6 +104,7 @@
     <string name="action_reply">답장</string>
 
     <!-- Chat Screen & Bubble -->
+    <string name="bot_chat_never_resets_notice">봇 대화는 지속적인 대화입니다 — 대신 압축합니다. 임시 세션을 사용하려면 일반 채팅을 생성하세요.</string>
     <string name="chat_action_search">검색</string>
     <string name="chat_action_close_search">검색 닫기</string>
     <string name="chat_action_reconnect">재접속</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -105,6 +105,7 @@
     <string name="notif_channel_chat_name">Hermes 对话回复</string>
     <string name="notif_channel_chat_desc">Hermes 新回复提醒</string>
     <string name="action_reply">回复</string>
+    <string name="bot_chat_never_resets_notice">Bot 聊天是连续对话 — 正在压缩替代。如需临时会话，请使用普通聊天。</string>
     <string name="chat_action_search">搜索</string>
     <string name="chat_action_close_search">关闭搜索</string>
     <string name="chat_action_reconnect">重新连接</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,7 @@
     <string name="action_reply">Reply</string>
 
     <!-- Chat Screen & Bubble -->
+    <string name="bot_chat_never_resets_notice">Bot chats are one continuous conversation — compacting instead. For a throwaway session, create a standard chat.</string>
     <string name="chat_action_search">Search</string>
     <string name="chat_action_close_search">Close search</string>
     <string name="chat_action_reconnect">Reconnect</string>

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -289,6 +289,50 @@ class ChatViewModelTest {
         }
 
     @Test
+    fun testSlashCommand_new_inBotChat_compactsInsteadOfCreatingSession() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+            // Set session title to "Bot Chat" via SESSION_LIST result
+            mockEventsFlow.emit(
+                WsEvent.RpcResult(
+                    id = "req-id-1",
+                    result =
+                        mapOf(
+                            "sessions" to
+                                listOf(
+                                    mapOf(
+                                        "id" to sessionId,
+                                        "title" to "Bot Chat",
+                                        "message_count" to 5.0,
+                                    ),
+                                ),
+                        ),
+                ),
+            )
+            advanceUntilIdle()
+
+            // Reset recording on HermesWsClient to only inspect calls after /new
+            clearMocks(HermesWsClient, answers = false, recordedCalls = true)
+
+            viewModel.sendMessage("/new")
+            advanceUntilIdle()
+
+            // In Bot Chat, /new should NOT create a fresh session, but instead dispatch /compact
+            verify(exactly = 0) {
+                HermesWsClient.send(
+                    WsMethods.SESSION_CREATE,
+                    any(),
+                    any(),
+                )
+            }
+            assertTrue(
+                viewModel.uiState.value.messages.any {
+                    it.content.contains("compacting instead")
+                },
+            )
+        }
+
+    @Test
     fun profileSwitch_wipesOpenSessionForFreshStart() =
         runTest {
             val (viewModel, sessionId) = createViewModelWithSession()


### PR DESCRIPTION
## Summary

Intercept `/new` (and `/reset`) slash commands inside canonical "Bot Chat" sessions, rerouting to `/compact` with an explanatory notice to preserve continuous agent memory and relationship context.

Stacked on top of #977. Part of #972.

## Type of Change

- [x] ✨ Feature
- [x] ✅ Tests

## What changed

- Updated `ChatViewModel.kt` slash command dispatcher handling:
  - Detects if the current conversation is a canonical `"Bot Chat"`.
  - When `/new` is sent, injects an assistant notice explaining that bot chats are continuous.
  - Automatically dispatches `/compact` via RPC to keep fresh working context while preserving conversation continuity (matching Desktop/CLI Bot Mode semantics).
  - Regular scratchpad sessions in Sessions mode continue to allow normal `/new` session creation.
- Added localized strings for notice message in English, Chinese (`values-zh`), and Korean (`values-ko`).
- Added unit test in `ChatViewModelTest.kt` verifying that `/new` dispatches `/compact` without invoking `SESSION_CREATE` in Bot Chat.

## How to test

1. Run `./gradlew testDebugUnitTest --tests "com.m57.hermescontrol.ui.chat.ChatViewModelTest.testSlashCommand_new*"`
2. Run `./gradlew ktlintCheck`

## Checklist

- [x] Stacked on `feat/bot-mode-screen`
- [x] `./gradlew ktlintCheck` passes
- [x] `./gradlew testDebugUnitTest` green
- [x] `checkColorLiterals` passes