### PR TITLE
fix(chat): use runtime session ID in approval RPCs to prevent 4001

### DIFF
--- a/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/m57/hermescontrol/ui/chat/ChatViewModel.kt
@@ -947,7 +947,12 @@ class ChatViewModel(
                             rid != null &&
                                 _uiState.value.messages.any { it.approvalInfo?.requestId == rid }
                         if (!alreadyShown) {
-                            handleApprovalRequest(parseApprovalMap(pendingApproval, _uiState.value.currentSessionId))
+                            handleApprovalRequest(
+                                parseApprovalMap(
+                                    pendingApproval,
+                                    runtimeSessionId ?: _uiState.value.currentSessionId,
+                                ),
+                            )
                         }
                     }
                 }
@@ -1241,10 +1246,16 @@ class ChatViewModel(
                         rid != null &&
                             _uiState.value.messages.any { it.approvalInfo?.requestId == rid }
                     if (!alreadyShown) {
-                        handleApprovalRequest(parseApprovalMap(pendingApproval, sessionId))
+                        handleApprovalRequest(
+                            parseApprovalMap(
+                                pendingApproval,
+                                runtimeSessionId ?: sessionId,
+                            ),
+                        )
                     }
                 }
-                if (sessionId != null) replayPendingApproval(sessionId)
+                val activeSessionId = runtimeSessionId ?: sessionId
+                if (activeSessionId != null) replayPendingApproval(activeSessionId)
             }
 
             WsMethods.SESSION_INTERRUPT -> {
@@ -3648,7 +3659,7 @@ class ChatViewModel(
         // Desktop parity (`prompts.ts` receiveApprovalRequest): ack the render
         // so the backend knows this client holds the prompt. Fire-and-forget.
         val requestId = event.requestId
-        val sessionId = event.sessionId ?: _uiState.value.currentSessionId
+        val sessionId = runtimeSessionId ?: event.sessionId ?: _uiState.value.currentSessionId
         if (requestId != null && sessionId != null) {
             viewModelScope.launch(ioDispatcher) {
                 runCatching {
@@ -3715,10 +3726,11 @@ class ChatViewModel(
      * after resume and after each respond (the queue can hold more).
      */
     private fun replayPendingApproval(sessionId: String) {
+        val targetSessionId = runtimeSessionId ?: sessionId
         viewModelScope.launch(ioDispatcher) {
             wsClient.send(
                 method = WsMethods.APPROVAL_PENDING,
-                params = mapOf("session_id" to sessionId),
+                params = mapOf("session_id" to targetSessionId),
                 onSent = { id -> trackRequest(id, WsMethods.APPROVAL_PENDING) },
             )
         }
@@ -3729,7 +3741,7 @@ class ChatViewModel(
         val approvals = (result as? Map<*, *>)?.get("approvals") as? List<*>
         val first = approvals?.filterIsInstance<Map<*, *>>()?.firstOrNull() ?: return
         val requestId = first["request_id"] as? String ?: return
-        val sessionId = _uiState.value.currentSessionId
+        val sessionId = runtimeSessionId ?: _uiState.value.currentSessionId
         // Don't duplicate a prompt already on screen.
         val alreadyShown =
             _uiState.value.messages.any { it.approvalInfo?.requestId == requestId }
@@ -3740,7 +3752,7 @@ class ChatViewModel(
     fun respondToApproval(action: String) {
         val state = _uiState.value
         val approvalMsg = state.messages.lastOrNull { it.approvalInfo != null } ?: return
-        val sessionId = state.currentSessionId ?: return
+        val sessionId = runtimeSessionId ?: state.currentSessionId ?: return
         // Desktop sends `once` for a single run; legacy mobile sent `approve`
         // (any non-deny still unblocks, but stay on-spec going forward).
         val choice = if (action == "approve") "once" else action

--- a/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/m57/hermescontrol/ui/chat/ChatViewModelTest.kt
@@ -3196,6 +3196,75 @@ class ChatViewModelTest {
             }
         }
 
+    @Test
+    fun testApprovalFlow_prefersRuntimeSessionIdOverStorageId() =
+        runTest {
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            mockConnectionStatus.value = ConnectionStatus.CONNECTED
+            mockEventsFlow.emit(WsEvent.GatewayReady(null))
+            advanceUntilIdle()
+
+            mockEventsFlow.emit(
+                WsEvent.RpcResult(
+                    "req-id-3",
+                    mapOf(
+                        "session_id" to "runtime-sid-999",
+                        "stored_session_id" to "storage-uuid-111",
+                    ),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals("storage-uuid-111", viewModel.uiState.value.currentSessionId)
+
+            mockEventsFlow.emit(
+                WsEvent.ApprovalRequest(
+                    command = "rm -rf /data",
+                    description = "Dangerous operation",
+                    patternKeys = null,
+                    sessionId = null,
+                    requestId = "req-runtime-test",
+                    choices = listOf("once", "deny"),
+                ),
+            )
+            advanceUntilIdle()
+
+            verify {
+                HermesWsClient.send(
+                    WsMethods.APPROVAL_RECEIVED,
+                    withArg { params ->
+                        assertEquals("runtime-sid-999", params["session_id"])
+                        assertEquals("req-runtime-test", params["request_id"])
+                    },
+                    any(),
+                )
+            }
+
+            viewModel.respondToApproval("once")
+            advanceUntilIdle()
+
+            verify {
+                HermesWsClient.send(
+                    WsMethods.APPROVAL_RESPOND,
+                    withArg { params ->
+                        assertEquals("runtime-sid-999", params["session_id"])
+                        assertEquals("once", params["choice"])
+                        assertEquals("req-runtime-test", params["request_id"])
+                    },
+                    any(),
+                )
+                HermesWsClient.send(
+                    WsMethods.APPROVAL_PENDING,
+                    withArg { params ->
+                        assertEquals("runtime-sid-999", params["session_id"])
+                    },
+                    any(),
+                )
+            }
+        }
+
     // ── Sudo / secret prompt flow (issue #524) ───────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary
Use `runtimeSessionId ?: sessionId` across all approval RPC flows (`approval.respond`, `approval.pending`, `approval.received`) to prevent gateway error 4001 (`session not found`).

## Description
The backend gateway (`methods_prompt.py` and `server.py:_sess`) tracks live runtime sessions via runtime `sid` in `_sessions`. When replaying pending approvals on reconnect or responding to an inline approval, passing `currentSessionId` (the storage UUID) caused the gateway to return `4001 session not found`.

This PR ensures:
1. `respondToApproval` resolves `runtimeSessionId ?: state.currentSessionId` for `approval.respond` and `replayPendingApproval`.
2. `replayPendingApproval` sends `runtimeSessionId ?: sessionId` in `approval.pending`.
3. `SESSION_RESUME` triggers `replayPendingApproval` with `runtimeSessionId ?: sessionId`.
4. `handleApprovalRequest` sends `runtimeSessionId ?: event.sessionId ?: currentSessionId` in `approval.received`.
5. Added unit test verifying the preference of `runtimeSessionId` over storage ID across all approval RPCs.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Docs
- [x] ✅ Tests
- [ ] 🔧 CI / chore

## How to test
1. Trigger a tool requiring approval (e.g. bash command).
2. Tap an approval option (once/session/always/deny) or reconnect while approval is pending.
3. Verify no 4001 error appears in the UI and the agent unblocks immediately.

## Checklist
- [x] Branch rebased onto `dev` (`git rebase origin/dev`)
- [x] `./gradlew ktlintCheck` passes (ran `ktlintFormat` first)
- [x] `./gradlew testDebugUnitTest` green (or CI unit-tests job)
- [x] `checkColorLiterals` passes (no hardcoded Color outside theme/)
- [x] Navigation goes through `NavigationController.navigateTo()` (not `backStack.add`)
- [ ] Tested on device/emulator or verified via CI APK