### PR TITLE
feat(chat): support /undo command with transcript reload and composer prefill

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/local/ChatMessageDao.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/ChatMessageDao.kt
@@ -18,4 +18,7 @@ interface ChatMessageDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertAll(messages: List<ChatMessageEntity>)
+
+    @Query("DELETE FROM chat_messages WHERE session_id = :sessionId")
+    suspend fun deleteMessagesForSession(sessionId: String)
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatPersistenceRepository.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatPersistenceRepository.kt
@@ -33,4 +33,9 @@ open class ChatPersistenceRepository(
     /** Load cached messages for a session from Room. */
     suspend fun loadMessages(sessionId: String): List<ChatMessage> =
         dao.getMessagesForSession(sessionId).map { it.toUiModel() }
+
+    /** Clear all cached messages for a session (e.g. after /undo rewind). */
+    suspend fun clearMessagesForSession(sessionId: String) {
+        dao.deleteMessagesForSession(sessionId)
+    }
 }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -290,6 +290,14 @@ fun ChatScreen(
     var inputFieldValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(TextFieldValue(""))
     }
+
+    LaunchedEffect(state.pendingPrefillText) {
+        val prefill = state.pendingPrefillText
+        if (prefill != null) {
+            inputFieldValue = ChatInputPolicy.commandFieldValue(prefill)
+            viewModel.consumePendingPrefill()
+        }
+    }
     var isListening by rememberSaveable { mutableStateOf(false) }
     var lastAnimatedMessageId by rememberSaveable { mutableStateOf<String?>(null) }
     var showReloginDialog by rememberSaveable { mutableStateOf(false) }

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -1605,11 +1605,6 @@ class ChatViewModel(
             return
         }
 
-        if (result is SlashResult.Undo) {
-            handleUndoCommand(result.count)
-            return
-        }
-
         val displayContent =
             if (result is SlashResult.QueuePrompt) result.displayContent else command
         val userMsg = ChatMessage(role = MessageRole.USER, content = displayContent)
@@ -1622,6 +1617,11 @@ class ChatViewModel(
             viewModelScope.launch(ioDispatcher) {
                 repo.persistMessage(userMsg, sessionId)
             }
+        }
+
+        if (result is SlashResult.Undo) {
+            handleUndoCommand(result.count)
+            return
         }
 
         // Block desktop/CLI-only + TUI-only commands that don't function on
@@ -2047,23 +2047,26 @@ class ChatViewModel(
         if (message.isNotBlank()) {
             _uiState.update { it.copy(pendingPrefillText = message) }
         }
+        val feedback =
+            when {
+                notice.isNotBlank() && message.isNotBlank() -> "$notice (Rewound to: \"$message\")"
+                notice.isNotBlank() -> notice
+                message.isNotBlank() -> "↶ Rewound to: \"$message\""
+                else -> "↶ Rewound"
+            }
         if (storageSessionId != null) {
-            val generation = ++sessionGeneration
+            val generation = sessionGeneration
             viewModelScope.launch {
                 withContext(ioDispatcher) {
                     repo.clearMessagesForSession(storageSessionId)
                 }
                 _uiState.update { it.copy(messages = emptyList()) }
                 loadSessionMessages(storageSessionId, generation)
-                if (notice.isNotBlank()) {
-                    addSystemMessage(notice, persist = true)
-                }
+                addSystemMessage(feedback, persist = true)
                 fetchContextUsage()
             }
         } else {
-            if (notice.isNotBlank()) {
-                addSystemMessage(notice, persist = false)
-            }
+            addSystemMessage(feedback, persist = false)
         }
     }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -363,6 +363,8 @@ data class ChatUiState(
     // Session resume recovery (desktop parity: bounded auto-retry + error UI)
     val resumeError: String? = null,
     val isResumeRetrying: Boolean = false,
+    /** Text staged to prefill the composer (e.g. from /undo). */
+    val pendingPrefillText: String? = null,
 ) {
     /** Convenience — derived from [connectionStatus]. */
     val isConnected: Boolean get() = connectionStatus == ConnectionStatus.CONNECTED
@@ -1270,6 +1272,12 @@ class ChatViewModel(
                 handleSlashCommand(target)
             }
 
+            "prefill" -> {
+                val message = map["message"] as? String ?: ""
+                val notice = map["notice"] as? String ?: ""
+                handlePrefillResult(message, notice)
+            }
+
             else -> {
                 val output = map["output"] as? String ?: map.toString()
                 addAssistantMessage(output)
@@ -1597,6 +1605,11 @@ class ChatViewModel(
             return
         }
 
+        if (result is SlashResult.Undo) {
+            handleUndoCommand(result.count)
+            return
+        }
+
         val displayContent =
             if (result is SlashResult.QueuePrompt) result.displayContent else command
         val userMsg = ChatMessage(role = MessageRole.USER, content = displayContent)
@@ -1680,6 +1693,10 @@ class ChatViewModel(
 
             is SlashResult.SideQuestion -> {
                 handleSideQuestionCommand(result.question)
+            }
+
+            is SlashResult.Undo -> {
+                handleUndoCommand(result.count)
             }
 
             is SlashResult.RpcDispatch -> {
@@ -1994,6 +2011,64 @@ class ChatViewModel(
                 repo.persistMessage(msg, sessionId)
             }
         }
+    }
+
+    private fun handleUndoCommand(count: String) {
+        val sessionId = runtimeSessionId
+        if (sessionId == null) {
+            addAssistantMessage("No active session to undo.")
+            return
+        }
+        viewModelScope.launch {
+            slashUsageStore.recordUse("/undo")
+        }
+        viewModelScope.launch(ioDispatcher) {
+            try {
+                val result =
+                    wsClient
+                        .request(
+                            WsMethods.COMMAND_DISPATCH,
+                            mapOf("name" to "undo", "arg" to count, "session_id" to sessionId),
+                        ).await()
+                handleDispatchResult(result)
+            } catch (e: HermesWsClient.HermesRpcException) {
+                addAssistantMessage(e.message ?: "Failed to undo.")
+            } catch (e: Exception) {
+                addAssistantMessage(e.message ?: "Failed to undo.")
+            }
+        }
+    }
+
+    private fun handlePrefillResult(
+        message: String,
+        notice: String,
+    ) {
+        val storageSessionId = _uiState.value.currentSessionId
+        if (message.isNotBlank()) {
+            _uiState.update { it.copy(pendingPrefillText = message) }
+        }
+        if (storageSessionId != null) {
+            val generation = ++sessionGeneration
+            viewModelScope.launch {
+                withContext(ioDispatcher) {
+                    repo.clearMessagesForSession(storageSessionId)
+                }
+                _uiState.update { it.copy(messages = emptyList()) }
+                loadSessionMessages(storageSessionId, generation)
+                if (notice.isNotBlank()) {
+                    addSystemMessage(notice, persist = true)
+                }
+                fetchContextUsage()
+            }
+        } else {
+            if (notice.isNotBlank()) {
+                addSystemMessage(notice, persist = false)
+            }
+        }
+    }
+
+    fun consumePendingPrefill() {
+        _uiState.update { it.copy(pendingPrefillText = null) }
     }
 
     // ── Session management ───────────────────────────────────────────────
@@ -2659,6 +2734,7 @@ class ChatViewModel(
                 todos = emptyList(),
                 resumeError = null,
                 isResumeRetrying = false,
+                pendingPrefillText = null,
             )
         }
         return generation

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatcher.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatcher.kt
@@ -66,6 +66,11 @@ class SlashCommandDispatcher {
                 SlashResult.SideQuestion(question = arg)
             }
 
+            "/undo" -> {
+                val arg = command.split(" ", limit = 2).getOrElse(1) { "" }.trim()
+                SlashResult.Undo(count = arg)
+            }
+
             else -> {
                 SlashResult.RpcDispatch
             }
@@ -142,5 +147,13 @@ sealed class SlashResult {
      */
     data class SideQuestion(
         val question: String,
+    ) : SlashResult()
+
+    /**
+     * Rewind conversation turns via the `undo` command.dispatch RPC.
+     * Rewinds server transcript, reloads active messages, and prefills the composer.
+     */
+    data class Undo(
+        val count: String,
     ) : SlashResult()
 }

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -896,6 +896,45 @@ class ChatViewModelTest {
             assertEquals("openai/gpt-4o", viewModel.uiState.value.currentSessionModel)
         }
 
+    @Test
+    fun testUndoCommand_dispatchesAndPrefillsComposer() =
+        runTest {
+            val (viewModel, sessionId) = createViewModelWithSession()
+
+            every {
+                HermesWsClient.request(
+                    WsMethods.COMMAND_DISPATCH,
+                    mapOf("name" to "undo", "arg" to "2", "session_id" to sessionId),
+                    any(),
+                )
+            } returns
+                CompletableDeferred(
+                    mapOf(
+                        "type" to "prefill",
+                        "message" to "undone user message",
+                        "notice" to "↶ Undid 2 turns",
+                    ),
+                )
+
+            viewModel.sendMessage("/undo 2")
+            advanceUntilIdle()
+
+            // Prefill text is staged in UI state
+            assertEquals("undone user message", viewModel.uiState.value.pendingPrefillText)
+            // Notice is displayed as system message
+            assertTrue(
+                viewModel.uiState.value.messages
+                    .any { it.content == "↶ Undid 2 turns" },
+            )
+            // Verify slash usage was recorded
+            assertEquals(1, viewModel.uiState.value.slashUsageCounts["/undo"])
+
+            // Consume prefill text
+            viewModel.consumePendingPrefill()
+            advanceUntilIdle()
+            assertNull(viewModel.uiState.value.pendingPrefillText)
+        }
+
     // ── Connection / init tests ──────────────────────────────────────────────
 
     @Test

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -921,10 +921,10 @@ class ChatViewModelTest {
 
             // Prefill text is staged in UI state
             assertEquals("undone user message", viewModel.uiState.value.pendingPrefillText)
-            // Notice is displayed as system message
+            // Notice is displayed as system message with rewind target feedback
             assertTrue(
                 viewModel.uiState.value.messages
-                    .any { it.content == "↶ Undid 2 turns" },
+                    .any { it.content.contains("↶ Undid 2 turns") && it.content.contains("undone user message") },
             )
             // Verify slash usage was recorded
             assertEquals(1, viewModel.uiState.value.slashUsageCounts["/undo"])

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatcherTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/SlashCommandDispatcherTest.kt
@@ -83,6 +83,14 @@ class SlashCommandDispatcherTest {
     }
 
     @Test
+    fun `undo routes to Undo`() {
+        assertEquals(SlashResult.Undo(""), dispatcher.dispatch("/undo"))
+        assertEquals(SlashResult.Undo("2"), dispatcher.dispatch("/undo 2"))
+        assertEquals(SlashResult.Undo("3"), dispatcher.dispatch("/UNDO 3"))
+        assertEquals(SlashResult.Undo(""), dispatcher.dispatch("/Undo"))
+    }
+
+    @Test
     fun `NEW uppercase still routes to NewSession`() {
         // Dispatcher lower-cases before matching, so case must not matter.
         assertEquals(SlashResult.NewSession, dispatcher.dispatch("/NEW"))

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/fakes/FakeChatMessageDao.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/fakes/FakeChatMessageDao.kt
@@ -27,6 +27,10 @@ class FakeChatMessageDao : ChatMessageDao {
         messageList.forEach { messages[it.id] = it }
     }
 
+    override suspend fun deleteMessagesForSession(sessionId: String) {
+        messages.values.removeAll { it.sessionId == sessionId }
+    }
+
     /** Direct access for test setup — bypasses the suspend modifier. */
     fun addMessageDirect(message: ChatMessageEntity) {
         messages[message.id] = message


### PR DESCRIPTION
## Summary
Implements full support for the `/undo` (and `/undo N`) command in the chat screen:
- **Slash Dispatch**: Intercepts `/undo` in `SlashCommandDispatcher` (`SlashResult.Undo`) and sends `command.dispatch` with `name="undo"` and optional turn count.
- **Prefill Handling**: Handles the backend's `{"type": "prefill", "message": "...", "notice": "..."}` response in `handleDispatchResult`.
- **Transcript Resync**: Wipes the stale local Room cache for the session (`ChatMessageDao.deleteMessagesForSession`), resets `_uiState.messages`, and reloads the trimmed server transcript via `loadSessionMessages`.
- **Composer Prefill**: Populates the backed-up user prompt into `inputFieldValue` using `ChatInputPolicy.commandFieldValue`, placing the cursor at the end for immediate editing.
- **System Notice**: Renders the server's undo notice (e.g. `↶ Undid 1 turn`) as a system message and updates the context meter.

## Verification
- `./gradlew compileDebugKotlin compileDebugUnitTestKotlin` passed cleanly.
- `./gradlew testDebugUnitTest` passed cleanly (new tests in `ChatViewModelTest` and `SlashCommandDispatcherTest`).
- `./gradlew ktlintCheck` passed (0 style violations).
- Verified live over ADB/Logcat on emulator.