### PR TITLE
ci: smart path filtering to skip heavy Android builds on doc-only PRs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,10 +22,42 @@ concurrency:
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────
+  # Job 0: Detect changes — skips heavy Android build/tests for doc-only PRs
+  # ─────────────────────────────────────────────────────────────────────
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Paths Filter
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'app/**'
+              - 'gradle/**'
+              - 'build.gradle.kts'
+              - 'settings.gradle.kts'
+              - 'gradle.properties'
+              - 'gradlew'
+              - 'gradlew.bat'
+              - '.github/workflows/android.yml'
+              - '.editorconfig'
+              - 'flake.nix'
+              - 'flake.lock'
+
+  # ─────────────────────────────────────────────────────────────────────
   # Job 1: ktlint (code style) — fastest feedback, runs in parallel.
   # ─────────────────────────────────────────────────────────────────────
   ktlint:
     name: ktlint — Code Style
+    needs: [changes]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -88,6 +120,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   android-lint:
     name: Android Lint — Static Analysis
+    needs: [changes]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -125,6 +159,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   unit-tests:
     name: Unit & Integration Tests
+    needs: [changes]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -162,7 +198,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   build:
     name: Build Debug APK
-    needs: [ktlint, android-lint, unit-tests]
+    needs: [changes, ktlint, android-lint, unit-tests]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -204,7 +241,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   release-compile:
     name: Release Compile Check
-    needs: [ktlint, android-lint, unit-tests]
+    needs: [changes, ktlint, android-lint, unit-tests]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -236,6 +274,8 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   instrumented-tests:
     name: Instrumented Tests
+    needs: [changes]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -299,7 +339,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   ci-summary:
     name: CI Summary
-    needs: [ktlint, android-lint, unit-tests, build, release-compile]
+    needs: [changes, ktlint, android-lint, unit-tests, build, release-compile]
     runs-on: ubuntu-latest
     timeout-minutes: 2
     if: always()
@@ -323,7 +363,7 @@ jobs:
             name="${entry%%:*}"
             result="${entry#*:}"
             echo "::notice::$name = $result"
-            if [[ "$result" != "success" ]]; then
+            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
               FAILED=1
               FAILED_JOBS+="$name "
             fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,34 @@ name: "CodeQL Analysis"
 on:
   push:
     branches: [ "main", "dev" ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/workflows/pr-labeler.yml'
+      - '.github/workflows/stale.yml'
+      - '.github/workflows/merge-conflict-detector.yml'
+      - 'LICENSE'
+      - 'fastlane/**'
+      - '.gitignore'
+      - '.editorconfig'
+      - '.envrc'
+      - '*.html'
   pull_request:
     branches: [ "main", "dev" ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/workflows/pr-labeler.yml'
+      - '.github/workflows/stale.yml'
+      - '.github/workflows/merge-conflict-detector.yml'
+      - 'LICENSE'
+      - 'fastlane/**'
+      - '.gitignore'
+      - '.editorconfig'
+      - '.envrc'
+      - '*.html'
   schedule:
     - cron: '30 3 * * 1' # Runs at 03:30 UTC every Monday
 


### PR DESCRIPTION
### Summary
Optimizes CI runtime by skipping expensive Android build/emulator steps and CodeQL analysis on documentation, metadata, and non-code pull requests while maintaining the full `CI Summary` required status check for branch protection.

### How it works
1. **Detect Changes (`changes` job in `android.yml`)**: Uses `dorny/paths-filter@v3` to check if code files (`app/**`, `gradle/**`, `build.gradle.kts`, etc.) changed.
2. **Conditional Execution**: If no code changed, heavy jobs (`ktlint`, `android-lint`, `unit-tests`, `build`, `release-compile`, `instrumented-tests`) are skipped immediately (~0s).
3. **Branch Protection (`ci-summary` aggregator)**: Runs in ~5s, treats `skipped` as passing when no code changed, and immediately emits green check for branch protection.
4. **CodeQL (`codeql.yml`)**: Added `paths-ignore` for markdown/docs/metadata.