### PR TITLE
fix(chat): restrict @ bot mention suggestions strictly to group chat

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatScreen.kt
@@ -815,7 +815,6 @@ fun ChatScreen(
                 isAgentTyping = state.isAgentTyping,
                 isConnected = state.isConnected,
                 commandCatalog = state.commandCatalog,
-                availableBots = state.availableBots,
                 slashUsageCounts = state.slashUsageCounts,
                 pendingAttachments = state.pendingAttachments,
                 onCameraTap = {

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -312,7 +312,6 @@ data class ChatUiState(
     val typingEffectDelayMs: Int = 30,
     // Commands catalog
     val commandCatalog: CommandCatalog = CommandCatalog(),
-    val availableBots: List<ProfileInfo> = emptyList(),
     // Per-command usage counts for the slash-autocomplete ranking (issue
     // #865). Empty until the local store loads; commands without recorded
     // usage keep their catalog order.
@@ -2205,15 +2204,6 @@ class ChatViewModel(
                 WsMethods.COMMANDS_CATALOG,
                 onSent = { id -> trackRequest(id, WsMethods.COMMANDS_CATALOG) },
             )
-            // Fetch available bot profiles for @ autocomplete
-            val profilesResult = safeApiCall { ApiClient.hermesApi.getProfiles() }
-            if (profilesResult is NetworkResult.Success) {
-                val profiles =
-                    profilesResult.data.profiles.orEmpty().filter {
-                        !AuthManager.isProfileHidden(it.name) && it.botMeta()?.hidden != true
-                    }
-                _uiState.update { it.copy(availableBots = profiles) }
-            }
         }
     }
 

--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatComposer.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/components/ChatComposer.kt
@@ -91,7 +91,6 @@ fun ChatInputBar(
     commandCatalog: CommandCatalog,
     slashUsageCounts: Map<String, Int> = emptyMap(),
     pendingAttachments: List<Attachment> = emptyList(),
-    availableBots: List<ProfileInfo> = emptyList(),
     onCameraTap: () -> Unit = {},
     onImageTap: () -> Unit = {},
     onFileTap: () -> Unit = {},
@@ -184,90 +183,6 @@ fun ChatInputBar(
                                         },
                                         onClick = { onInputChange(ChatInputPolicy.commandFieldValue(cmd)) },
                                     )
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Bot mention @ suggestions
-                val mentionQuery =
-                    remember(inputFieldValue.text, inputFieldValue.selection.end) {
-                        ChatInputPolicy.extractMentionQuery(
-                            inputFieldValue.text,
-                            inputFieldValue.selection.end,
-                        )
-                    }
-
-                androidx.compose.animation.AnimatedVisibility(
-                    visible = mentionQuery != null && availableBots.isNotEmpty(),
-                    enter = androidx.compose.animation.fadeIn() + androidx.compose.animation.expandVertically(),
-                    exit = androidx.compose.animation.fadeOut() + androidx.compose.animation.shrinkVertically(),
-                ) {
-                    val filteredBots =
-                        remember(mentionQuery, availableBots) {
-                            if (mentionQuery == null) {
-                                emptyList()
-                            } else {
-                                availableBots.filter { bot ->
-                                    bot.name.startsWith(mentionQuery, ignoreCase = true) ||
-                                        bot.effectiveTitle.contains(mentionQuery, ignoreCase = true)
-                                }
-                            }
-                        }
-
-                    if (filteredBots.isNotEmpty()) {
-                        Surface(
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 12.dp, vertical = 4.dp),
-                            shape = RoundedCornerShape(12.dp),
-                            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-                            border =
-                                BorderStroke(
-                                    1.dp,
-                                    MaterialTheme.colorScheme.outline.copy(alpha = 0.2f),
-                                ),
-                        ) {
-                            LazyColumn(
-                                modifier = Modifier.heightIn(max = 200.dp),
-                            ) {
-                                items(filteredBots, key = { it.name }) { bot ->
-                                    Row(
-                                        modifier =
-                                            Modifier
-                                                .fillMaxWidth()
-                                                .clickable {
-                                                    onInputChange(
-                                                        ChatInputPolicy.applyMention(inputFieldValue, bot.name),
-                                                    )
-                                                }.padding(horizontal = 12.dp, vertical = 8.dp),
-                                        verticalAlignment = Alignment.CenterVertically,
-                                    ) {
-                                        BotAvatar(
-                                            name = bot.name,
-                                            avatar = bot.botMeta()?.avatar,
-                                            size = 28.dp,
-                                            showPresence = false,
-                                        )
-                                        Spacer(modifier = Modifier.width(8.dp))
-                                        Column {
-                                            Text(
-                                                text = "@${bot.name}",
-                                                fontWeight = FontWeight.Bold,
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                color = MaterialTheme.colorScheme.primary,
-                                            )
-                                            if (bot.effectiveTitle != bot.name) {
-                                                Text(
-                                                    text = bot.effectiveTitle,
-                                                    style = MaterialTheme.typography.labelSmall,
-                                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                )
-                                            }
-                                        }
-                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
Removes accidental bot @ mention popup from the standard 1-on-1 `ChatComposer` / `ChatScreen`.

- Bot mentions (`@<bot>` and `@all`) are designed specifically for group chats to ping/address participating bots.
- In 1-on-1 chat, typing `@` was bringing up a full profile picker across all bots in the system.
- This PR strips `availableBots` from `ChatComposer` and `ChatViewModel` / `ChatScreen`, keeping the mention chip bar strictly scoped to `GroupChatScreen` where only members of that specific group chat are shown.

## Verification
- `./gradlew compileDebugKotlin compileDebugUnitTestKotlin ktlintCheck` passed (0 style violations).
- `./gradlew testDebugUnitTest --tests "com.m57.hermescontrol.ui.bots.group.GroupChatMentionsTest"` passed cleanly.
- Gradle daemons killed cleanly.