### PR TITLE
fix(bots): create clean profile without cloning default soul and custom skills

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/bots/BotsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/bots/BotsViewModel.kt
@@ -238,11 +238,11 @@ class BotsViewModel(
                 CreateProfileRequest(
                     name = name,
                     description = description.ifBlank { null },
-                    clone_from_default = true,
+                    clone_from_default = false,
                 )
             val result = safeApiCall { ApiClient.hermesApi.createProfile(req) }
             if (result is NetworkResult.Success) {
-                // Configure UI metadata (avatar, custom title) via RPC
+                // Configure UI metadata (avatar, custom title) and bot SOUL via RPC
                 val botMeta =
                     BotRosterMeta(
                         title = title.ifBlank { null },
@@ -253,7 +253,8 @@ class BotsViewModel(
                                 color = color,
                             ),
                     )
-                wsClientConfigureBot(name, botMeta)
+                val botSoul = composeBotSoul(name, title, description)
+                wsClientConfigureBot(name, botMeta, soul = botSoul)
                 loadBots()
                 onSuccess()
             } else {
@@ -363,18 +364,36 @@ class BotsViewModel(
         }
     }
 
+    private fun composeBotSoul(
+        name: String,
+        title: String,
+        description: String,
+    ): String {
+        val displayName = title.ifBlank { name }
+        val lines = mutableListOf<String>()
+        lines.add("# $displayName")
+        lines.add("")
+        if (title.isNotBlank()) lines.add("**Role:** $title")
+        if (description.isNotBlank()) lines.add("**Mission:** $description")
+        lines.add("")
+        lines.add("You are $displayName, a persistent named agent (profile `$name`) on this machine.")
+        lines.add("You keep your own memory, skills, and conversation history across sessions.")
+        return lines.joinToString("\n")
+    }
+
     private fun wsClientConfigureBot(
         name: String,
         meta: BotRosterMeta,
+        soul: String? = null,
     ): kotlinx.coroutines.CompletableDeferred<Any?> {
         val metaMap =
-            buildMap<String, Any?> {
-                put("title", meta.title)
-                put("description", meta.description)
+            buildMap<String, Any> {
+                meta.title?.let { put("title", it) }
+                meta.description?.let { put("description", it) }
                 meta.avatar?.let { av ->
                     put(
                         "avatar",
-                        buildMap<String, Any?> {
+                        buildMap<String, Any> {
                             av.shape?.let { put("shape", it) }
                             av.color?.let { put("color", it) }
                             av.icon?.let { put("icon", it) }
@@ -386,12 +405,16 @@ class BotsViewModel(
                 }
             }
 
+        val params =
+            buildMap<String, Any> {
+                put("name", name)
+                put("ui_meta", mapOf("hermes-bots" to metaMap))
+                soul?.let { put("soul", it) }
+            }
+
         return HermesWsClient.request(
             WsMethods.PROFILES_CONFIGURE,
-            mapOf(
-                "name" to name,
-                "ui_meta" to mapOf("hermes-bots" to metaMap),
-            ),
+            params,
         )
     }
 }

--- a/app/src/test/java/com/m57/hermescontrol/ui/bots/BotsViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/bots/BotsViewModelTest.kt
@@ -165,7 +165,15 @@ class BotsViewModelTest {
             advanceUntilIdle()
 
             assertTrue(successCalled)
-            coVerify(exactly = 1) { mockApi.createProfile(match { it.name == "researcher" }) }
+            coVerify(exactly = 1) {
+                mockApi.createProfile(
+                    match {
+                        it.name == "researcher" &&
+                            it.clone_from_default == false &&
+                            it.description == "Deep research agent"
+                    },
+                )
+            }
         }
 
     @Test


### PR DESCRIPTION
### Summary
- Disables `clone_from_default` when creating a new bot in `BotsViewModel`, matching desktop bot creation behavior.
- Composes a bot-tailored `SOUL.md` (with role, mission, and identity) and writes it via `profiles.configure` over WebSocket RPC.
- Fixes new bots inheriting the default profile's persona, custom skills, and personalized soul configuration.

### Verification
- `ktlintCheck` passes
- `testDebugUnitTest --tests com.m57.hermescontrol.ui.bots.*` passes (6/6 tests green)