### PR TITLE
fix(theme): disable dynamic colors by default to preserve curated preset aesthetics

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/data/config/ServerStoreMigration.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/config/ServerStoreMigration.kt
@@ -55,7 +55,7 @@ class ServerStoreMigration(
             runCatching { ThemePreference.valueOf(themePrefString!!) }
                 .getOrDefault(ThemePreference.SYSTEM)
 
-        val useDynamicColors = prefs.getBoolean("use_dynamic_colors", true)
+        val useDynamicColors = prefs.getBoolean("use_dynamic_colors", false)
 
         val themePresetString = prefs.getString("theme_preset", ThemePreset.DEFAULT.name)
         val themePreset =

--- a/app/src/main/java/com/m57/hermescontrol/data/config/ServerStoreState.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/config/ServerStoreState.kt
@@ -13,7 +13,7 @@ data class ServerStoreState(
     val baseUrl: String? = null,
     val autoReconnect: Boolean = true,
     val themePreference: ThemePreference = ThemePreference.SYSTEM,
-    val useDynamicColors: Boolean = true,
+    val useDynamicColors: Boolean = false,
     val themePreset: ThemePreset = ThemePreset.DEFAULT,
     val connectionProfiles: List<ConnectionProfile> = emptyList(),
     val selectedProfileId: String? = null,

--- a/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
+++ b/app/src/main/java/com/m57/hermescontrol/data/local/AuthManager.kt
@@ -68,7 +68,7 @@ object AuthManager {
     private val _themePreferenceFlow = MutableStateFlow<ThemePreference>(ThemePreference.SYSTEM)
     val themePreferenceFlow: StateFlow<ThemePreference> = _themePreferenceFlow.asStateFlow()
 
-    private val _useDynamicColorsFlow = MutableStateFlow<Boolean>(true)
+    private val _useDynamicColorsFlow = MutableStateFlow<Boolean>(false)
     val useDynamicColorsFlow: StateFlow<Boolean> = _useDynamicColorsFlow.asStateFlow()
 
     private val _themePresetFlow = MutableStateFlow<ThemePreset>(ThemePreset.DEFAULT)

--- a/app/src/main/java/com/m57/hermescontrol/theme/THEMES.md
+++ b/app/src/main/java/com/m57/hermescontrol/theme/THEMES.md
@@ -95,8 +95,8 @@ private fun themeFor(preset: ThemePreset): ThemePalette = when (preset) {
 }
 ```
 
-Dynamic (Material You) color on API 31+ overrides the preset scheme when
-`useDynamicColors = true`. Semantic status colors are always resolved from the
+Dynamic (Material You) color on API 31+ can optionally override the preset scheme when
+`useDynamicColors = true` (defaults to `false`). Semantic status colors are always resolved from the
 active preset via `LocalHermesStatusColors`.
 
 ## Adding a new theme

--- a/app/src/main/java/com/m57/hermescontrol/theme/Theme.kt
+++ b/app/src/main/java/com/m57/hermescontrol/theme/Theme.kt
@@ -74,7 +74,7 @@ internal fun resolveStatusColors(
 @Composable
 fun HermesControlTheme(
     themePreference: ThemePreference = LocalThemePreference.current,
-    useDynamicColors: Boolean = true,
+    useDynamicColors: Boolean = false,
     themePreset: ThemePreset = ThemePreset.DEFAULT,
     chatFontScale: Float = LocalChatFontScale.current,
     content: @Composable () -> Unit,

--- a/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/settings/SettingsViewModel.kt
@@ -29,7 +29,7 @@ data class SettingsUiState(
     val token: String = "",
     val autoReconnect: Boolean = true,
     val themePreference: ThemePreference = ThemePreference.SYSTEM,
-    val useDynamicColors: Boolean = true,
+    val useDynamicColors: Boolean = false,
     val themePreset: ThemePreset = ThemePreset.DEFAULT,
     val isTesting: Boolean = false,
     val testResult: String? = null,


### PR DESCRIPTION
## Summary
Disables dynamic colors (Material You wallpaper extraction) by default across the app, ensuring fresh installs boot directly with the app's curated themes (e.g. Default/Nord/Catppuccin).

- Updated default `useDynamicColors = false` in `Theme.kt`, `ServerStoreState.kt`, `AuthManager.kt`, `SettingsViewModel.kt`, and `ServerStoreMigration.kt`.
- Updated documentation in `THEMES.md`.
- Users can still opt-in to dynamic colors in **Settings > Appearance**.

## Verification
- `./gradlew ktlintCheck compileDebugKotlin compileDebugUnitTestKotlin` passed cleanly.
- Gradle daemons stopped cleanly.