### PR TITLE
fix(chat): support batch clarify.request payload and route question_id on respond (fixes #1045)

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/ws/EventParser.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/EventParser.kt
@@ -134,17 +134,32 @@ object EventParser {
             "clarify.request" -> {
                 // Gateway sends "question"/"choices" — fall back to "text"/"options" for any
                 // older client or test that still uses the legacy field names. (Issue #206)
+                // Batch clarify (issue #18450): gateway sends "questions" array of {qid, question, choices, multi_select}.
+                val rawQuestions = payload?.get("questions") as? List<*>
+                val firstQuestion = rawQuestions?.firstOrNull() as? Map<*, *>
+
                 val text =
                     payload?.get("question") as? String
                         ?: payload?.get("text") as? String
+                        ?: if (rawQuestions != null && rawQuestions.size > 1) {
+                            rawQuestions.mapIndexedNotNull { index, item ->
+                                val q = (item as? Map<*, *>)?.get("question") as? String
+                                q?.let { "${index + 1}. $it" }
+                            }.joinToString("\n\n")
+                        } else {
+                            firstQuestion?.get("question") as? String
+                        }
+
                 val rawOptions =
                     payload?.get("choices")
                         ?: payload?.get("options")
+                        ?: firstQuestion?.get("choices")
                 val clarifyId = payload?.get("clarify_id") as? String ?: payload?.get("request_id") as? String
+                val questionId = firstQuestion?.get("qid") as? String
 
                 @Suppress("UNCHECKED_CAST")
                 val options = (rawOptions as? List<*>)?.filterIsInstance<String>()
-                WsEvent.ClarifyRequest(text, options, clarifyId, sessionId)
+                WsEvent.ClarifyRequest(text, options, clarifyId, sessionId, questionId)
             }
 
             "status.update" -> {

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/EventParser.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/EventParser.kt
@@ -142,10 +142,11 @@ object EventParser {
                     payload?.get("question") as? String
                         ?: payload?.get("text") as? String
                         ?: if (rawQuestions != null && rawQuestions.size > 1) {
-                            rawQuestions.mapIndexedNotNull { index, item ->
-                                val q = (item as? Map<*, *>)?.get("question") as? String
-                                q?.let { "${index + 1}. $it" }
-                            }.joinToString("\n\n")
+                            rawQuestions
+                                .mapIndexedNotNull { index, item ->
+                                    val q = (item as? Map<*, *>)?.get("question") as? String
+                                    q?.let { "${index + 1}. $it" }
+                                }.joinToString("\n\n")
                         } else {
                             firstQuestion?.get("question") as? String
                         }

--- a/app/src/main/java/com/m57/hermescontrol/data/ws/WsEvent.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/ws/WsEvent.kt
@@ -140,6 +140,7 @@ sealed class WsEvent {
         val options: List<String>?,
         val clarifyId: String? = null,
         val sessionId: String? = null,
+        val questionId: String? = null,
     ) : WsEvent()
 
     /**

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -379,6 +379,7 @@ data class ClarifyUi(
     val text: String,
     val options: List<String>,
     val clarifyId: String? = null,
+    val questionId: String? = null,
 )
 
 /**
@@ -3236,6 +3237,7 @@ class ChatViewModel(
     fun dismissClarify() {
         val sessionId = _uiState.value.currentSessionId ?: return
         val clarifyId = _uiState.value.clarifyRequest?.clarifyId
+        val questionId = _uiState.value.clarifyRequest?.questionId
         _uiState.update { it.copy(clarifyRequest = null) }
 
         addSystemMessage("Clarify dismissed — no answer sent", persist = true)
@@ -3251,6 +3253,9 @@ class ChatViewModel(
                 params["clarify_id"] = clarifyId
                 params["request_id"] = clarifyId
             }
+            if (questionId != null) {
+                params["question_id"] = questionId
+            }
             wsClient.send(
                 method = WsMethods.CLARIFY_RESPOND,
                 params = params,
@@ -3262,6 +3267,7 @@ class ChatViewModel(
     fun respondToClarify(option: String) {
         val sessionId = _uiState.value.currentSessionId ?: return
         val clarifyId = _uiState.value.clarifyRequest?.clarifyId
+        val questionId = _uiState.value.clarifyRequest?.questionId
         _uiState.update { it.copy(clarifyRequest = null) }
 
         val userMessage =
@@ -3291,6 +3297,9 @@ class ChatViewModel(
             if (clarifyId != null) {
                 params["clarify_id"] = clarifyId
                 params["request_id"] = clarifyId
+            }
+            if (questionId != null) {
+                params["question_id"] = questionId
             }
             wsClient.send(
                 method = WsMethods.CLARIFY_RESPOND,

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatWsEventReducer.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatWsEventReducer.kt
@@ -633,6 +633,7 @@ object ChatWsEventReducer {
                             text = event.text.orEmpty(),
                             options = event.options.orEmpty(),
                             clarifyId = event.clarifyId,
+                            questionId = event.questionId,
                         ),
                     isAgentTyping = false,
                 ),

--- a/app/src/test/java/com/m57/hermescontrol/data/ws/EventParserTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/data/ws/EventParserTest.kt
@@ -291,6 +291,42 @@ class EventParserTest {
         assertEquals(listOf("staging", "production"), clarifyEvent.options)
     }
 
+    @Test
+    fun testParseClarifyRequest_withBatchQuestions_parsesSuccessfully() {
+        val response =
+            createJsonRpcResponse(
+                jsonrpc = "2.0",
+                id = null,
+                result = null,
+                error = null,
+                method = "event",
+                params =
+                    mapOf(
+                        "type" to "clarify.request",
+                        "payload" to
+                            mapOf(
+                                "request_id" to "req-batch-1",
+                                "questions" to
+                                    listOf(
+                                        mapOf(
+                                            "qid" to "q0",
+                                            "question" to "Which database?",
+                                            "choices" to listOf("Postgres", "SQLite"),
+                                            "multi_select" to false,
+                                        ),
+                                    ),
+                            ),
+                    ),
+            )
+        val event = EventParser.parse(response)
+        assertTrue(event is WsEvent.ClarifyRequest)
+        val clarifyEvent = event as WsEvent.ClarifyRequest
+        assertEquals("Which database?", clarifyEvent.text)
+        assertEquals(listOf("Postgres", "SQLite"), clarifyEvent.options)
+        assertEquals("req-batch-1", clarifyEvent.clarifyId)
+        assertEquals("q0", clarifyEvent.questionId)
+    }
+
     // ── TEST-07: Untested subtypes ─────────────────────────────────────
 
     @Test

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -1218,6 +1218,46 @@ class ChatViewModelTest {
         }
 
     @Test
+    fun testClarifyRequestWithQuestionIdAndRespond() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+
+            mockEventsFlow.emit(
+                WsEvent.ClarifyRequest(
+                    text = "Pick one:",
+                    options = listOf("Option 1"),
+                    clarifyId = "clarify-batch-1",
+                    sessionId = sessionId,
+                    questionId = "q0",
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals("Pick one:", viewModel.uiState.value.clarifyRequest?.text)
+            assertEquals("q0", viewModel.uiState.value.clarifyRequest?.questionId)
+
+            viewModel.respondToClarify("Option 1")
+            advanceUntilIdle()
+
+            assertNull(viewModel.uiState.value.clarifyRequest)
+            verify {
+                HermesWsClient.send(
+                    method = WsMethods.CLARIFY_RESPOND,
+                    params =
+                        mapOf(
+                            "session_id" to sessionId,
+                            "response" to "Option 1",
+                            "answer" to "Option 1",
+                            "clarify_id" to "clarify-batch-1",
+                            "request_id" to "clarify-batch-1",
+                            "question_id" to "q0",
+                        ),
+                    onSent = any(),
+                )
+            }
+        }
+
+    @Test
     fun testClarifyRequestCustomResponse() =
         runTest {
             val (viewModel, sessionId) = createViewModelWithSession()
@@ -1310,6 +1350,53 @@ class ChatViewModelTest {
                             "answer" to "The user cancelled — no answer provided.",
                             "clarify_id" to "clarify-789",
                             "request_id" to "clarify-789",
+                        ),
+                    onSent = any(),
+                )
+            }
+        }
+
+    @Test
+    fun testClarifyDismissWithQuestionIdInformsAgent() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+
+            mockEventsFlow.emit(
+                WsEvent.ClarifyRequest(
+                    "Please choose:",
+                    listOf("Yes", "No"),
+                    "clarify-789",
+                    sessionId,
+                    questionId = "q0",
+                ),
+            )
+            advanceUntilIdle()
+            assertEquals(
+                "clarify-789",
+                viewModel.uiState.value.clarifyRequest
+                    ?.clarifyId,
+            )
+            assertEquals(
+                "q0",
+                viewModel.uiState.value.clarifyRequest
+                    ?.questionId,
+            )
+
+            viewModel.dismissClarify()
+            advanceUntilIdle()
+
+            assertNull(viewModel.uiState.value.clarifyRequest)
+            verify {
+                HermesWsClient.send(
+                    method = WsMethods.CLARIFY_RESPOND,
+                    params =
+                        mapOf(
+                            "session_id" to sessionId,
+                            "response" to "The user cancelled — no answer provided.",
+                            "answer" to "The user cancelled — no answer provided.",
+                            "clarify_id" to "clarify-789",
+                            "request_id" to "clarify-789",
+                            "question_id" to "q0",
                         ),
                     onSent = any(),
                 )

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -1233,8 +1233,16 @@ class ChatViewModelTest {
             )
             advanceUntilIdle()
 
-            assertEquals("Pick one:", viewModel.uiState.value.clarifyRequest?.text)
-            assertEquals("q0", viewModel.uiState.value.clarifyRequest?.questionId)
+            assertEquals(
+                "Pick one:",
+                viewModel.uiState.value.clarifyRequest
+                    ?.text,
+            )
+            assertEquals(
+                "q0",
+                viewModel.uiState.value.clarifyRequest
+                    ?.questionId,
+            )
 
             viewModel.respondToClarify("Option 1")
             advanceUntilIdle()


### PR DESCRIPTION
## Summary

Support batch `clarify.request` event payload and route `question_id` on respond so clarify questions, options chips, and answers work properly on mobile.

Fixes #1045

## Description

The gateway recently adopted a batch wire format for `clarify.request` where questions and choices are delivered inside a `questions` array with stable `qid`s (`q0`..`qN`).

`EventParser` previously only looked for top-level `question`/`choices` (or legacy `text`/`options`). When the batch format was sent:
1. `text` and `options` resolved to `null`, causing `ClarifyBubble` to render without question text or suggestion chips (only the free-text input field).
2. Responding via `respondToClarify` or `dismissClarify` omitted `question_id`. Without `question_id`, the batch handler in the gateway (`server.py:_block`) treated the answer as an unparseable cancel-all and returned empty `user_response: ""` to the tool.

This PR:
- Updates `EventParser` to parse `payload["questions"]`, extracting question text, option chips, and `questionId` (`qid`).
- Extends `WsEvent.ClarifyRequest` and `ClarifyUi` to carry `questionId: String? = null`.
- Propagates `questionId` through `ChatWsEventReducer`.
- Updates `ChatViewModel.respondToClarify` and `ChatViewModel.dismissClarify` to include `question_id` in `params` when present.
- Adds unit test coverage in `EventParserTest` and `ChatViewModelTest`.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs
- [x] ✅ Tests
- [ ] 🔧 CI / chore

## How to test

1. Trigger a clarify prompt from an agent (e.g. `clarify` tool call with questions/choices).
2. Verify `ClarifyBubble` renders the question text and suggestion chips.
3. Tap an option chip or type a custom answer and tap Send.
4. Verify the agent receives the answer rather than an empty string.