### PR TITLE
feat(i18n): add Weblate component config and translation docs

### DIFF
--- a/.weblate.json
+++ b/.weblate.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "Hermes Mobile",
+    "slug": "hermes-mobile",
+    "project": "hermes-mobile",
+    "vcs": "git",
+    "branch": "dev",
+    "filemask": "app/src/main/res/values-*/strings.xml",
+    "template": "app/src/main/res/values/strings.xml",
+    "file_format": "android",
+    "new_base": "app/src/main/res/values/strings.xml",
+    "language_code_style": "android"
+  }
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,16 @@ If you use AI coding tools (including agents) to contribute:
 
 ---
 
+## Translations
+
+Translations for Hermes Mobile are managed through [Hosted Weblate](https://hosted.weblate.org/projects/hermes-mobile/hermes-mobile/).
+
+- Source strings are located in `app/src/main/res/values/strings.xml`.
+- Localized strings are stored in `app/src/main/res/values-<locale>/strings.xml`.
+- You can contribute translations directly on Weblate without modifying code or opening manual PRs.
+
+---
+
 ## Code Style
 
 We enforce Kotlin coding conventions and Jetpack Compose best practices.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ app/src/main/java/com/m57/hermescontrol/
 
 Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for our branch workflow, code style guidelines, and PR checklist.
 
+### Translations
+
+Help translate Hermes Mobile into your language on [Hosted Weblate](https://hosted.weblate.org/projects/hermes-mobile/hermes-mobile/)!
+
 For developer-specific details, code conventions, and project architecture notes, refer to [AGENTS.md](AGENTS.md).
 
 ---


### PR DESCRIPTION
## Summary
- Adds `.weblate.json` configuration for automated localization management via Hosted Weblate.
- Adds Translations section to `CONTRIBUTING.md` and `README.md` directing translators to Hosted Weblate.
- Configures `dev` as the target branch and `app/src/main/res/values/strings.xml` as the source template with Android locale code style.

## Testing
- Verified `.weblate.json` schema format.
- Checked string resource formats and positional argument indexing.