### PR TITLE
fix(chat): use runtime session IDs for approval RPCs

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -1241,10 +1241,10 @@ class ChatViewModel(
                         rid != null &&
                             _uiState.value.messages.any { it.approvalInfo?.requestId == rid }
                     if (!alreadyShown) {
-                        handleApprovalRequest(parseApprovalMap(pendingApproval, sessionId))
+                        handleApprovalRequest(parseApprovalMap(pendingApproval, runtimeSessionId))
                     }
                 }
-                if (sessionId != null) replayPendingApproval(sessionId)
+                replayPendingApproval()
             }
 
             WsMethods.SESSION_INTERRUPT -> {
@@ -1282,6 +1282,10 @@ class ChatViewModel(
                 if (resolved > 0) {
                     addSystemMessage("Approval submitted")
                 }
+            }
+
+            WsMethods.APPROVAL_RECEIVED -> {
+                // Render acknowledgement has no chat content.
             }
 
             WsMethods.APPROVAL_PENDING -> {
@@ -3648,20 +3652,8 @@ class ChatViewModel(
         // Desktop parity (`prompts.ts` receiveApprovalRequest): ack the render
         // so the backend knows this client holds the prompt. Fire-and-forget.
         val requestId = event.requestId
-        val sessionId = event.sessionId ?: _uiState.value.currentSessionId
-        if (requestId != null && sessionId != null) {
-            viewModelScope.launch(ioDispatcher) {
-                runCatching {
-                    wsClient.send(
-                        method = WsMethods.APPROVAL_RECEIVED,
-                        params =
-                            mapOf(
-                                "session_id" to sessionId,
-                                "request_id" to requestId,
-                            ),
-                    )
-                }
-            }
+        if (requestId != null) {
+            sendApprovalRpc(WsMethods.APPROVAL_RECEIVED, mapOf("request_id" to requestId))
         }
     }
 
@@ -3714,13 +3706,41 @@ class ChatViewModel(
      * gateway for unresolved approvals and surface the oldest one. Called
      * after resume and after each respond (the queue can hold more).
      */
-    private fun replayPendingApproval(sessionId: String) {
+    private fun replayPendingApproval() {
+        sendApprovalRpc(WsMethods.APPROVAL_PENDING)
+    }
+
+    // Approval replay regression: gateway RPCs require the runtime registry ID,
+    // not the stored transcript ID. Correlate replies across switches/reconnects.
+    private fun sendApprovalRpc(
+        method: String,
+        params: Map<String, Any> = emptyMap(),
+    ) {
+        val storageId = _uiState.value.currentSessionId ?: return
+        val runtimeId = runtimeSessionId ?: return
+        val generation = sessionGeneration
+        val resumeSequence = activeResumeRequestSequence
         viewModelScope.launch(ioDispatcher) {
+            if (!isCurrentSessionRequest(storageId, generation) ||
+                resumeSequence != activeResumeRequestSequence || runtimeId != runtimeSessionId
+            ) {
+                return@launch
+            }
             wsClient.send(
-                method = WsMethods.APPROVAL_PENDING,
-                params = mapOf("session_id" to sessionId),
-                onSent = { id -> trackRequest(id, WsMethods.APPROVAL_PENDING) },
+                method = method,
+                params = params + ("session_id" to runtimeId),
+                onSent = { id -> trackSessionRequest(id, method, generation, resumeSequence, storageId) },
             )
+            if (method == WsMethods.APPROVAL_RESPOND) {
+                // Preserve respond-before-replay ordering on the same runtime.
+                wsClient.send(
+                    method = WsMethods.APPROVAL_PENDING,
+                    params = mapOf("session_id" to runtimeId),
+                    onSent = { id ->
+                        trackSessionRequest(id, WsMethods.APPROVAL_PENDING, generation, resumeSequence, storageId)
+                    },
+                )
+            }
         }
     }
 
@@ -3729,7 +3749,7 @@ class ChatViewModel(
         val approvals = (result as? Map<*, *>)?.get("approvals") as? List<*>
         val first = approvals?.filterIsInstance<Map<*, *>>()?.firstOrNull() ?: return
         val requestId = first["request_id"] as? String ?: return
-        val sessionId = _uiState.value.currentSessionId
+        val sessionId = runtimeSessionId
         // Don't duplicate a prompt already on screen.
         val alreadyShown =
             _uiState.value.messages.any { it.approvalInfo?.requestId == requestId }
@@ -3740,7 +3760,7 @@ class ChatViewModel(
     fun respondToApproval(action: String) {
         val state = _uiState.value
         val approvalMsg = state.messages.lastOrNull { it.approvalInfo != null } ?: return
-        val sessionId = state.currentSessionId ?: return
+        if (state.currentSessionId == null || runtimeSessionId == null) return
         // Desktop sends `once` for a single run; legacy mobile sent `approve`
         // (any non-deny still unblocks, but stay on-spec going forward).
         val choice = if (action == "approve") "once" else action
@@ -3760,22 +3780,13 @@ class ChatViewModel(
             )
         }
 
-        viewModelScope.launch(ioDispatcher) {
-            val params =
-                mutableMapOf<String, Any>(
-                    "session_id" to sessionId,
-                    "choice" to choice,
-                    "all" to false,
-                )
-            if (requestId != null) params["request_id"] = requestId
-            wsClient.send(
-                method = WsMethods.APPROVAL_RESPOND,
-                params = params,
-                onSent = { id -> trackRequest(id, WsMethods.APPROVAL_RESPOND) },
+        val params =
+            mutableMapOf<String, Any>(
+                "choice" to choice,
+                "all" to false,
             )
-            // The queue can hold more pendings — surface the next one.
-            replayPendingApproval(sessionId)
-        }
+        if (requestId != null) params["request_id"] = requestId
+        sendApprovalRpc(WsMethods.APPROVAL_RESPOND, params)
     }
 
     // ── Sudo / secret prompt flow (issue #524) ──────────────────────────

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -2961,6 +2961,125 @@ class ChatViewModelTest {
 
     // ── Approval flow ────────────────────────────────────────────────────────
 
+    private suspend fun TestScope.resumeApprovalTestSession(): ChatViewModel {
+        stubEmptySessionRests("approval-stored", "other-stored")
+        val (viewModel, _) = createViewModelWithSession()
+        var resumeId = ""
+        every { HermesWsClient.send(WsMethods.SESSION_RESUME, any(), any()) } answers {
+            val id = "approval-resume-${++reqCount}"
+            resumeId = id
+            arg<((String) -> Unit)?>(2)?.invoke(id)
+            id
+        }
+        viewModel.switchSession("approval-stored")
+        advanceUntilIdle()
+        mockEventsFlow.emit(
+            WsEvent.RpcResult(
+                resumeId,
+                mapOf("session_id" to "approval-runtime", "resumed" to "approval-stored"),
+            ),
+        )
+        advanceUntilIdle()
+        assertEquals("approval-runtime", ActiveSessionHolder.activeSessionId.value)
+        return viewModel
+    }
+
+    @Test
+    fun testApprovalReplay_usesRuntimeIdForPendingReceivedAndRespond() =
+        runTest {
+            var pendingId = ""
+            every { HermesWsClient.send(WsMethods.APPROVAL_PENDING, any(), any()) } answers {
+                pendingId = "approval-pending-${++reqCount}"
+                arg<((String) -> Unit)?>(2)?.invoke(pendingId)
+                pendingId
+            }
+            val viewModel = resumeApprovalTestSession()
+            verify {
+                HermesWsClient.send(
+                    WsMethods.APPROVAL_PENDING,
+                    mapOf("session_id" to "approval-runtime"),
+                    any(),
+                )
+            }
+            mockEventsFlow.emit(
+                WsEvent.RpcResult(
+                    pendingId,
+                    mapOf("approvals" to listOf(mapOf("request_id" to "approval-1", "command" to "test"))),
+                ),
+            )
+            advanceUntilIdle()
+            verify {
+                HermesWsClient.send(
+                    WsMethods.APPROVAL_RECEIVED,
+                    mapOf("session_id" to "approval-runtime", "request_id" to "approval-1"),
+                    any(),
+                )
+            }
+            viewModel.respondToApproval("approve")
+            advanceUntilIdle()
+            verify {
+                HermesWsClient.send(
+                    WsMethods.APPROVAL_RESPOND,
+                    mapOf(
+                        "session_id" to "approval-runtime",
+                        "request_id" to "approval-1",
+                        "choice" to "once",
+                        "all" to false,
+                    ),
+                    any(),
+                )
+            }
+            assertEquals("approval-stored", viewModel.uiState.value.currentSessionId)
+        }
+
+    @Test
+    fun testApprovalReplay_ignoresLateResultAfterSessionSwitch() =
+        runTest {
+            var pendingId = ""
+            every { HermesWsClient.send(WsMethods.APPROVAL_PENDING, any(), any()) } answers {
+                pendingId = "approval-pending-${++reqCount}"
+                arg<((String) -> Unit)?>(2)?.invoke(pendingId)
+                pendingId
+            }
+            val viewModel = resumeApprovalTestSession()
+            viewModel.switchSession("other-stored")
+            advanceUntilIdle()
+            mockEventsFlow.emit(
+                WsEvent.RpcResult(
+                    pendingId,
+                    mapOf("approvals" to listOf(mapOf("request_id" to "old-approval", "command" to "test"))),
+                ),
+            )
+            advanceUntilIdle()
+            assertEquals("other-stored", viewModel.uiState.value.currentSessionId)
+            assertTrue(
+                viewModel.uiState.value.messages
+                    .none { it.approvalInfo != null },
+            )
+            verify(exactly = 0) { HermesWsClient.send(WsMethods.APPROVAL_RECEIVED, any(), any()) }
+        }
+
+    @Test
+    fun testApprovalReplay_ignoresLateErrorAfterReconnect() =
+        runTest {
+            var pendingId = ""
+            every { HermesWsClient.send(WsMethods.APPROVAL_PENDING, any(), any()) } answers {
+                pendingId = "approval-pending-${++reqCount}"
+                arg<((String) -> Unit)?>(2)?.invoke(pendingId)
+                pendingId
+            }
+            val viewModel = resumeApprovalTestSession()
+            mockEventsFlow.emit(WsEvent.GatewayReady(null))
+            advanceUntilIdle()
+            mockEventsFlow.emit(WsEvent.RpcError(pendingId, JsonRpcError(4001, "session not found")))
+            advanceUntilIdle()
+            assertNull(viewModel.uiState.value.errorMessage)
+            assertTrue(
+                viewModel.uiState.value.messages
+                    .none { it.content.contains("session not found") },
+            )
+        }
+
     @Test
     fun testApprovalRequest_addsSystemMessage() =
         runTest {


### PR DESCRIPTION
## Summary
- Use the active runtime session ID for `approval.pending`, `approval.received`, and `approval.respond`, while retaining the stored session ID for transcript/UI identity.
- Correlate approval RPC responses with the originating session generation and resume sequence, discarding stale results and errors after switching chats or reconnecting.
- Preserve respond-before-replay ordering and keep render acknowledgements out of the chat transcript.

## Why
After a successful `session.resume`, the stored transcript ID may differ from the runtime ID in the gateway registry. Passing the stored ID to `approval.pending` produces `4001: session not found` even though the conversation was resumed successfully. Uncorrelated late approval responses could also affect a different chat.

## Verification
- Regression tests cover distinct runtime/stored IDs across pending/ack/respond, late approval results after switching sessions, and late errors after reconnecting.
- The regression tests failed before the fix and passed after it.
- Local `testDebugUnitTest`, `ktlintCheck`, `checkColorLiterals`, and `lintRelease` on this isolated branch.

## Scope
No changes to approval choices, permanent-approval permissions, notification routing, or attachment dispatch. Independent of the attachment-memory hotfix.
